### PR TITLE
feat(iot): Thêm LEDStatusManager để hiển thị trạng thái xe qua LED RGB

### DIFF
--- a/apps/iot/include/LEDStatusManager.h
+++ b/apps/iot/include/LEDStatusManager.h
@@ -1,0 +1,77 @@
+#ifndef LED_STATUS_MANAGER_H
+#define LED_STATUS_MANAGER_H
+
+#include <Arduino.h>
+
+// RED and YELLOW:(HIGH = ON, LOW = OFF)
+// GREEN: Sink (LOW = ON, HIGH = OFF)
+#define LED_RED_PIN 16
+#define LED_YELLOW_PIN 17
+#define LED_GREEN_PIN 18
+
+// PWM pulsiating
+#define LED_PWM_FREQ 25000   // 25 kHz
+#define LED_PWM_RESOLUTION 8 //  (0-255)
+
+// PWM channels
+#define LED_RED_CHANNEL 0
+#define LED_YELLOW_CHANNEL 1
+#define LED_GREEN_CHANNEL 2
+
+#define LED_FULL_BRIGHTNESS 255
+#define LED_OFF 0
+#define LED_GREEN_DUTY 35 //  nhỏ lại ko nó 3.3V cùng làm hư pin của esp32
+
+// MIN MAX  PULSE LIGH
+#define LED_PULSE_MIN_BRIGHTNESS 60
+#define LED_PULSE_MAX_BRIGHTNESS 255
+
+#define LED_FAST_BLINK_INTERVAL 200
+#define LED_SLOW_PULSE_PERIOD 2000
+#define LED_SOLID_UPDATE_INTERVAL 100
+
+enum LEDPattern
+{
+    LED_PATTERN_OFF,
+    LED_PATTERN_SOLID,
+    LED_PATTERN_SLOW_PULSE,
+    LED_PATTERN_FAST_BLINK
+};
+
+enum LEDColor
+{
+    LED_COLOR_OFF,
+    LED_COLOR_RED,
+    LED_COLOR_YELLOW,
+    LED_COLOR_GREEN
+};
+
+class LEDStatusManager
+{
+public:
+    LEDStatusManager();
+    void begin();
+    void update();
+    void setStatus(int state);
+
+private:
+    LEDColor currentColor;
+    LEDPattern currentPattern;
+    unsigned long lastUpdateTime;
+    bool blinkState;
+
+    void setColor(LEDColor color, uint8_t brightness = LED_FULL_BRIGHTNESS);
+    void turnOffAll();
+    void updatePattern();
+
+    //  LED configu
+    struct LEDConfig
+    {
+        LEDColor color;
+        LEDPattern pattern;
+    };
+
+    LEDConfig getConfigForState(int state); // Tuwf enum ma ra
+};
+
+#endif // LED_STATUS_MANAGER_H

--- a/apps/iot/include/globals.h
+++ b/apps/iot/include/globals.h
@@ -8,6 +8,9 @@
 #include "MQTTManager.h"
 #include "BufferedLogger.h"
 #include "network.h"
