### PR TITLE
feat(mobile): let agency use staff rental tools

### DIFF
--- a/apps/mobile/hooks/query/stations/use-get-station-list-query.ts
+++ b/apps/mobile/hooks/query/stations/use-get-station-list-query.ts
@@ -12,8 +12,9 @@ async function fetchStationList() {
   return result.value;
 }
 
-export function useGetStationListQuery() {
+export function useGetStationListQuery(enabled: boolean = true) {
   return useQuery<Awaited<ReturnType<typeof fetchStationList>>, StationError>({
+    enabled,
     queryFn: fetchStationList,
     queryKey: ["stations", "list"],
   });

--- a/apps/mobile/navigation/main-tab-navigator.tsx
+++ b/apps/mobile/navigation/main-tab-navigator.tsx
@@ -22,7 +22,8 @@ function StationTabRedirectScreen() {
 }
 
 function MainTabNavigator() {
-  const { status, isAuthenticated, isStaff, isTechnician } = useAuthNext();
+  const { status, isAuthenticated, isTechnician, user } = useAuthNext();
+  const canUseStaffTools = user?.role === "STAFF" || user?.role === "AGENCY";
 
   if (status === "loading") {
     return <LoadingScreen />;
@@ -36,7 +37,7 @@ function MainTabNavigator() {
       }}
       tabBar={props => <BottomTabBar {...props} />}
     >
-      {isStaff || isTechnician
+      {canUseStaffTools || isTechnician
         ? (
             <>
               <Tab.Screen

--- a/apps/mobile/screen/staff/dashboard/staff-dashboard-screen.tsx
+++ b/apps/mobile/screen/staff/dashboard/staff-dashboard-screen.tsx
@@ -108,7 +108,8 @@ function DashboardActionRow({
 
 export default function StaffDashboardScreen() {
   const navigation = useNavigation<StackNavigationProp<RootStackParamList>>();
-  const { isStaff } = useAuthNext();
+  const { user } = useAuthNext();
+  const canUseStaffTools = user?.role === "STAFF" || user?.role === "AGENCY";
   const pendingBikeSwapQuery = useStaffBikeSwapRequestsQuery(
     {
       status: "PENDING",
@@ -117,7 +118,7 @@ export default function StaffDashboardScreen() {
       sortBy: "createdAt",
       sortDir: "desc",
     },
-    isStaff,
+    canUseStaffTools,
   );
   const pendingRequestCount = pendingBikeSwapQuery.data?.pagination.total ?? 0;
 

--- a/apps/mobile/screen/staff/rental-detail/components/staff-end-rental-card.tsx
+++ b/apps/mobile/screen/staff/rental-detail/components/staff-end-rental-card.tsx
@@ -17,7 +17,7 @@ type Props = {
   isSubmitting: boolean;
   isVisible: boolean;
   note: string;
-  operatorStation: {
+  managedStation: {
     id: string;
     name: string;
   } | null;
@@ -39,14 +39,14 @@ export default function StaffEndRentalCard({
   isSubmitting,
   isVisible,
   note,
-  operatorStation,
+  managedStation,
   onChangeVisible,
   onNoteChange,
   onSubmit,
 }: Props) {
   const theme = useTheme();
   const activeReturnSlot = booking.returnSlot;
-  const endStation = activeReturnSlot?.station ?? operatorStation;
+  const endStation = activeReturnSlot?.station ?? managedStation;
   const canEndRental = booking.status === "RENTED" && Boolean(endStation);
 
   const handleConfirm = () => {
@@ -136,14 +136,14 @@ export default function StaffEndRentalCard({
                 <AppText variant="bodyStrong">
                   {activeReturnSlot
                     ? activeReturnSlot.station.name
-                    : (operatorStation?.name ?? "Chưa xác định được trạm trả xe")}
+                    : (managedStation?.name ?? "Chưa xác định được trạm trả xe")}
                 </AppText>
                 <AppText tone="muted" variant="bodySmall">
                   {activeReturnSlot
                     ? `Giữ chỗ từ ${formatVietnamDateTime(activeReturnSlot.reservedFrom)}`
-                    : operatorStation
+                    : managedStation
                       ? "Khách chưa giữ chỗ trước. Hệ thống sẽ kiểm tra chỗ trống hiện tại tại trạm của bạn khi xác nhận trả xe."
-                      : "Không tìm thấy trạm vận hành của bạn để xác nhận trả xe."}
+                      : "Không tìm thấy trạm được gán cho bạn để xác nhận trả xe."}
                 </AppText>
               </YStack>
             </XStack>

--- a/apps/mobile/screen/staff/rental-detail/hooks/use-staff-rental-detail-screen.ts
+++ b/apps/mobile/screen/staff/rental-detail/hooks/use-staff-rental-detail-screen.ts
@@ -1,10 +1,11 @@
 import { useStaffEndRentalMutation } from "@hooks/mutations/rentals/use-staff-end-rental-mutation";
 import { useStaffRentalDetailQuery } from "@hooks/query/rentals/use-staff-rental-detail-query";
+import { useGetStationListQuery } from "@hooks/query/stations/use-get-station-list-query";
+import { useAuthNext } from "@providers/auth-provider-next";
 import { useCallback, useState } from "react";
 import { Alert } from "react-native";
 
 import { presentRentalError } from "@/presenters/rentals/rental-error-presenter";
-import { useAuthNext } from "@/providers/auth-provider-next";
 
 type EndRentalPayload = {
   stationId: string;
@@ -21,6 +22,12 @@ type EndRentalCallbacks = {
 export function useStaffRentalDetailScreen(rentalId: string) {
   const [isRefreshing, setIsRefreshing] = useState(false);
   const { user } = useAuthNext();
+  const assignedStation = user?.orgAssignment?.station ?? null;
+  const agencyId = user?.role === "AGENCY" ? (user.orgAssignment?.agency?.id ?? null) : null;
+  const stationListQuery = useGetStationListQuery(Boolean(agencyId) && !assignedStation);
+  const managedStation = assignedStation
+    ?? stationListQuery.data?.find(station => station.agencyId === agencyId)
+    ?? null;
 
   const {
     data: booking,
@@ -30,7 +37,6 @@ export function useStaffRentalDetailScreen(rentalId: string) {
   } = useStaffRentalDetailQuery(rentalId, true);
 
   const endRentalMutation = useStaffEndRentalMutation();
-  const operatorStation = user?.orgAssignment?.station ?? null;
 
   const onRefresh = useCallback(async () => {
     setIsRefreshing(true);
@@ -45,7 +51,7 @@ export function useStaffRentalDetailScreen(rentalId: string) {
   const handleEndRental = useCallback(
     ({ stationId, reason, confirmationMethod, confirmedAt }: EndRentalPayload, callbacks?: EndRentalCallbacks) => {
       const returnSlot = booking?.returnSlot;
-      const resolvedStationId = stationId || returnSlot?.station.id || operatorStation?.id || "";
+      const resolvedStationId = stationId || returnSlot?.station.id || managedStation?.id || "";
 
       if (!resolvedStationId) {
         Alert.alert("Thiếu thông tin", "Vui lòng chọn trạm kết thúc.");
@@ -80,7 +86,7 @@ export function useStaffRentalDetailScreen(rentalId: string) {
         },
       );
     },
-    [booking?.returnSlot, endRentalMutation, operatorStation?.id, rentalId],
+    [booking?.returnSlot, endRentalMutation, managedStation?.id, rentalId],
   );
 
   return {
@@ -89,7 +95,7 @@ export function useStaffRentalDetailScreen(rentalId: string) {
     isEndingRental: endRentalMutation.isPending,
     isError,
     isInitialLoading: isRentalLoading,
-    operatorStation,
+    managedStation,
     isRefreshing,
     onRefresh,
   };

--- a/apps/mobile/screen/staff/rental-detail/staff-rental-detail-screen.tsx
+++ b/apps/mobile/screen/staff/rental-detail/staff-rental-detail-screen.tsx
@@ -58,7 +58,7 @@ function StaffRentalDetailScreen() {
     isInitialLoading,
     isRefreshing,
     onRefresh,
-    operatorStation,
+    managedStation,
   } = useStaffRentalDetailScreen(rentalId);
 
   if (isInitialLoading && !booking) {
@@ -130,10 +130,10 @@ function StaffRentalDetailScreen() {
             {booking.status === "RENTED" && !booking.returnSlot
               ? (
                   <StaffWarningCard
-                    description={operatorStation
-                      ? `Khách hàng chưa đặt chỗ trả xe trước. Bạn vẫn có thể thu xe tại ${operatorStation.name} nếu hệ thống xác nhận còn chỗ trống.`
-                      : "Khách hàng chưa đặt chỗ trả xe và tài khoản của bạn chưa có trạm vận hành để xác nhận thu xe."}
-                    title={operatorStation ? "Chưa có chỗ trả xe trước" : "Không thể kết thúc phiên"}
+                    description={managedStation
+                      ? `Khách hàng chưa đặt chỗ trả xe trước. Bạn vẫn có thể thu xe tại ${managedStation.name} nếu hệ thống xác nhận còn chỗ trống.`
+                      : "Khách hàng chưa đặt chỗ trả xe và tài khoản của bạn chưa có trạm được gán để xác nhận thu xe."}
+                    title={managedStation ? "Chưa có chỗ trả xe trước" : "Không thể kết thúc phiên"}
                   />
                 )
               : null}
@@ -151,7 +151,7 @@ function StaffRentalDetailScreen() {
               isSubmitting={isEndingRental}
               isVisible={isEndRentalOpen}
               note={endReason}
-              operatorStation={operatorStation}
+              managedStation={managedStation}
               onChangeVisible={(visible) => {
                 setIsEndRentalOpen(visible);
                 if (!visible) {

--- a/apps/server/src/http/routes/rentals.ts
+++ b/apps/server/src/http/routes/rentals.ts
@@ -46,7 +46,7 @@ export function registerRentalRoutes(
 
   const staffGetRoute = {
     ...rentals.staffGetRental,
-    middleware: [requireStaffMiddleware] as const,
+    middleware: [requireRentalOperatorMiddleware] as const,
   } satisfies RouteConfig;
 
   app.openapi(staffGetRoute, RentalStaffController.staffGetRental);

--- a/apps/server/src/http/test/e2e/rentals-end-routing.e2e.int.test.ts
+++ b/apps/server/src/http/test/e2e/rentals-end-routing.e2e.int.test.ts
@@ -181,6 +181,23 @@ describe("rentals end routing e2e", () => {
     expect(body.returnSlot?.status).toBe("ACTIVE");
   });
 
+  it("allows an agency user to fetch rental detail from the staff route", async () => {
+    const { rental } = await createActiveRentalGraph();
+    const { token: agencyToken } = await createAgencyToken();
+
+    const response = await fixture.app.request(`http://test/v1/staff/rentals/${rental.id}`, {
+      headers: {
+        Authorization: `Bearer ${agencyToken}`,
+      },
+    });
+
+    const body = await response.json() as RentalsContracts.RentalDetail;
+
+    expect(response.status).toBe(200);
+    expect(body.id).toBe(rental.id);
+    expect(body.status).toBe("RENTED");
+  });
+
   it("lists my bike swap requests without being shadowed by the rental detail route", async () => {
     const { user, rental } = await createActiveRentalGraph();
     const userToken = fixture.auth.makeAccessToken({ userId: user.id, role: "USER" });


### PR DESCRIPTION
## Summary
- let agency users enter the existing staff tools flow for bike-swap, phone lookup, QR rental detail, and end-rental on mobile
- resolve a managed station for agency users in the staff rental detail flow when no direct station assignment is present
- allow agency access to the existing staff rental-detail route on the server and add e2e coverage for that access

## Testing
- ran focused eslint on the files touched by this branch
- added agency coverage to `apps/server/src/http/test/e2e/rentals-end-routing.e2e.int.test.ts`