### PR TITLE
Thêm chức năng quản lý TTL và dọn dẹp thiết bị cũ trong DeviceManager

### DIFF
--- a/apps/iot-service/src/application/index.ts
+++ b/apps/iot-service/src/application/index.ts
@@ -72,6 +72,7 @@ export class IotApplication {
     const results = await Promise.allSettled([
       this.deps.connection.disconnect(),
       this.closeHttpServer(),
+      this.deps.deviceManager.destroy(),
     ]);
 
     for (const result of results) {

--- a/apps/iot-service/src/config/index.ts
+++ b/apps/iot-service/src/config/index.ts
@@ -18,6 +18,8 @@ const envSchema = z.object({
   HTTP_HOST: z.string().default("0.0.0.0"),
   BACKEND_API_URL: z.string().url().default("http://localhost:4000"),
   CARD_TAP_API_KEY: z.string(),
+  DEVICE_TTL_MS: z.coerce.number().default(5 * 60 * 1000),
+  DEVICE_CLEANUP_INTERVAL_MS: z.coerce.number().default(60 * 1000),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/apps/iot-service/src/services/device-manager.ts
+++ b/apps/iot-service/src/services/device-manager.ts
@@ -3,30 +3,92 @@ import logger from "../lib/logger";
 
 export class DeviceManager {
   private deviceStates = new Map<string, string>();
+  private deviceLastSeen = new Map<string, number>();
+  private readonly deviceTtlMs: number;
+  private readonly cleanupIntervalMs: number;
+  private cleanupTimer: NodeJS.Timeout | undefined;
 
-  constructor() {
+  constructor(deviceTtlMs: number = 5 * 60 * 1000, cleanupIntervalMs: number = 60 * 1000) {
+    this.deviceTtlMs = deviceTtlMs;
+    this.cleanupIntervalMs = cleanupIntervalMs;
     this.setupEventListeners();
+    this.startCleanupTimer();
   }
 
   private setupEventListeners(): void {
     eventBus.on(EVENTS.DEVICE_STATUS_CHANGED, (data) => {
       if (data.deviceId) {
+        const now = Date.now();
         this.deviceStates.set(data.deviceId, data.status);
+        this.deviceLastSeen.set(data.deviceId, now);
         logger.info({ deviceId: data.deviceId, status: data.status }, "device status updated");
       }
     });
 
     eventBus.on(EVENTS.BOOKING_STATUS_UPDATED, (data) => {
       if (data.deviceId) {
+        this.deviceLastSeen.set(data.deviceId, Date.now());
         logger.info({ deviceId: data.deviceId, status: data.status }, "device booking status");
       }
     });
 
     eventBus.on(EVENTS.MAINTENANCE_STATUS_UPDATED, (data) => {
       if (data.deviceId) {
+        this.deviceLastSeen.set(data.deviceId, Date.now());
         logger.info({ deviceId: data.deviceId, status: data.status }, "device maintenance status");
       }
     });
+  }
+
+  private startCleanupTimer(): void {
+    this.cleanupTimer = setInterval(() => {
+      this.cleanupStaleDevices();
+    }, this.cleanupIntervalMs);
+
+    logger.info(
+      { deviceTtlMs: this.deviceTtlMs, cleanupIntervalMs: this.cleanupIntervalMs },
+      "Device eviction timer started",
+    );
+  }
+
+  private cleanupStaleDevices(): void {
+    const now = Date.now();
+    const staleDevices: string[] = [];
+
+    for (const [deviceId, lastSeen] of this.deviceLastSeen.entries()) {
+      if (now - lastSeen > this.deviceTtlMs) {
+        staleDevices.push(deviceId);
+      }
+    }
+
+    for (const deviceId of staleDevices) {
+      this.deviceStates.delete(deviceId);
+      this.deviceLastSeen.delete(deviceId);
+      logger.warn({ deviceId }, "Device evicted due to inactivity");
+    }
+
+    if (staleDevices.length > 0) {
+      logger.info(
+        { evictedCount: staleDevices.length, remainingDevices: this.deviceLastSeen.size },
+        "Stale device cleanup completed",
+      );
+    }
+  }
+
+  public destroy(): void {
+    if (this.cleanupTimer) {
+      clearInterval(this.cleanupTimer);
+      this.cleanupTimer = undefined;
+      logger.info("Device eviction timer stopped");
+    }
+  }
+
+  public forceCleanup(): void {
+    this.cleanupStaleDevices();
+  }
+
+  public getDeviceCount(): number {
+    return this.deviceLastSeen.size;
   }
 
   getDeviceState(deviceId: string): string | undefined {

--- a/apps/iot-service/src/services/index.ts
+++ b/apps/iot-service/src/services/index.ts
@@ -1,11 +1,12 @@
 import type { CommandPublisher } from "../publishers";
 import type { StateMachineOptions } from "./state-machine";
 
+import { env } from "../config";
 import { DeviceManager } from "./device-manager";
 import { StateMachineService } from "./state-machine";
 
 export function createDeviceManager(): DeviceManager {
-  return new DeviceManager();
+  return new DeviceManager(env.DEVICE_TTL_MS, env.DEVICE_CLEANUP_INTERVAL_MS);
 }
 
 export function createStateMachineService(


### PR DESCRIPTION
Pull request này thêm chức năng quản lý TTL (Time To Live) và dọn dẹp tự động các thiết bị cũ trong DeviceManager của iot-service. Các thay đổi bao gồm:

- Thêm cấu hình DEVICE_TTL_MS và DEVICE_CLEANUP_INTERVAL_MS
- Cập nhật DeviceManager để theo dõi thời gian cuối cùng thấy thiết bị
- Triển khai logic dọn dẹp định kỳ để loại bỏ thiết bị không hoạt động
- Thêm phương thức destroy để dừng timer khi tắt ứng dụng

Điều này giúp cải thiện hiệu suất và quản lý bộ nhớ bằng cách loại bỏ các thiết bị không còn hoạt động.