+
+class LEDStatusManager;
+
 enum DeviceState
 {
     // Connection states
@@ -34,6 +37,7 @@ namespace Global
     extern std::unique_ptr<NetworkManager> networkManager;
     extern std::unique_ptr<MQTTManager> mqttManager;
     extern std::unique_ptr<BufferedLogger> bufferedLogger;
+    extern std::unique_ptr<LEDStatusManager> ledStatusManager;
 
     inline const NetworkTopics &getTopics()
     {

--- a/apps/iot/src/core/globals.cpp
+++ b/apps/iot/src/core/globals.cpp
@@ -1,4 +1,5 @@
 #include "globals.h"
+#include "LEDStatusManager.h"
 #include "mqtt.h"
 
 DeviceState currentState;
@@ -7,6 +8,7 @@ namespace Global
     std::unique_ptr<NetworkManager> networkManager = nullptr;
     std::unique_ptr<MQTTManager> mqttManager = nullptr;
     std::unique_ptr<BufferedLogger> bufferedLogger = nullptr;
+    std::unique_ptr<LEDStatusManager> ledStatusManager = nullptr;
 
     bool setupMQTT(const char *brokerIP, int port, const char *username, const char *pass)
     {

--- a/apps/iot/src/handlers/CommandHandler.cpp
+++ b/apps/iot/src/handlers/CommandHandler.cpp
@@ -25,6 +25,7 @@
 #include <ArduinoLog.h>
 #include <cstring>
 #include "globals.h"
+#include "LEDStatusManager.h"
 #include "StateMachine.h"
 
 static bool matchesTopic(const char *incoming, const char *baseTopic, const std::string &deviceTopic)
@@ -340,5 +341,11 @@ void CommandHandler::changeState(DeviceState newState)
 {
     Log.info("Changing state from %s to %s\n", getStateName(currentState), getStateName(newState));
     currentState = newState;
+
+    if (Global::ledStatusManager)
+    {
+        Global::ledStatusManager->setStatus(newState);
+    }
+
     resetStateEntryFlags();
 }

--- a/apps/iot/src/main.cpp
+++ b/apps/iot/src/main.cpp
@@ -6,39 +6,56 @@
 #include "globals.h"
 #include "StateMachine.h"
 #include "NetworkManager.h"
+#include "LEDStatusManager.h"
 
 void setup()
 {
-
   Serial.begin(74880);
   Log.begin(LOG_LEVEL_VERBOSE, &Serial);
+
+  Global::ledStatusManager.reset(new LEDStatusManager());
+  Global::ledStatusManager->begin();
+
   Global::bufferedLogger.reset(new BufferedLogger());
   Global::bufferedLogger->setTopic("esp/logs"); // temporary
   Global::logInfoLocal("Buffered logger initialized");
   delay(5000);
+
   currentState = STATE_INIT;
+  Global::ledStatusManager->setStatus(currentState);
+
   AppConfig config = loadConfig();
   Global::networkManager.reset(new NetworkManager());
   Global::networkManager->setCredentials(config.wifiSsid, config.wifiPass);
   if (!Global::networkManager->initialize())
   {
     currentState = STATE_ERROR;
+    Global::ledStatusManager->setStatus(currentState);
     return;
   }
   if (!Global::setupMQTT(config.mqttBrokerIP.c_str(), config.mqttPort, config.mqttUsername.c_str(), config.mqttPassword.c_str()))
   {
     currentState = STATE_ERROR;
+    Global::ledStatusManager->setStatus(currentState);
     return;
   }
   currentState = STATE_CONNECTED;
+  Global::ledStatusManager->setStatus(currentState);
 }
 
 void loop()
 {
+ 
+  if (Global::ledStatusManager)
+  {
+    Global::ledStatusManager->update();
+  }
+
   if (Global::bufferedLogger)
   {
     Global::bufferedLogger->loop();
   }
+
   switch (currentState)
   {
   case STATE_INIT:
@@ -81,6 +98,13 @@ void loop()
   {
     Log.info("State changed to %s (%d)\n", getStateName(currentState), currentState);
     Global::logInfoMQTT("State changed to %s (%d)", getStateName(currentState), currentState);
+
+   
+    if (Global::ledStatusManager)
+    {
+      Global::ledStatusManager->setStatus(currentState);
+    }
+
     lastLoggedState = currentState;
   }
 }

--- a/apps/iot/src/managers/LEDStatusManager.cpp
+++ b/apps/iot/src/managers/LEDStatusManager.cpp
@@ -1,0 +1,204 @@
+#include "LEDStatusManager.h"
+#include "globals.h"
+#include <ArduinoLog.h>
+
+LEDStatusManager::LEDStatusManager()
+    : currentColor(LED_COLOR_OFF),
+      currentPattern(LED_PATTERN_OFF),
+      lastUpdateTime(0),
+      blinkState(false)
+{
+}
+
+void LEDStatusManager::begin()
+{
+    ledcSetup(LED_RED_CHANNEL, LED_PWM_FREQ, LED_PWM_RESOLUTION);
+    ledcSetup(LED_YELLOW_CHANNEL, LED_PWM_FREQ, LED_PWM_RESOLUTION);
+    ledcSetup(LED_GREEN_CHANNEL, LED_PWM_FREQ, LED_PWM_RESOLUTION);
+
+    ledcAttachPin(LED_RED_PIN, LED_RED_CHANNEL);
+    ledcAttachPin(LED_YELLOW_PIN, LED_YELLOW_CHANNEL);
+    ledcAttachPin(LED_GREEN_PIN, LED_GREEN_CHANNEL);
+
+    turnOffAll();
+
+    Log.info("LED Status Manager initialized (R=%d(source), Y=%d(source), G=%d(sink))\n",
+             LED_RED_PIN, LED_YELLOW_PIN, LED_GREEN_PIN);
+}
+
+void LEDStatusManager::turnOffAll()
+{
+    ledcWrite(LED_RED_CHANNEL, LED_OFF);
+    ledcWrite(LED_YELLOW_CHANNEL, LED_OFF);
+    ledcWrite(LED_GREEN_CHANNEL, LED_FULL_BRIGHTNESS); // nay nguoc laij sink
+}
+
+void LEDStatusManager::setColor(LEDColor color, uint8_t brightness)
+{
+    turnOffAll();
+
+    switch (color)
+    {
+    case LED_COLOR_RED:
+
+        ledcWrite(LED_RED_CHANNEL, brightness);
+        break;
+
+    case LED_COLOR_YELLOW:
+
+        ledcWrite(LED_YELLOW_CHANNEL, brightness);
+        break;
+
+    case LED_COLOR_GREEN:
+
+        ledcWrite(LED_GREEN_CHANNEL, 255 - brightness);
+        break;
+
+    case LED_COLOR_OFF:
+    default:
+
+        break;
+    }
+}
+
+void LEDStatusManager::setStatus(int state)
+{
+    DeviceState deviceState = static_cast<DeviceState>(state);
+    LEDConfig config = getConfigForState(deviceState);
+    currentColor = config.color;
+    currentPattern = config.pattern;
+    lastUpdateTime = millis();
+    blinkState = false;
+
+    Log.info("LED Status: Color=%d, Pattern=%d for state=%s\n",
+             currentColor, currentPattern, getStateName(deviceState));
+}
+
+LEDStatusManager::LEDConfig LEDStatusManager::getConfigForState(int state)
+{
+    DeviceState deviceState = static_cast<DeviceState>(state);
+    LEDConfig config;
+
+    switch (deviceState)
+    {
+    case STATE_AVAILABLE:
+
+        config.color = LED_COLOR_GREEN;
+        config.pattern = LED_PATTERN_SOLID;
+        break;
+
+    case STATE_RESERVED:
+        config.color = LED_COLOR_YELLOW;
+        config.pattern = LED_PATTERN_SLOW_PULSE;
+        break;
+
+    case STATE_BOOKED:
+        config.color = LED_COLOR_YELLOW;
+        config.pattern = LED_PATTERN_SOLID;
+        break;
+
+    case STATE_BROKEN:
+    case STATE_MAINTAINED:
+    case STATE_UNAVAILABLE:
+        config.color = LED_COLOR_RED;
+        config.pattern = LED_PATTERN_SOLID;
+        break;
+
+    case STATE_INIT:
+    case STATE_CONNECTING_WIFI:
+    case STATE_CONNECTED:
+
+        config.color = LED_COLOR_YELLOW;
+        config.pattern = LED_PATTERN_FAST_BLINK;
+        break;
+
+    case STATE_ERROR:
+
+        config.color = LED_COLOR_RED;
+        config.pattern = LED_PATTERN_FAST_BLINK;
+        break;
+
+    default:
+        config.color = LED_COLOR_OFF;
+        config.pattern = LED_PATTERN_OFF;
+        break;
+    }
+
+    return config;
+}
+
+void LEDStatusManager::updatePattern()
+{
+    unsigned long currentTime = millis();
+
+    switch (currentPattern)
+    {
+    case LED_PATTERN_SOLID:
+
+        if (currentColor == LED_COLOR_GREEN)
+        {
+            setColor(currentColor, LED_GREEN_DUTY);
+        }
+        else
+        {
+            setColor(currentColor, LED_FULL_BRIGHTNESS);
+        }
+        break;
+
+    case LED_PATTERN_FAST_BLINK:
+        if (currentTime - lastUpdateTime >= LED_FAST_BLINK_INTERVAL)
+        {
+            blinkState = !blinkState;
+            if (blinkState)
+            {
+                if (currentColor == LED_COLOR_GREEN)
+                {
+                    setColor(currentColor, LED_GREEN_DUTY);
+                }
+                else
+                {
+                    setColor(currentColor, LED_FULL_BRIGHTNESS);
+                }
+            }
+            else
+            {
+                turnOffAll();
+            }
+            lastUpdateTime = currentTime;
+        }
+        break;
+
+    case LED_PATTERN_SLOW_PULSE:
+
+    {
+        float phase = (float)((currentTime % LED_SLOW_PULSE_PERIOD)) / LED_SLOW_PULSE_PERIOD;
+        // Sine wave:
+        float intensity = (sin(phase * 2 * PI - PI / 2) + 1.0) / 2.0;
+
+        uint8_t brightness;
+        if (currentColor == LED_COLOR_GREEN)
+        {
+
+            uint8_t minBright = LED_PULSE_MIN_BRIGHTNESS * LED_GREEN_DUTY / LED_FULL_BRIGHTNESS;
+            brightness = (uint8_t)(minBright + intensity * (LED_GREEN_DUTY - minBright));
+        }
+        else
+        {
+            brightness = (uint8_t)(LED_PULSE_MIN_BRIGHTNESS + intensity * (LED_PULSE_MAX_BRIGHTNESS - LED_PULSE_MIN_BRIGHTNESS));
+        }
+
+        setColor(currentColor, brightness);
+    }
+    break;
+
+    case LED_PATTERN_OFF:
+    default:
+        turnOffAll();
+        break;
+    }
+}
+
+void LEDStatusManager::update()
+{
+    pdatePattern();
+}


### PR DESCRIPTION
## Tổng quan

PR này triển khai hệ thống quản lý LED RGB để hiển thị trạng thái hoạt động của xe IoT thông qua 3 LED màu đỏ, vàng, và xanh lá.

## Chức năng chính

### Hiển thị trạng thái qua LED

| Trạng thái | LED đỏ | LED vàng | LED xanh lá | Hiệu ứng |
|------------|---------|-----------|-------------|----------|
| AVAILABLE | Tắt | Tắt | Sáng | Nhấp nháy chậm (pulsating) |
| RESERVED | Tắt | Sáng | Tắt | Nhấp nháy nhanh |
| BOOKED | Tắt | Sáng | Tắt | Sáng liên tục |
| BROKEN | Sáng | Tắt | Tắt | Nhấp nháy nhanh |
| MAINTAINED | Sáng | Tắt | Tắt | Sáng liên tục |
| UNAVAILABLE | Tắt | Tắt | Tắt | Tất cả tắt |

### Các tính năng kỹ thuật

- Sử dụng PWM với tần số 25kHz và độ phân giải 8-bit
- Hiệu ứng pulsating mượt mà cho trạng thái AVAILABLE
- Nhấp nháy nhanh (200ms) cho trạng thái cảnh báo
- Tự động cập nhật LED khi trạng thái thay đổi

## Cấu hình phần cứng

### Sơ đồ kết nối

```
ESP32          Điện trở        LED
GPIO 16  -->   220-330Ω   -->  LED Đỏ    --> GND
GPIO 17  -->   220-330Ω   -->  LED Vàng  --> GND
GPIO 18  -->   GND        <--  LED Xanh  <-- 3.3V
```

### Thông số kỹ thuật

- Chân GPIO: RED=16, YELLOW=17, GREEN=18
- LED đỏ và vàng: logic thuận (HIGH=ON, LOW=OFF)
- LED xanh: logic đảo/sink (LOW=ON, HIGH=OFF)
- Điện trở khuyến nghị: 220-330Ω cho LED đỏ và vàng
- PWM duty cycle cho LED xanh: 35/255

## CẢNH BÁO QUAN TRỌNG VỀ PHẦN CỨNG

### Cảnh báo về điện trở

Nếu bạn chỉ có điện trở 1kΩ hoặc cao hơn, cần mắc song song nhiều điện trở để giảm xuống khoảng 220-330Ω cho LED đỏ và vàng.

**Tại sao:**
- Điện trở quá cao sẽ làm LED yếu hoặc không sáng
- Dòng điện qua LED sẽ quá nhỏ (I = V/R, với R lớn thì I nhỏ)

**Cách mắc song song:**

Công thức: R_total = 1 / (1/R1 + 1/R2 + 1/R3 + ...)

Ví dụ:
- 2 điện trở 1kΩ song song = 500Ω
- 3 điện trở 1kΩ song song = 333Ω (lý tưởng)
- 4 điện trở 1kΩ song song = 250Ω (rất tốt)

**Sơ đồ mắc song song:**

```
        R1 (1kΩ)
GPIO ---+---[====]---+--- LED --- GND
        |            |
        +---[====]---+
            R2 (1kΩ)
        |            |
        +---[====]---+
            R3 (1kΩ)
```

### Cảnh báo về LED xanh lá

LED xanh sử dụng cấu hình sink current (dòng điện chìm) với logic đảo:
- LOW = LED sáng
- HIGH = LED tắt

**Lý do sử dụng sink current:**
- GPIO của ESP32 có khả năng sink tốt hơn source
- Bảo vệ vi điều khiển khỏi quá tải dòng điện

**PWM duty cycle thấp (35/255):**
- Giá trị này được tính toán để bảo vệ ESP32
- KHÔNG tăng duty cycle lên quá 50/255
- Tăng quá cao có thể làm hư GPIO hoặc ESP32

**Tại sao duty cycle thấp:**
- LED xanh kết nối trực tiếp với 3.3V
- ESP32 sink dòng về GND
- Dòng quá lớn có thể hư hỏng GPIO pin

## Các file thay đổi

### File mới

1. `apps/iot/include/LEDStatusManager.h` - Định nghĩa class và hằng số
2. `apps/iot/src/managers/LEDStatusManager.cpp` - Triển khai logic điều khiển LED

### File sửa đổi

1. `apps/iot/include/globals.h` - Thêm global pointer cho LEDStatusManager
2. `apps/iot/src/core/globals.cpp` - Khởi tạo global instance
3. `apps/iot/src/main.cpp` - Setup và loop cho LED manager
4. `apps/iot/src/handlers/CommandHandler.cpp` - Cập nhật LED khi nhận lệnh thay đổi trạng thái





## Hướng dẫn sử dụng

### Upload code lên ESP32

```bash
cd apps/iot
pio run --target upload
```

### Quan sát LED

1. Sau khi upload, LED xanh sẽ nhấp nháy chậm (AVAILABLE)
2. Gửi lệnh từ IoT service để thay đổi trạng thái
3. LED sẽ tự động cập nhật theo trạng thái mới

### Debug

Nếu LED không sáng:
1. Kiểm tra kết nối dây
2. Kiểm tra giá trị điện trở (phải 220-330Ω hoặc tương đương)
3. Kiểm tra cực của LED (chân dài = anode +)
4. Kiểm tra serial monitor để xác nhận trạng thái



### Khắc phục sự cố

| Vấn đề | Nguyên nhân | Giải pháp |
|--------|-------------|-----------|
| LED không sáng | Điện trở quá cao | Giảm điện trở hoặc mắc song song |
| LED quá sáng | Điện trở quá thấp | Tăng điện trở |
| LED xanh không hoạt động | Kết nối sai | Kiểm tra cathode nối GND, anode nối 3.3V |
| ESP32 reset liên tục | Duty cycle LED xanh quá cao | Giảm LED_GREEN_DUTY xuống 35 |

## Breaking Changes

Không có breaking changes. Tất cả các chức năng hiện tại vẫn hoạt động bình thường.

## Tham khảo

- ESP32 GPIO specifications: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/gpio.html
- PWM LED control: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/ledc.html
- Resistor parallel calculator: R_total = 1 / (1/R1 + 1/R2 + ... + 1/Rn)

---
