### PR TITLE
fix(server): require station assignment for managers

### DIFF
--- a/apps/server/src/domain/users/services/test/user.policies.test.ts
+++ b/apps/server/src/domain/users/services/test/user.policies.test.ts
@@ -1,0 +1,27 @@
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+
+import { validateOrgAssignmentForRole } from "../user.policies";
+
+describe("validateOrgAssignmentForRole", () => {
+  it("rejects manager without station assignment", async () => {
+    const result = await Effect.runPromise(
+      validateOrgAssignmentForRole("MANAGER", null).pipe(Effect.either),
+    );
+
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left._tag).toBe("InvalidOrgAssignment");
+    }
+  });
+
+  it("accepts manager with station assignment", async () => {
+    const result = await Effect.runPromise(
+      validateOrgAssignmentForRole("MANAGER", {
+        stationId: "0195b6c2-e0f0-7a11-8d45-55f3b5f0a001",
+      }).pipe(Effect.either),
+    );
+
+    expect(result._tag).toBe("Right");
+  });
+});

--- a/apps/server/src/domain/users/services/user.policies.ts
+++ b/apps/server/src/domain/users/services/user.policies.ts
@@ -70,10 +70,7 @@ export function validateOrgAssignmentForRole(
     case "ADMIN":
       return hasStation || hasAgency || hasTechnicianTeam ? fail() : Effect.void;
     case "MANAGER":
-      return (hasStation && !hasAgency && !hasTechnicianTeam)
-        || (!hasStation && !hasAgency && !hasTechnicianTeam)
-        ? Effect.void
-        : fail();
+      return hasStation && !hasAgency && !hasTechnicianTeam ? Effect.void : fail();
     case "STAFF":
       return hasStation && !hasAgency && !hasTechnicianTeam ? Effect.void : fail();
     case "AGENCY":

--- a/apps/server/src/http/test/e2e/manage-users-org-assignment.e2e.int.test.ts
+++ b/apps/server/src/http/test/e2e/manage-users-org-assignment.e2e.int.test.ts
@@ -224,9 +224,22 @@ describe("manage-users org assignment e2e", () => {
       }),
     });
 
+    const managerWithoutStationResponse = await fixture.app.request("http://test/v1/users/manage-users/create", {
+      method: "POST",
+      headers: adminAuthHeader(),
+      body: JSON.stringify({
+        fullname: "Manager Missing Assignment",
+        email: "manager-missing-assignment@example.com",
+        password: "password123",
+        role: "MANAGER",
+        orgAssignment: null,
+      }),
+    });
+
     const staffWithTeamBody = await staffWithTeamResponse.json() as UsersContracts.UserErrorResponse;
     const userWithStationBody = await userWithStationResponse.json() as UsersContracts.UserErrorResponse;
     const managerWithTeamBody = await managerWithTeamResponse.json() as UsersContracts.UserErrorResponse;
+    const managerWithoutStationBody = await managerWithoutStationResponse.json() as UsersContracts.UserErrorResponse;
 
     expect(staffWithTeamResponse.status).toBe(400);
     expect(staffWithTeamBody.details.code).toBe("INVALID_ORG_ASSIGNMENT");
@@ -234,6 +247,8 @@ describe("manage-users org assignment e2e", () => {
     expect(userWithStationBody.details.code).toBe("INVALID_ORG_ASSIGNMENT");
     expect(managerWithTeamResponse.status).toBe(400);
     expect(managerWithTeamBody.details.code).toBe("INVALID_ORG_ASSIGNMENT");
+    expect(managerWithoutStationResponse.status).toBe(400);
+    expect(managerWithoutStationBody.details.code).toBe("INVALID_ORG_ASSIGNMENT");
   });
 
   it("returns INVALID_ORG_ASSIGNMENT when create references nonexistent station or technician team", async () => {
@@ -558,7 +573,7 @@ describe("manage-users org assignment e2e", () => {
     expect(body.data.some(user => user.fullName === "Regular User")).toBe(false);
   });
 
-  it("replaces org assignment and can clear it on update", async () => {
+  it("replaces org assignment on update and rejects manager without station", async () => {
     const station = await fixture.factories.station({ name: "Station Team Base" });
     const team = await fixture.prisma.technicianTeam.create({
       data: {
@@ -615,11 +630,10 @@ describe("manage-users org assignment e2e", () => {
       },
     );
 
-    const cleared = await clearResponse.json() as UsersContracts.AdminUserDetailResponse;
+    const cleared = await clearResponse.json() as UsersContracts.UserErrorResponse;
 
-    expect(clearResponse.status).toBe(200);
-    expect(cleared.role).toBe("MANAGER");
-    expect(cleared.orgAssignment).toBeNull();
+    expect(clearResponse.status).toBe(400);
+    expect(cleared.details.code).toBe("INVALID_ORG_ASSIGNMENT");
   });
 
   it("returns team member limit error when updating a user into a full technician team", async () => {


### PR DESCRIPTION
## Summary
- require `MANAGER` org assignments to include a station in server-side validation
- align manage-users create/update e2e coverage so manager-without-station now fails with `INVALID_ORG_ASSIGNMENT`
- add focused validator tests for manager station assignment rules

## Testing
- `pnpm vitest run src/domain/users/services/test/user.policies.test.ts`
- `pnpm vitest run --config vitest.e2e.config.ts --mode test src/http/test/e2e/manage-users-org-assignment.e2e.int.test.ts`