### PR TITLE
feat(server): add admin technician team management APIs

### DIFF
--- a/apps/server/src/domain/technician-teams/domain-errors.ts
+++ b/apps/server/src/domain/technician-teams/domain-errors.ts
@@ -14,3 +14,7 @@ export class TechnicianTeamInternalStationRequired extends Data.TaggedError("Tec
   readonly stationId: string;
   readonly stationType: "INTERNAL" | "AGENCY";
 }> {}
+
+export class TechnicianTeamNotFound extends Data.TaggedError("TechnicianTeamNotFound")<{
+  readonly id: string;
+}> {}

--- a/apps/server/src/domain/technician-teams/domain-errors.ts
+++ b/apps/server/src/domain/technician-teams/domain-errors.ts
@@ -5,3 +5,7 @@ import type { WithGenericError } from "@/domain/shared";
 export class TechnicianTeamRepositoryError extends Data.TaggedError("TechnicianTeamRepositoryError")<
   WithGenericError
 > {}
+
+export class TechnicianTeamStationNotFound extends Data.TaggedError("TechnicianTeamStationNotFound")<{
+  readonly stationId: string;
+}> {}

--- a/apps/server/src/domain/technician-teams/domain-errors.ts
+++ b/apps/server/src/domain/technician-teams/domain-errors.ts
@@ -9,3 +9,8 @@ export class TechnicianTeamRepositoryError extends Data.TaggedError("TechnicianT
 export class TechnicianTeamStationNotFound extends Data.TaggedError("TechnicianTeamStationNotFound")<{
   readonly stationId: string;
 }> {}
+
+export class TechnicianTeamInternalStationRequired extends Data.TaggedError("TechnicianTeamInternalStationRequired")<{
+  readonly stationId: string;
+  readonly stationType: "INTERNAL" | "AGENCY";
+}> {}

--- a/apps/server/src/domain/technician-teams/index.ts
+++ b/apps/server/src/domain/technician-teams/index.ts
@@ -1,3 +1,9 @@
 export * from "./domain-errors";
 export * from "./models";
+export * from "./repository/technician-team-command.repository";
 export * from "./repository/technician-team-query.repository";
+export * from "./services/technician-team-command.live";
+export * from "./services/technician-team-command.service";
+export * from "./services/technician-team-query.live";
+export * from "./services/technician-team-query.service";
+export type * from "./services/technician-team.service.types";

--- a/apps/server/src/domain/technician-teams/models.ts
+++ b/apps/server/src/domain/technician-teams/models.ts
@@ -8,6 +8,11 @@ export type CreateTechnicianTeamInput = {
   readonly availabilityStatus?: TechnicianTeamAvailability;
 };
 
+export type UpdateTechnicianTeamInput = {
+  readonly name?: string;
+  readonly availabilityStatus?: TechnicianTeamAvailability;
+};
+
 export type TechnicianTeamFilter = {
   readonly stationId?: string;
   readonly availabilityStatus?: TechnicianTeamAvailability;

--- a/apps/server/src/domain/technician-teams/models.ts
+++ b/apps/server/src/domain/technician-teams/models.ts
@@ -2,11 +2,26 @@ import type { TechnicianTeamAvailability } from "generated/prisma/client";
 
 export const TECHNICIAN_TEAM_MEMBER_LIMIT = 3;
 
+export type CreateTechnicianTeamInput = {
+  readonly name: string;
+  readonly stationId: string;
+  readonly availabilityStatus?: TechnicianTeamAvailability;
+};
+
+export type TechnicianTeamFilter = {
+  readonly stationId?: string;
+  readonly availabilityStatus?: TechnicianTeamAvailability;
+};
+
 export type TechnicianTeamRow = {
   readonly id: string;
   readonly name: string;
   readonly stationId: string;
+  readonly stationName: string;
   readonly availabilityStatus: TechnicianTeamAvailability;
+  readonly memberCount: number;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
 };
 
 export type TechnicianTeamAvailableOption = {

--- a/apps/server/src/domain/technician-teams/repository/read/technician-team.read.repository.ts
+++ b/apps/server/src/domain/technician-teams/repository/read/technician-team.read.repository.ts
@@ -67,14 +67,14 @@ export function makeTechnicianTeamReadRepository(
             operation: "getById",
             cause,
           }),
-        }).pipe(
-          Effect.map(row =>
-            Option.fromNullable(row).pipe(
-              Option.map(mapRow),
-            ),
+      }).pipe(
+        Effect.map(row =>
+          Option.fromNullable(row).pipe(
+            Option.map(mapRow),
           ),
-          defectOn(TechnicianTeamRepositoryError),
         ),
+        defectOn(TechnicianTeamRepositoryError),
+      ),
 
     list: args =>
       Effect.tryPromise({

--- a/apps/server/src/domain/technician-teams/repository/read/technician-team.read.repository.ts
+++ b/apps/server/src/domain/technician-teams/repository/read/technician-team.read.repository.ts
@@ -17,6 +17,26 @@ import {
 export function makeTechnicianTeamReadRepository(
   client: PrismaClient | PrismaTypes.TransactionClient,
 ): TechnicianTeamQueryRepo {
+  const mapRow = (row: {
+    id: string;
+    name: string;
+    stationId: string;
+    station: { name: string };
+    availabilityStatus: import("generated/prisma/client").TechnicianTeamAvailability;
+    createdAt: Date;
+    updatedAt: Date;
+    _count: { userAssignments: number };
+  }): TechnicianTeamRow => ({
+    id: row.id,
+    name: row.name,
+    stationId: row.stationId,
+    stationName: row.station.name,
+    availabilityStatus: row.availabilityStatus,
+    memberCount: row._count.userAssignments,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  });
+
   return {
     getById: id =>
       Effect.tryPromise({
@@ -27,7 +47,19 @@ export function makeTechnicianTeamReadRepository(
               id: true,
               name: true,
               stationId: true,
+              station: {
+                select: {
+                  name: true,
+                },
+              },
               availabilityStatus: true,
+              createdAt: true,
+              updatedAt: true,
+              _count: {
+                select: {
+                  userAssignments: true,
+                },
+              },
             },
           }),
         catch: cause =>
@@ -35,17 +67,52 @@ export function makeTechnicianTeamReadRepository(
             operation: "getById",
             cause,
           }),
-      }).pipe(
-        Effect.map(row =>
-          Option.fromNullable(row).pipe(
-            Option.map((item): TechnicianTeamRow => ({
-              id: item.id,
-              name: item.name,
-              stationId: item.stationId,
-              availabilityStatus: item.availabilityStatus,
-            })),
+        }).pipe(
+          Effect.map(row =>
+            Option.fromNullable(row).pipe(
+              Option.map(mapRow),
+            ),
           ),
+          defectOn(TechnicianTeamRepositoryError),
         ),
+
+    list: args =>
+      Effect.tryPromise({
+        try: () =>
+          client.technicianTeam.findMany({
+            where: pickDefined({
+              stationId: args?.stationId,
+              availabilityStatus: args?.availabilityStatus,
+            }),
+            orderBy: {
+              name: "asc",
+            },
+            select: {
+              id: true,
+              name: true,
+              stationId: true,
+              station: {
+                select: {
+                  name: true,
+                },
+              },
+              availabilityStatus: true,
+              createdAt: true,
+              updatedAt: true,
+              _count: {
+                select: {
+                  userAssignments: true,
+                },
+              },
+            },
+          }),
+        catch: cause =>
+          new TechnicianTeamRepositoryError({
+            operation: "list",
+            cause,
+          }),
+      }).pipe(
+        Effect.map(rows => rows.map(mapRow)),
         defectOn(TechnicianTeamRepositoryError),
       ),
 

--- a/apps/server/src/domain/technician-teams/repository/technician-team-command.repository.ts
+++ b/apps/server/src/domain/technician-teams/repository/technician-team-command.repository.ts
@@ -1,0 +1,36 @@
+import { Effect, Layer } from "effect";
+
+import type { PrismaClient, Prisma as PrismaTypes } from "generated/prisma/client";
+
+import { Prisma } from "@/infrastructure/prisma";
+
+import type { TechnicianTeamCommandRepo } from "./technician-team.repository.types";
+
+import { makeTechnicianTeamWriteRepository } from "./write/technician-team.write.repository";
+
+export type { TechnicianTeamCommandRepo } from "./technician-team.repository.types";
+
+const makeTechnicianTeamCommandRepositoryEffect = Effect.gen(function* () {
+  const { client } = yield* Prisma;
+  return makeTechnicianTeamCommandRepository(client);
+});
+
+export class TechnicianTeamCommandRepository extends Effect.Service<TechnicianTeamCommandRepository>()(
+  "TechnicianTeamCommandRepository",
+  {
+    effect: makeTechnicianTeamCommandRepositoryEffect,
+  },
+) {}
+
+export function makeTechnicianTeamCommandRepository(
+  client: PrismaClient | PrismaTypes.TransactionClient,
+): TechnicianTeamCommandRepo {
+  return makeTechnicianTeamWriteRepository(client);
+}
+
+export const TechnicianTeamCommandRepositoryLive = Layer.effect(
+  TechnicianTeamCommandRepository,
+  makeTechnicianTeamCommandRepositoryEffect.pipe(
+    Effect.map(TechnicianTeamCommandRepository.make),
+  ),
+);

--- a/apps/server/src/domain/technician-teams/repository/technician-team.repository.types.ts
+++ b/apps/server/src/domain/technician-teams/repository/technician-team.repository.types.ts
@@ -1,7 +1,9 @@
 import type { Effect, Option } from "effect";
 
 import type {
+  CreateTechnicianTeamInput,
   TechnicianTeamAvailableOption,
+  TechnicianTeamFilter,
   TechnicianTeamRow,
 } from "../models";
 
@@ -9,6 +11,7 @@ export type TechnicianTeamQueryRepo = {
   readonly getById: (
     id: string,
   ) => Effect.Effect<Option.Option<TechnicianTeamRow>>;
+  readonly list: (args?: TechnicianTeamFilter) => Effect.Effect<readonly TechnicianTeamRow[]>;
   readonly listAvailable: (args?: {
     readonly stationId?: string;
   }) => Effect.Effect<readonly TechnicianTeamAvailableOption[]>;
@@ -16,4 +19,10 @@ export type TechnicianTeamQueryRepo = {
     technicianTeamId: string,
     options?: { readonly excludeUserId?: string },
   ) => Effect.Effect<number>;
+};
+
+export type TechnicianTeamCommandRepo = {
+  readonly create: (
+    input: Required<CreateTechnicianTeamInput>,
+  ) => Effect.Effect<TechnicianTeamRow>;
 };

--- a/apps/server/src/domain/technician-teams/repository/technician-team.repository.types.ts
+++ b/apps/server/src/domain/technician-teams/repository/technician-team.repository.types.ts
@@ -5,6 +5,7 @@ import type {
   TechnicianTeamAvailableOption,
   TechnicianTeamFilter,
   TechnicianTeamRow,
+  UpdateTechnicianTeamInput,
 } from "../models";
 
 export type TechnicianTeamQueryRepo = {
@@ -24,5 +25,9 @@ export type TechnicianTeamQueryRepo = {
 export type TechnicianTeamCommandRepo = {
   readonly create: (
     input: Required<CreateTechnicianTeamInput>,
+  ) => Effect.Effect<TechnicianTeamRow>;
+  readonly update: (
+    id: string,
+    input: UpdateTechnicianTeamInput,
   ) => Effect.Effect<TechnicianTeamRow>;
 };

--- a/apps/server/src/domain/technician-teams/repository/test/read/technician-team.read.repository.int.test.ts
+++ b/apps/server/src/domain/technician-teams/repository/test/read/technician-team.read.repository.int.test.ts
@@ -62,6 +62,41 @@ describe("technicianTeamReadRepository Integration", () => {
     expect(excludedCount).toBe(1);
   });
 
+  it("list returns technician teams with filters and member counts", async () => {
+    const stationA = await fixture.factories.station({ name: "List Team Station A" });
+    const stationB = await fixture.factories.station({ name: "List Team Station B" });
+    const availableTeam = await fixture.factories.technicianTeam({
+      name: "List Available Team",
+      stationId: stationA.id,
+    });
+    await fixture.factories.technicianTeam({
+      name: "List Unavailable Team",
+      stationId: stationB.id,
+      availabilityStatus: "UNAVAILABLE",
+    });
+    const technician = await fixture.factories.user({
+      role: "TECHNICIAN",
+      email: "list-team-tech@example.com",
+    });
+    const repo = makeTechnicianTeamQueryRepository(fixture.prisma);
+
+    await fixture.factories.userOrgAssignment({
+      userId: technician.id,
+      technicianTeamId: availableTeam.id,
+    });
+
+    const rows = await runEffect(repo.list({
+      stationId: stationA.id,
+      availabilityStatus: "AVAILABLE",
+    }));
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.id).toBe(availableTeam.id);
+    expect(rows[0]?.stationId).toBe(stationA.id);
+    expect(rows[0]?.stationName).toBe("List Team Station A");
+    expect(rows[0]?.memberCount).toBe(1);
+  });
+
   it("listAvailable omits full and unavailable teams and supports station filter", async () => {
     const stationA = await fixture.factories.station({ name: "Tech Team Station A" });
     const stationB = await fixture.factories.station({ name: "Tech Team Station B" });

--- a/apps/server/src/domain/technician-teams/repository/test/write/technician-team.write.repository.int.test.ts
+++ b/apps/server/src/domain/technician-teams/repository/test/write/technician-team.write.repository.int.test.ts
@@ -23,4 +23,24 @@ describe("technicianTeamWriteRepository Integration", () => {
     expect(created.availabilityStatus).toBe("AVAILABLE");
     expect(created.memberCount).toBe(0);
   });
+
+  it("update changes technician team mutable fields", async () => {
+    const station = await fixture.factories.station({ name: "Update Team Station" });
+    const team = await fixture.factories.technicianTeam({
+      name: "Update Team Alpha",
+      stationId: station.id,
+      availabilityStatus: "AVAILABLE",
+    });
+    const repo = makeTechnicianTeamCommandRepository(fixture.prisma);
+
+    const updated = await runEffect(repo.update(team.id, {
+      name: "Update Team Beta",
+      availabilityStatus: "UNAVAILABLE",
+    }));
+
+    expect(updated.id).toBe(team.id);
+    expect(updated.name).toBe("Update Team Beta");
+    expect(updated.stationId).toBe(station.id);
+    expect(updated.availabilityStatus).toBe("UNAVAILABLE");
+  });
 });

--- a/apps/server/src/domain/technician-teams/repository/test/write/technician-team.write.repository.int.test.ts
+++ b/apps/server/src/domain/technician-teams/repository/test/write/technician-team.write.repository.int.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { makeTechnicianTeamCommandRepository } from "@/domain/technician-teams";
+import { runEffect } from "@/test/effect/run";
+import { setupPrismaIntFixture } from "@/test/prisma/prisma-int-fixture";
+
+describe("technicianTeamWriteRepository Integration", () => {
+  const fixture = setupPrismaIntFixture();
+
+  it("create inserts technician team with station snapshot fields", async () => {
+    const station = await fixture.factories.station({ name: "Write Team Station" });
+    const repo = makeTechnicianTeamCommandRepository(fixture.prisma);
+
+    const created = await runEffect(repo.create({
+      name: "Write Team Alpha",
+      stationId: station.id,
+      availabilityStatus: "AVAILABLE",
+    }));
+
+    expect(created.name).toBe("Write Team Alpha");
+    expect(created.stationId).toBe(station.id);
+    expect(created.stationName).toBe("Write Team Station");
+    expect(created.availabilityStatus).toBe("AVAILABLE");
+    expect(created.memberCount).toBe(0);
+  });
+});

--- a/apps/server/src/domain/technician-teams/repository/write/technician-team.write.repository.ts
+++ b/apps/server/src/domain/technician-teams/repository/write/technician-team.write.repository.ts
@@ -1,0 +1,64 @@
+import { Effect } from "effect";
+import { uuidv7 } from "uuidv7";
+
+import type { PrismaClient, Prisma as PrismaTypes } from "generated/prisma/client";
+
+import type { TechnicianTeamCommandRepo } from "../technician-team.repository.types";
+
+import { defectOn } from "@/domain/shared";
+
+import { TechnicianTeamRepositoryError } from "../../domain-errors";
+
+export function makeTechnicianTeamWriteRepository(
+  client: PrismaClient | PrismaTypes.TransactionClient,
+): TechnicianTeamCommandRepo {
+  return {
+    create: input =>
+      Effect.tryPromise({
+        try: () =>
+          client.technicianTeam.create({
+            data: {
+              id: uuidv7(),
+              name: input.name,
+              stationId: input.stationId,
+              availabilityStatus: input.availabilityStatus,
+            },
+            select: {
+              id: true,
+              name: true,
+              stationId: true,
+              station: {
+                select: {
+                  name: true,
+                },
+              },
+              availabilityStatus: true,
+              createdAt: true,
+              updatedAt: true,
+              _count: {
+                select: {
+                  userAssignments: true,
+                },
+              },
+            },
+          }),
+        catch: cause =>
+          new TechnicianTeamRepositoryError({
+            operation: "create",
+            cause,
+          }),
+      }).pipe(
+        Effect.map(row => ({
+          id: row.id,
+          name: row.name,
+          stationId: row.stationId,
+          stationName: row.station.name,
+          availabilityStatus: row.availabilityStatus,
+          memberCount: row._count.userAssignments,
+          createdAt: row.createdAt,
+          updatedAt: row.updatedAt,
+        })),
+        defectOn(TechnicianTeamRepositoryError),
+      ),
+  };
+}

--- a/apps/server/src/domain/technician-teams/repository/write/technician-team.write.repository.ts
+++ b/apps/server/src/domain/technician-teams/repository/write/technician-team.write.repository.ts
@@ -1,13 +1,59 @@
 import { Effect } from "effect";
 import { uuidv7 } from "uuidv7";
 
-import type { PrismaClient, Prisma as PrismaTypes } from "generated/prisma/client";
+import type {
+  PrismaClient,
+  Prisma as PrismaTypes,
+  TechnicianTeamAvailability,
+} from "generated/prisma/client";
+
+import { defectOn } from "@/domain/shared";
+import { pickDefined } from "@/domain/shared/pick-defined";
 
 import type { TechnicianTeamCommandRepo } from "../technician-team.repository.types";
 
-import { defectOn } from "@/domain/shared";
-
 import { TechnicianTeamRepositoryError } from "../../domain-errors";
+
+const technicianTeamDetailSelect = {
+  id: true,
+  name: true,
+  stationId: true,
+  station: {
+    select: {
+      name: true,
+    },
+  },
+  availabilityStatus: true,
+  createdAt: true,
+  updatedAt: true,
+  _count: {
+    select: {
+      userAssignments: true,
+    },
+  },
+} satisfies PrismaTypes.TechnicianTeamSelect;
+
+function mapTechnicianTeamRow(row: {
+  id: string;
+  name: string;
+  stationId: string;
+  station: { name: string };
+  availabilityStatus: TechnicianTeamAvailability;
+  createdAt: Date;
+  updatedAt: Date;
+  _count: { userAssignments: number };
+}) {
+  return {
+    id: row.id,
+    name: row.name,
+    stationId: row.stationId,
+    stationName: row.station.name,
+    availabilityStatus: row.availabilityStatus,
+    memberCount: row._count.userAssignments,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
 
 export function makeTechnicianTeamWriteRepository(
   client: PrismaClient | PrismaTypes.TransactionClient,
@@ -23,24 +69,7 @@ export function makeTechnicianTeamWriteRepository(
               stationId: input.stationId,
               availabilityStatus: input.availabilityStatus,
             },
-            select: {
-              id: true,
-              name: true,
-              stationId: true,
-              station: {
-                select: {
-                  name: true,
-                },
-              },
-              availabilityStatus: true,
-              createdAt: true,
-              updatedAt: true,
-              _count: {
-                select: {
-                  userAssignments: true,
-                },
-              },
-            },
+            select: technicianTeamDetailSelect,
           }),
         catch: cause =>
           new TechnicianTeamRepositoryError({
@@ -48,16 +77,28 @@ export function makeTechnicianTeamWriteRepository(
             cause,
           }),
       }).pipe(
-        Effect.map(row => ({
-          id: row.id,
-          name: row.name,
-          stationId: row.stationId,
-          stationName: row.station.name,
-          availabilityStatus: row.availabilityStatus,
-          memberCount: row._count.userAssignments,
-          createdAt: row.createdAt,
-          updatedAt: row.updatedAt,
-        })),
+        Effect.map(mapTechnicianTeamRow),
+        defectOn(TechnicianTeamRepositoryError),
+      ),
+
+    update: (id, input) =>
+      Effect.tryPromise({
+        try: () =>
+          client.technicianTeam.update({
+            where: { id },
+            data: pickDefined({
+              name: input.name,
+              availabilityStatus: input.availabilityStatus,
+            }),
+            select: technicianTeamDetailSelect,
+          }),
+        catch: cause =>
+          new TechnicianTeamRepositoryError({
+            operation: "update",
+            cause,
+          }),
+      }).pipe(
+        Effect.map(mapTechnicianTeamRow),
         defectOn(TechnicianTeamRepositoryError),
       ),
   };

--- a/apps/server/src/domain/technician-teams/services/technician-team-command.live.ts
+++ b/apps/server/src/domain/technician-teams/services/technician-team-command.live.ts
@@ -1,0 +1,32 @@
+import { Effect, Layer } from "effect";
+
+import { StationQueryRepository } from "@/domain/stations";
+
+import { TechnicianTeamCommandRepository } from "../repository/technician-team-command.repository";
+import { makeTechnicianTeamCommandService } from "./technician-team-command.service";
+
+export type { TechnicianTeamCommandService } from "./technician-team.service.types";
+
+const makeTechnicianTeamCommandServiceEffect = Effect.gen(function* () {
+  const commandRepo = yield* TechnicianTeamCommandRepository;
+  const stationRepo = yield* StationQueryRepository;
+
+  return makeTechnicianTeamCommandService({
+    commandRepo,
+    stationRepo,
+  });
+});
+
+export class TechnicianTeamCommandServiceTag extends Effect.Service<TechnicianTeamCommandServiceTag>()(
+  "TechnicianTeamCommandService",
+  {
+    effect: makeTechnicianTeamCommandServiceEffect,
+  },
+) {}
+
+export const TechnicianTeamCommandServiceLive = Layer.effect(
+  TechnicianTeamCommandServiceTag,
+  makeTechnicianTeamCommandServiceEffect.pipe(
+    Effect.map(TechnicianTeamCommandServiceTag.make),
+  ),
+);

--- a/apps/server/src/domain/technician-teams/services/technician-team-command.live.ts
+++ b/apps/server/src/domain/technician-teams/services/technician-team-command.live.ts
@@ -3,16 +3,19 @@ import { Effect, Layer } from "effect";
 import { StationQueryRepository } from "@/domain/stations";
 
 import { TechnicianTeamCommandRepository } from "../repository/technician-team-command.repository";
+import { TechnicianTeamQueryRepository } from "../repository/technician-team-query.repository";
 import { makeTechnicianTeamCommandService } from "./technician-team-command.service";
 
 export type { TechnicianTeamCommandService } from "./technician-team.service.types";
 
 const makeTechnicianTeamCommandServiceEffect = Effect.gen(function* () {
   const commandRepo = yield* TechnicianTeamCommandRepository;
+  const queryRepo = yield* TechnicianTeamQueryRepository;
   const stationRepo = yield* StationQueryRepository;
 
   return makeTechnicianTeamCommandService({
     commandRepo,
+    queryRepo,
     stationRepo,
   });
 });

--- a/apps/server/src/domain/technician-teams/services/technician-team-command.service.ts
+++ b/apps/server/src/domain/technician-teams/services/technician-team-command.service.ts
@@ -2,8 +2,7 @@ import { Effect, Option } from "effect";
 
 import type { StationQueryRepo } from "@/domain/stations";
 
-import type { TechnicianTeamQueryRepo } from "../repository/technician-team.repository.types";
-import type { TechnicianTeamCommandRepo } from "../repository/technician-team.repository.types";
+import type { TechnicianTeamCommandRepo, TechnicianTeamQueryRepo } from "../repository/technician-team.repository.types";
 import type { TechnicianTeamCommandService } from "./technician-team.service.types";
 
 import {

--- a/apps/server/src/domain/technician-teams/services/technician-team-command.service.ts
+++ b/apps/server/src/domain/technician-teams/services/technician-team-command.service.ts
@@ -1,0 +1,28 @@
+import { Effect, Option } from "effect";
+
+import type { StationQueryRepo } from "@/domain/stations";
+
+import type { TechnicianTeamCommandRepo } from "../repository/technician-team.repository.types";
+import type { TechnicianTeamCommandService } from "./technician-team.service.types";
+
+import { TechnicianTeamStationNotFound } from "../domain-errors";
+
+export function makeTechnicianTeamCommandService(args: {
+  commandRepo: TechnicianTeamCommandRepo;
+  stationRepo: Pick<StationQueryRepo, "getById">;
+}): TechnicianTeamCommandService {
+  return {
+    createTechnicianTeam: input =>
+      Effect.gen(function* () {
+        const station = yield* args.stationRepo.getById(input.stationId);
+        if (Option.isNone(station)) {
+          return yield* Effect.fail(new TechnicianTeamStationNotFound({ stationId: input.stationId }));
+        }
+
+        return yield* args.commandRepo.create({
+          ...input,
+          availabilityStatus: input.availabilityStatus ?? "AVAILABLE",
+        });
+      }),
+  };
+}

--- a/apps/server/src/domain/technician-teams/services/technician-team-command.service.ts
+++ b/apps/server/src/domain/technician-teams/services/technician-team-command.service.ts
@@ -2,16 +2,19 @@ import { Effect, Option } from "effect";
 
 import type { StationQueryRepo } from "@/domain/stations";
 
+import type { TechnicianTeamQueryRepo } from "../repository/technician-team.repository.types";
 import type { TechnicianTeamCommandRepo } from "../repository/technician-team.repository.types";
 import type { TechnicianTeamCommandService } from "./technician-team.service.types";
 
 import {
   TechnicianTeamInternalStationRequired,
+  TechnicianTeamNotFound,
   TechnicianTeamStationNotFound,
 } from "../domain-errors";
 
 export function makeTechnicianTeamCommandService(args: {
   commandRepo: TechnicianTeamCommandRepo;
+  queryRepo: Pick<TechnicianTeamQueryRepo, "getById">;
   stationRepo: Pick<StationQueryRepo, "getById">;
 }): TechnicianTeamCommandService {
   return {
@@ -33,6 +36,16 @@ export function makeTechnicianTeamCommandService(args: {
           ...input,
           availabilityStatus: input.availabilityStatus ?? "AVAILABLE",
         });
+      }),
+
+    updateTechnicianTeam: (id, input) =>
+      Effect.gen(function* () {
+        const current = yield* args.queryRepo.getById(id);
+        if (Option.isNone(current)) {
+          return yield* Effect.fail(new TechnicianTeamNotFound({ id }));
+        }
+
+        return yield* args.commandRepo.update(id, input);
       }),
   };
 }

--- a/apps/server/src/domain/technician-teams/services/technician-team-command.service.ts
+++ b/apps/server/src/domain/technician-teams/services/technician-team-command.service.ts
@@ -5,7 +5,10 @@ import type { StationQueryRepo } from "@/domain/stations";
 import type { TechnicianTeamCommandRepo } from "../repository/technician-team.repository.types";
 import type { TechnicianTeamCommandService } from "./technician-team.service.types";
 
-import { TechnicianTeamStationNotFound } from "../domain-errors";
+import {
+  TechnicianTeamInternalStationRequired,
+  TechnicianTeamStationNotFound,
+} from "../domain-errors";
 
 export function makeTechnicianTeamCommandService(args: {
   commandRepo: TechnicianTeamCommandRepo;
@@ -17,6 +20,13 @@ export function makeTechnicianTeamCommandService(args: {
         const station = yield* args.stationRepo.getById(input.stationId);
         if (Option.isNone(station)) {
           return yield* Effect.fail(new TechnicianTeamStationNotFound({ stationId: input.stationId }));
+        }
+
+        if (station.value.stationType !== "INTERNAL") {
+          return yield* Effect.fail(new TechnicianTeamInternalStationRequired({
+            stationId: input.stationId,
+            stationType: station.value.stationType,
+          }));
         }
 
         return yield* args.commandRepo.create({

--- a/apps/server/src/domain/technician-teams/services/technician-team-query.live.ts
+++ b/apps/server/src/domain/technician-teams/services/technician-team-query.live.ts
@@ -1,0 +1,25 @@
+import { Effect, Layer } from "effect";
+
+import { TechnicianTeamQueryRepository } from "../repository/technician-team-query.repository";
+import { makeTechnicianTeamQueryService } from "./technician-team-query.service";
+
+export type { TechnicianTeamQueryService } from "./technician-team.service.types";
+
+const makeTechnicianTeamQueryServiceEffect = Effect.gen(function* () {
+  const repo = yield* TechnicianTeamQueryRepository;
+  return makeTechnicianTeamQueryService(repo);
+});
+
+export class TechnicianTeamQueryServiceTag extends Effect.Service<TechnicianTeamQueryServiceTag>()(
+  "TechnicianTeamQueryService",
+  {
+    effect: makeTechnicianTeamQueryServiceEffect,
+  },
+) {}
+
+export const TechnicianTeamQueryServiceLive = Layer.effect(
+  TechnicianTeamQueryServiceTag,
+  makeTechnicianTeamQueryServiceEffect.pipe(
+    Effect.map(TechnicianTeamQueryServiceTag.make),
+  ),
+);

--- a/apps/server/src/domain/technician-teams/services/technician-team-query.service.ts
+++ b/apps/server/src/domain/technician-teams/services/technician-team-query.service.ts
@@ -1,0 +1,11 @@
+import type { TechnicianTeamQueryRepo } from "../repository/technician-team.repository.types";
+import type { TechnicianTeamQueryService } from "./technician-team.service.types";
+
+export function makeTechnicianTeamQueryService(
+  repo: TechnicianTeamQueryRepo,
+): TechnicianTeamQueryService {
+  return {
+    listTechnicianTeams: filter => repo.list(filter),
+    listAvailableTechnicianTeams: args => repo.listAvailable(args),
+  };
+}

--- a/apps/server/src/domain/technician-teams/services/technician-team.service.types.ts
+++ b/apps/server/src/domain/technician-teams/services/technician-team.service.types.ts
@@ -2,6 +2,7 @@ import type { Effect } from "effect";
 
 import type {
   TechnicianTeamInternalStationRequired,
+  TechnicianTeamNotFound,
   TechnicianTeamStationNotFound,
 } from "../domain-errors";
 import type {
@@ -9,6 +10,7 @@ import type {
   TechnicianTeamAvailableOption,
   TechnicianTeamFilter,
   TechnicianTeamRow,
+  UpdateTechnicianTeamInput,
 } from "../models";
 
 export type TechnicianTeamCommandService = {
@@ -18,6 +20,10 @@ export type TechnicianTeamCommandService = {
     TechnicianTeamRow,
     TechnicianTeamStationNotFound | TechnicianTeamInternalStationRequired
   >;
+  updateTechnicianTeam: (
+    id: string,
+    input: UpdateTechnicianTeamInput,
+  ) => Effect.Effect<TechnicianTeamRow, TechnicianTeamNotFound>;
 };
 
 export type TechnicianTeamQueryService = {

--- a/apps/server/src/domain/technician-teams/services/technician-team.service.types.ts
+++ b/apps/server/src/domain/technician-teams/services/technician-team.service.types.ts
@@ -1,6 +1,9 @@
 import type { Effect } from "effect";
 
-import type { TechnicianTeamStationNotFound } from "../domain-errors";
+import type {
+  TechnicianTeamInternalStationRequired,
+  TechnicianTeamStationNotFound,
+} from "../domain-errors";
 import type {
   CreateTechnicianTeamInput,
   TechnicianTeamAvailableOption,
@@ -11,7 +14,10 @@ import type {
 export type TechnicianTeamCommandService = {
   createTechnicianTeam: (
     input: CreateTechnicianTeamInput,
-  ) => Effect.Effect<TechnicianTeamRow, TechnicianTeamStationNotFound>;
+  ) => Effect.Effect<
+    TechnicianTeamRow,
+    TechnicianTeamStationNotFound | TechnicianTeamInternalStationRequired
+  >;
 };
 
 export type TechnicianTeamQueryService = {

--- a/apps/server/src/domain/technician-teams/services/technician-team.service.types.ts
+++ b/apps/server/src/domain/technician-teams/services/technician-team.service.types.ts
@@ -1,0 +1,24 @@
+import type { Effect } from "effect";
+
+import type { TechnicianTeamStationNotFound } from "../domain-errors";
+import type {
+  CreateTechnicianTeamInput,
+  TechnicianTeamAvailableOption,
+  TechnicianTeamFilter,
+  TechnicianTeamRow,
+} from "../models";
+
+export type TechnicianTeamCommandService = {
+  createTechnicianTeam: (
+    input: CreateTechnicianTeamInput,
+  ) => Effect.Effect<TechnicianTeamRow, TechnicianTeamStationNotFound>;
+};
+
+export type TechnicianTeamQueryService = {
+  listTechnicianTeams: (
+    filter?: TechnicianTeamFilter,
+  ) => Effect.Effect<readonly TechnicianTeamRow[]>;
+  listAvailableTechnicianTeams: (args?: {
+    readonly stationId?: string;
+  }) => Effect.Effect<readonly TechnicianTeamAvailableOption[]>;
+};

--- a/apps/server/src/http/app.ts
+++ b/apps/server/src/http/app.ts
@@ -34,6 +34,7 @@ import { registerStripeConnectRoutes } from "./routes/stripe-connect.routes";
 import { registerStripeWebhookRoutes } from "./routes/stripe-webhook.routes";
 import { registerSubscriptionRoutes } from "./routes/subscriptions";
 import { registerSupplierRoutes } from "./routes/suppliers";
+import { registerTechnicianTeamRoutes } from "./routes/technician-teams";
 import { registerUserRoutes } from "./routes/users";
 import { registerWalletRoutes } from "./routes/wallets";
 
@@ -129,6 +130,7 @@ export function createHttpApp({ runPromise }: { runPromise: RunPromise }) {
   registerRedistributionRoutes(app);
   registerReservationRoutes(app);
   registerSupplierRoutes(app);
+  registerTechnicianTeamRoutes(app);
   registerAuthRoutes(app);
   registerStripeConnectRoutes(app);
   registerStripeWebhookRoutes(app);

--- a/apps/server/src/http/controllers/technician-teams/admin.controller.ts
+++ b/apps/server/src/http/controllers/technician-teams/admin.controller.ts
@@ -1,0 +1,93 @@
+import type { RouteHandler } from "@hono/zod-openapi";
+
+import { Effect, Match } from "effect";
+
+import {
+  TechnicianTeamCommandServiceTag,
+  TechnicianTeamQueryServiceTag,
+} from "@/domain/technician-teams";
+import {
+  toContractAvailableTechnicianTeam,
+  toContractTechnicianTeamSummary,
+} from "@/http/presenters/technician-teams.presenter";
+
+import type {
+  TechnicianTeamAvailableListResponse,
+  TechnicianTeamErrorResponse,
+  TechnicianTeamListResponse,
+  TechnicianTeamsRoutes,
+  TechnicianTeamSummary,
+} from "./shared";
+
+import {
+  TechnicianTeamErrorCodeSchema,
+  technicianTeamErrorMessages,
+} from "./shared";
+
+const listTechnicianTeams: RouteHandler<TechnicianTeamsRoutes["adminList"]> = async (c) => {
+  const query = c.req.valid("query");
+
+  const eff = Effect.flatMap(TechnicianTeamQueryServiceTag, service =>
+    service.listTechnicianTeams({
+      stationId: query.stationId,
+      availabilityStatus: query.availabilityStatus,
+    }));
+
+  const result = await c.var.runPromise(eff);
+
+  return c.json<TechnicianTeamListResponse, 200>({
+    data: result.map(toContractTechnicianTeamSummary),
+  }, 200);
+};
+
+const listAvailableTechnicianTeams: RouteHandler<TechnicianTeamsRoutes["adminAvailable"]> = async (c) => {
+  const query = c.req.valid("query");
+
+  const eff = Effect.flatMap(TechnicianTeamQueryServiceTag, service =>
+    service.listAvailableTechnicianTeams({
+      stationId: query.stationId,
+    }));
+
+  const result = await c.var.runPromise(eff);
+
+  return c.json<TechnicianTeamAvailableListResponse, 200>({
+    data: result.map(toContractAvailableTechnicianTeam),
+  }, 200);
+};
+
+const createTechnicianTeam: RouteHandler<TechnicianTeamsRoutes["adminCreate"]> = async (c) => {
+  const body = c.req.valid("json");
+
+  const eff = Effect.flatMap(TechnicianTeamCommandServiceTag, service =>
+    service.createTechnicianTeam({
+      name: body.name,
+      stationId: body.stationId,
+      availabilityStatus: body.availabilityStatus,
+    }));
+
+  const result = await c.var.runPromise(eff.pipe(Effect.either));
+
+  if (result._tag === "Right") {
+    return c.json<TechnicianTeamSummary, 201>(toContractTechnicianTeamSummary(result.right), 201);
+  }
+
+  return Match.value(result.left).pipe(
+    Match.tag("TechnicianTeamStationNotFound", ({ stationId }) =>
+      c.json<TechnicianTeamErrorResponse, 400>({
+        error: technicianTeamErrorMessages.TECHNICIAN_TEAM_STATION_NOT_FOUND,
+        details: {
+          code: TechnicianTeamErrorCodeSchema.enum.TECHNICIAN_TEAM_STATION_NOT_FOUND,
+          stationId,
+        },
+      }, 400)),
+    Match.orElse((err) => {
+      throw err;
+    }),
+  );
+};
+
+export const TechnicianTeamAdminController = {
+  createTechnicianTeam,
+  listAvailableTechnicianTeams,
+  listTechnicianTeams,
+} as const;

--- a/apps/server/src/http/controllers/technician-teams/admin.controller.ts
+++ b/apps/server/src/http/controllers/technician-teams/admin.controller.ts
@@ -95,8 +95,40 @@ const createTechnicianTeam: RouteHandler<TechnicianTeamsRoutes["adminCreate"]> =
   );
 };
 
+const updateTechnicianTeam: RouteHandler<TechnicianTeamsRoutes["adminUpdate"]> = async (c) => {
+  const { teamId } = c.req.valid("param");
+  const body = c.req.valid("json");
+
+  const eff = Effect.flatMap(TechnicianTeamCommandServiceTag, service =>
+    service.updateTechnicianTeam(teamId, {
+      name: body.name,
+      availabilityStatus: body.availabilityStatus,
+    }));
+
+  const result = await c.var.runPromise(eff.pipe(Effect.either));
+
+  if (result._tag === "Right") {
+    return c.json<TechnicianTeamSummary, 200>(toContractTechnicianTeamSummary(result.right), 200);
+  }
+
+  return Match.value(result.left).pipe(
+    Match.tag("TechnicianTeamNotFound", ({ id }) =>
+      c.json<TechnicianTeamErrorResponse, 404>({
+        error: technicianTeamErrorMessages.TECHNICIAN_TEAM_NOT_FOUND,
+        details: {
+          code: TechnicianTeamErrorCodeSchema.enum.TECHNICIAN_TEAM_NOT_FOUND,
+          teamId: id,
+        },
+      }, 404)),
+    Match.orElse((err) => {
+      throw err;
+    }),
+  );
+};
+
 export const TechnicianTeamAdminController = {
   createTechnicianTeam,
   listAvailableTechnicianTeams,
   listTechnicianTeams,
+  updateTechnicianTeam,
 } as const;

--- a/apps/server/src/http/controllers/technician-teams/admin.controller.ts
+++ b/apps/server/src/http/controllers/technician-teams/admin.controller.ts
@@ -72,6 +72,15 @@ const createTechnicianTeam: RouteHandler<TechnicianTeamsRoutes["adminCreate"]> =
   }
 
   return Match.value(result.left).pipe(
+    Match.tag("TechnicianTeamInternalStationRequired", ({ stationId, stationType }) =>
+      c.json<TechnicianTeamErrorResponse, 400>({
+        error: technicianTeamErrorMessages.TECHNICIAN_TEAM_INTERNAL_STATION_REQUIRED,
+        details: {
+          code: TechnicianTeamErrorCodeSchema.enum.TECHNICIAN_TEAM_INTERNAL_STATION_REQUIRED,
+          stationId,
+          stationType,
+        },
+      }, 400)),
     Match.tag("TechnicianTeamStationNotFound", ({ stationId }) =>
       c.json<TechnicianTeamErrorResponse, 400>({
         error: technicianTeamErrorMessages.TECHNICIAN_TEAM_STATION_NOT_FOUND,

--- a/apps/server/src/http/controllers/technician-teams/index.ts
+++ b/apps/server/src/http/controllers/technician-teams/index.ts
@@ -1,0 +1,2 @@
+export * from "./admin.controller";
+export * from "./shared";

--- a/apps/server/src/http/controllers/technician-teams/shared.ts
+++ b/apps/server/src/http/controllers/technician-teams/shared.ts
@@ -1,0 +1,10 @@
+import { TechnicianTeamsContracts } from "@mebike/shared";
+
+export type TechnicianTeamsRoutes = typeof import("@mebike/shared")["serverRoutes"]["technicianTeams"];
+
+export const { TechnicianTeamErrorCodeSchema, technicianTeamErrorMessages } = TechnicianTeamsContracts;
+
+export type TechnicianTeamSummary = TechnicianTeamsContracts.TechnicianTeamSummary;
+export type TechnicianTeamListResponse = TechnicianTeamsContracts.TechnicianTeamListResponse;
+export type TechnicianTeamAvailableListResponse = TechnicianTeamsContracts.TechnicianTeamAvailableListResponse;
+export type TechnicianTeamErrorResponse = TechnicianTeamsContracts.TechnicianTeamErrorResponse;

--- a/apps/server/src/http/controllers/users/admin/users.controller.ts
+++ b/apps/server/src/http/controllers/users/admin/users.controller.ts
@@ -9,7 +9,6 @@ import { Effect, Match } from "effect";
 import { adminCreateAgencyAccountUseCase } from "@/domain/agency-account-provisioning";
 import { hashPassword } from "@/domain/auth/services/auth.service";
 import { withLoggedCause } from "@/domain/shared";
-import { TechnicianTeamQueryRepository } from "@/domain/technician-teams";
 import {
   adminCreateUserUseCase,
   UserCommandServiceTag,
@@ -18,7 +17,6 @@ import {
 import { routeContext } from "@/http/shared/route-context";
 
 import {
-  mapAvailableTechnicianTeam,
   mapUserDetail,
   mapUserSummary,
   pickDefined,
@@ -91,24 +89,6 @@ const adminTechnicians: RouteHandler<UsersRoutes["adminTechnicians"]> = async (c
 
   const data = await c.var.runPromise(eff);
   return c.json<UsersContracts.AdminTechnicianListResponse, 200>({ data: data.map(mapUserSummary) }, 200);
-};
-
-const adminAvailableTechnicianTeams: RouteHandler<UsersRoutes["adminAvailableTechnicianTeams"]> = async (c) => {
-  const query = c.req.valid("query");
-  const eff = withLoggedCause(
-    Effect.gen(function* () {
-      const repo = yield* TechnicianTeamQueryRepository;
-      return yield* repo.listAvailable({
-        stationId: query.stationId,
-      });
-    }),
-    routeContext(users.adminAvailableTechnicianTeams),
-  );
-
-  const data = await c.var.runPromise(eff);
-  return c.json<UsersContracts.AdminAvailableTechnicianTeamListResponse, 200>({
-    data: data.map(mapAvailableTechnicianTeam),
-  }, 200);
 };
 
 const adminDetail: RouteHandler<UsersRoutes["adminDetail"]> = async (c) => {
@@ -389,7 +369,6 @@ export const AdminUsersController = {
   adminList,
   adminSearch,
   adminTechnicians,
-  adminAvailableTechnicianTeams,
   adminDetail,
   adminUpdate,
   adminCreate,

--- a/apps/server/src/http/controllers/users/shared.ts
+++ b/apps/server/src/http/controllers/users/shared.ts
@@ -55,16 +55,6 @@ export function mapUserSummary(
   };
 }
 
-export function mapAvailableTechnicianTeam(
-  row: import("@/domain/technician-teams").TechnicianTeamAvailableOption,
-) {
-  return {
-    id: row.id,
-    name: row.name,
-    stationId: row.stationId,
-  };
-}
-
 function maskPushToken(token: string): string {
   if (token.length <= 10) {
     return "**********";

--- a/apps/server/src/http/presenters/technician-teams.presenter.ts
+++ b/apps/server/src/http/presenters/technician-teams.presenter.ts
@@ -1,0 +1,33 @@
+import type { TechnicianTeamsContracts } from "@mebike/shared";
+
+import type {
+  TechnicianTeamAvailableOption,
+  TechnicianTeamRow,
+} from "@/domain/technician-teams";
+
+export function toContractTechnicianTeamSummary(
+  team: TechnicianTeamRow,
+): TechnicianTeamsContracts.TechnicianTeamSummary {
+  return {
+    id: team.id,
+    name: team.name,
+    station: {
+      id: team.stationId,
+      name: team.stationName,
+    },
+    availabilityStatus: team.availabilityStatus,
+    memberCount: team.memberCount,
+    createdAt: team.createdAt.toISOString(),
+    updatedAt: team.updatedAt.toISOString(),
+  };
+}
+
+export function toContractAvailableTechnicianTeam(
+  team: TechnicianTeamAvailableOption,
+): TechnicianTeamsContracts.TechnicianTeamAvailableOption {
+  return {
+    id: team.id,
+    name: team.name,
+    stationId: team.stationId,
+  };
+}

--- a/apps/server/src/http/routes/technician-teams.ts
+++ b/apps/server/src/http/routes/technician-teams.ts
@@ -21,8 +21,13 @@ export function registerTechnicianTeamRoutes(
     ...technicianTeams.adminCreate,
     middleware: [requireAdminMiddleware] as const,
   } satisfies RouteConfig;
+  const adminUpdateRoute = {
+    ...technicianTeams.adminUpdate,
+    middleware: [requireAdminMiddleware] as const,
+  } satisfies RouteConfig;
 
   app.openapi(adminAvailableRoute, TechnicianTeamAdminController.listAvailableTechnicianTeams);
   app.openapi(adminListRoute, TechnicianTeamAdminController.listTechnicianTeams);
   app.openapi(adminCreateRoute, TechnicianTeamAdminController.createTechnicianTeam);
+  app.openapi(adminUpdateRoute, TechnicianTeamAdminController.updateTechnicianTeam);
 }

--- a/apps/server/src/http/routes/technician-teams.ts
+++ b/apps/server/src/http/routes/technician-teams.ts
@@ -1,0 +1,28 @@
+import type { RouteConfig } from "@hono/zod-openapi";
+
+import { serverRoutes } from "@mebike/shared";
+
+import { TechnicianTeamAdminController } from "@/http/controllers/technician-teams";
+import { requireAdminMiddleware } from "@/http/middlewares/auth";
+
+export function registerTechnicianTeamRoutes(
+  app: import("@hono/zod-openapi").OpenAPIHono,
+) {
+  const technicianTeams = serverRoutes.technicianTeams;
+  const adminListRoute = {
+    ...technicianTeams.adminList,
+    middleware: [requireAdminMiddleware] as const,
+  } satisfies RouteConfig;
+  const adminAvailableRoute = {
+    ...technicianTeams.adminAvailable,
+    middleware: [requireAdminMiddleware] as const,
+  } satisfies RouteConfig;
+  const adminCreateRoute = {
+    ...technicianTeams.adminCreate,
+    middleware: [requireAdminMiddleware] as const,
+  } satisfies RouteConfig;
+
+  app.openapi(adminAvailableRoute, TechnicianTeamAdminController.listAvailableTechnicianTeams);
+  app.openapi(adminListRoute, TechnicianTeamAdminController.listTechnicianTeams);
+  app.openapi(adminCreateRoute, TechnicianTeamAdminController.createTechnicianTeam);
+}

--- a/apps/server/src/http/routes/users/admin.ts
+++ b/apps/server/src/http/routes/users/admin.ts
@@ -7,7 +7,6 @@ export function registerAdminUserRoutes(app: import("@hono/zod-openapi").OpenAPI
   app.openapi(users.adminList, AdminUsersController.adminList);
   app.openapi(users.adminSearch, AdminUsersController.adminSearch);
   app.openapi(users.adminTechnicians, AdminUsersController.adminTechnicians);
-  app.openapi(users.adminAvailableTechnicianTeams, AdminUsersController.adminAvailableTechnicianTeams);
   app.openapi(users.adminDetail, AdminUsersController.adminDetail);
   app.openapi(users.adminUpdate, AdminUsersController.adminUpdate);
   app.openapi(users.adminCreate, AdminUsersController.adminCreate);

--- a/apps/server/src/http/shared/app.layers.ts
+++ b/apps/server/src/http/shared/app.layers.ts
@@ -15,6 +15,7 @@ import { StationDepsLive } from "./features/station.layers";
 import { StripeTopupDepsLive } from "./features/stripe-topup.layers";
 import { SubscriptionDepsLive } from "./features/subscription.layers";
 import { SupplierDepsLive } from "./features/supplier.layers";
+import { TechnicianTeamDepsLive } from "./features/technician-team.layers";
 import { UserDepsLive, UserStatsDepsLive } from "./features/user.layers";
 import { WalletDepsLive } from "./features/wallet.layers";
 import {
@@ -36,6 +37,7 @@ export const HttpDepsLive = Layer.mergeAll(
   SubscriptionDepsLive,
   StationDepsLive,
   SupplierDepsLive,
+  TechnicianTeamDepsLive,
   AgencyRequestDepsLive,
   NotificationDepsLive,
   UserDepsLive,

--- a/apps/server/src/http/shared/features/technician-team.layers.ts
+++ b/apps/server/src/http/shared/features/technician-team.layers.ts
@@ -23,7 +23,7 @@ export const TechnicianTeamQueryServiceLayer = TechnicianTeamQueryServiceLive.pi
 );
 
 export const TechnicianTeamCommandServiceLayer = TechnicianTeamCommandServiceLive.pipe(
-  Layer.provide(Layer.mergeAll(TechnicianTeamCommandReposLive, StationQueryReposLive)),
+  Layer.provide(Layer.mergeAll(TechnicianTeamCommandReposLive, TechnicianTeamQueryReposLive, StationQueryReposLive)),
 );
 
 export const TechnicianTeamDepsLive = Layer.mergeAll(

--- a/apps/server/src/http/shared/features/technician-team.layers.ts
+++ b/apps/server/src/http/shared/features/technician-team.layers.ts
@@ -1,14 +1,35 @@
 import { Layer } from "effect";
 
-import { TechnicianTeamQueryRepositoryLive } from "@/domain/technician-teams";
+import {
+  TechnicianTeamCommandRepositoryLive,
+  TechnicianTeamCommandServiceLive,
+  TechnicianTeamQueryRepositoryLive,
+  TechnicianTeamQueryServiceLive,
+} from "@/domain/technician-teams";
 
 import { PrismaLive } from "../infra.layers";
+import { StationQueryReposLive } from "./station.layers";
 
 export const TechnicianTeamQueryReposLive = TechnicianTeamQueryRepositoryLive.pipe(
   Layer.provide(PrismaLive),
 );
 
+export const TechnicianTeamCommandReposLive = TechnicianTeamCommandRepositoryLive.pipe(
+  Layer.provide(PrismaLive),
+);
+
+export const TechnicianTeamQueryServiceLayer = TechnicianTeamQueryServiceLive.pipe(
+  Layer.provide(TechnicianTeamQueryReposLive),
+);
+
+export const TechnicianTeamCommandServiceLayer = TechnicianTeamCommandServiceLive.pipe(
+  Layer.provide(Layer.mergeAll(TechnicianTeamCommandReposLive, StationQueryReposLive)),
+);
+
 export const TechnicianTeamDepsLive = Layer.mergeAll(
   TechnicianTeamQueryReposLive,
+  TechnicianTeamCommandReposLive,
+  TechnicianTeamQueryServiceLayer,
+  TechnicianTeamCommandServiceLayer,
   PrismaLive,
 );

--- a/apps/server/src/http/shared/providers.ts
+++ b/apps/server/src/http/shared/providers.ts
@@ -90,8 +90,11 @@ export {
   SupplierServiceLayer,
 } from "./features/supplier.layers";
 export {
+  TechnicianTeamCommandReposLive,
+  TechnicianTeamCommandServiceLayer,
   TechnicianTeamDepsLive,
   TechnicianTeamQueryReposLive,
+  TechnicianTeamQueryServiceLayer,
 } from "./features/technician-team.layers";
 export {
   AvatarUploadServiceLayer,

--- a/apps/server/src/http/test/e2e/admin-technician-teams-routing.e2e.int.test.ts
+++ b/apps/server/src/http/test/e2e/admin-technician-teams-routing.e2e.int.test.ts
@@ -143,6 +143,67 @@ describe("admin technician teams routing e2e", () => {
     expect(body.details.stationType).toBe("AGENCY");
   });
 
+  it("updates technician team name and availability", async () => {
+    const station = await fixture.factories.station({ name: "Patch Team Station" });
+    const team = await fixture.factories.technicianTeam({
+      name: "Patch Team Alpha",
+      stationId: station.id,
+      availabilityStatus: "AVAILABLE",
+    });
+
+    const response = await fixture.app.request(`http://test/v1/admin/technician-teams/${team.id}`, {
+      method: "PATCH",
+      headers: authHeader(),
+      body: JSON.stringify({
+        name: "Patch Team Beta",
+        availabilityStatus: "UNAVAILABLE",
+      }),
+    });
+    const body = await response.json() as TechnicianTeamsContracts.TechnicianTeamSummary;
+
+    expect(response.status).toBe(200);
+    expect(body.id).toBe(team.id);
+    expect(body.name).toBe("Patch Team Beta");
+    expect(body.availabilityStatus).toBe("UNAVAILABLE");
+    expect(body.station.id).toBe(station.id);
+  });
+
+  it("returns 404 when updating missing technician team", async () => {
+    const response = await fixture.app.request(`http://test/v1/admin/technician-teams/${uuidv7()}`, {
+      method: "PATCH",
+      headers: authHeader(),
+      body: JSON.stringify({
+        availabilityStatus: "UNAVAILABLE",
+      }),
+    });
+    const body = await response.json() as TechnicianTeamsContracts.TechnicianTeamErrorResponse;
+
+    expect(response.status).toBe(404);
+    expect(body.details.code).toBe("TECHNICIAN_TEAM_NOT_FOUND");
+  });
+
+  it("returns 400 when update payload is empty", async () => {
+    const station = await fixture.factories.station({ name: "Patch Empty Station" });
+    const team = await fixture.factories.technicianTeam({
+      name: "Patch Empty Team",
+      stationId: station.id,
+    });
+
+    const response = await fixture.app.request(`http://test/v1/admin/technician-teams/${team.id}`, {
+      method: "PATCH",
+      headers: authHeader(),
+      body: JSON.stringify({}),
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      error: "Invalid request payload",
+      details: {
+        code: "VALIDATION_ERROR",
+      },
+    });
+  });
+
   it("rejects non-admin access", async () => {
     const staff = await fixture.factories.user({
       fullname: "Staff Route",
@@ -153,6 +214,29 @@ describe("admin technician teams routing e2e", () => {
     const response = await fixture.app.request("http://test/v1/admin/technician-teams", {
       method: "GET",
       headers: authHeader("STAFF", staff.id),
+    });
+
+    expect(response.status).toBe(403);
+  });
+
+  it("rejects non-admin update access", async () => {
+    const station = await fixture.factories.station({ name: "Patch Forbidden Station" });
+    const team = await fixture.factories.technicianTeam({
+      name: "Patch Forbidden Team",
+      stationId: station.id,
+    });
+    const staff = await fixture.factories.user({
+      fullname: "Patch Staff Route",
+      email: "patch-staff-route-technician-teams@example.com",
+      role: "STAFF",
+    });
+
+    const response = await fixture.app.request(`http://test/v1/admin/technician-teams/${team.id}`, {
+      method: "PATCH",
+      headers: authHeader("STAFF", staff.id),
+      body: JSON.stringify({
+        availabilityStatus: "UNAVAILABLE",
+      }),
     });
 
     expect(response.status).toBe(403);

--- a/apps/server/src/http/test/e2e/admin-technician-teams-routing.e2e.int.test.ts
+++ b/apps/server/src/http/test/e2e/admin-technician-teams-routing.e2e.int.test.ts
@@ -122,6 +122,27 @@ describe("admin technician teams routing e2e", () => {
     expect(body.details.code).toBe("TECHNICIAN_TEAM_STATION_NOT_FOUND");
   });
 
+  it("rejects create for agency station", async () => {
+    const station = await fixture.factories.station({
+      name: "Agency Team Station",
+      stationType: "AGENCY",
+    });
+
+    const response = await fixture.app.request("http://test/v1/admin/technician-teams", {
+      method: "POST",
+      headers: authHeader(),
+      body: JSON.stringify({
+        name: "Agency Team",
+        stationId: station.id,
+      }),
+    });
+    const body = await response.json() as TechnicianTeamsContracts.TechnicianTeamErrorResponse;
+
+    expect(response.status).toBe(400);
+    expect(body.details.code).toBe("TECHNICIAN_TEAM_INTERNAL_STATION_REQUIRED");
+    expect(body.details.stationType).toBe("AGENCY");
+  });
+
   it("rejects non-admin access", async () => {
     const staff = await fixture.factories.user({
       fullname: "Staff Route",

--- a/apps/server/src/http/test/e2e/admin-technician-teams-routing.e2e.int.test.ts
+++ b/apps/server/src/http/test/e2e/admin-technician-teams-routing.e2e.int.test.ts
@@ -1,0 +1,139 @@
+import type { TechnicianTeamsContracts } from "@mebike/shared";
+
+import { uuidv7 } from "uuidv7";
+import { describe, expect, it } from "vitest";
+
+import { setupHttpE2eFixture } from "@/test/http/e2e-fixture";
+
+const ADMIN_USER_ID = "018d4529-6880-77a8-8e6f-4d2c88d22311";
+
+describe("admin technician teams routing e2e", () => {
+  const fixture = setupHttpE2eFixture({
+    buildLayer: async () => {
+      const { Layer } = await import("effect");
+      const { TechnicianTeamDepsLive } = await import("@/http/shared/features/technician-team.layers");
+      const { UserDepsLive } = await import("@/http/shared/features/user.layers");
+
+      return Layer.mergeAll(
+        TechnicianTeamDepsLive,
+        UserDepsLive,
+      );
+    },
+    seedData: async (_db, prisma) => {
+      await prisma.user.create({
+        data: {
+          id: ADMIN_USER_ID,
+          fullName: "Route Admin",
+          email: "route-admin-technician-teams@example.com",
+          passwordHash: "hash123",
+          phoneNumber: null,
+          username: null,
+          avatarUrl: null,
+          locationText: null,
+          nfcCardUid: null,
+          role: "ADMIN",
+          accountStatus: "ACTIVE",
+          verifyStatus: "VERIFIED",
+        },
+      });
+    },
+  });
+
+  function authHeader(role: "ADMIN" | "STAFF" = "ADMIN", userId = ADMIN_USER_ID) {
+    const token = fixture.auth.makeAccessToken({ userId, role });
+    return {
+      "Authorization": `Bearer ${token}`,
+      "Content-Type": "application/json",
+    };
+  }
+
+  it("lists technician teams with filters and member counts", async () => {
+    const stationA = await fixture.factories.station({ name: "Admin Team Station A" });
+    const stationB = await fixture.factories.station({ name: "Admin Team Station B" });
+    const matchingTeam = await fixture.factories.technicianTeam({
+      name: "Admin Team Available",
+      stationId: stationA.id,
+    });
+    await fixture.factories.technicianTeam({
+      name: "Admin Team Unavailable",
+      stationId: stationB.id,
+      availabilityStatus: "UNAVAILABLE",
+    });
+    const technician = await fixture.factories.user({
+      fullname: "Assigned Tech",
+      email: "assigned-tech@example.com",
+      role: "TECHNICIAN",
+    });
+
+    await fixture.factories.userOrgAssignment({
+      userId: technician.id,
+      technicianTeamId: matchingTeam.id,
+    });
+
+    const response = await fixture.app.request(
+      `http://test/v1/admin/technician-teams?stationId=${stationA.id}&availabilityStatus=AVAILABLE`,
+      {
+        method: "GET",
+        headers: authHeader(),
+      },
+    );
+    const body = await response.json() as TechnicianTeamsContracts.TechnicianTeamListResponse;
+
+    expect(response.status).toBe(200);
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0]?.id).toBe(matchingTeam.id);
+    expect(body.data[0]?.station.id).toBe(stationA.id);
+    expect(body.data[0]?.memberCount).toBe(1);
+  });
+
+  it("creates technician team for an existing station", async () => {
+    const station = await fixture.factories.station({ name: "Create Team Station" });
+
+    const response = await fixture.app.request("http://test/v1/admin/technician-teams", {
+      method: "POST",
+      headers: authHeader(),
+      body: JSON.stringify({
+        name: "Team Create Route",
+        stationId: station.id,
+      }),
+    });
+    const body = await response.json() as TechnicianTeamsContracts.TechnicianTeamSummary;
+
+    expect(response.status).toBe(201);
+    expect(body.name).toBe("Team Create Route");
+    expect(body.station.id).toBe(station.id);
+    expect(body.station.name).toBe("Create Team Station");
+    expect(body.availabilityStatus).toBe("AVAILABLE");
+    expect(body.memberCount).toBe(0);
+  });
+
+  it("rejects create when station does not exist", async () => {
+    const response = await fixture.app.request("http://test/v1/admin/technician-teams", {
+      method: "POST",
+      headers: authHeader(),
+      body: JSON.stringify({
+        name: "Broken Team",
+        stationId: uuidv7(),
+      }),
+    });
+    const body = await response.json() as TechnicianTeamsContracts.TechnicianTeamErrorResponse;
+
+    expect(response.status).toBe(400);
+    expect(body.details.code).toBe("TECHNICIAN_TEAM_STATION_NOT_FOUND");
+  });
+
+  it("rejects non-admin access", async () => {
+    const staff = await fixture.factories.user({
+      fullname: "Staff Route",
+      email: "staff-route-technician-teams@example.com",
+      role: "STAFF",
+    });
+
+    const response = await fixture.app.request("http://test/v1/admin/technician-teams", {
+      method: "GET",
+      headers: authHeader("STAFF", staff.id),
+    });
+
+    expect(response.status).toBe(403);
+  });
+});

--- a/apps/server/src/http/test/e2e/manage-users-org-assignment.e2e.int.test.ts
+++ b/apps/server/src/http/test/e2e/manage-users-org-assignment.e2e.int.test.ts
@@ -11,6 +11,7 @@ describe("manage-users org assignment e2e", () => {
   const fixture = setupHttpE2eFixture({
     buildLayer: async () => {
       const { Layer } = await import("effect");
+      const { TechnicianTeamDepsLive } = await import("@/http/shared/features/technician-team.layers");
       const { UserDepsLive } = await import("@/http/shared/features/user.layers");
       const { UserStatsRepositoryLive } = await import("@/domain/users/repository/user-stats.repository");
       const { UserStatsServiceLive } = await import("@/domain/users/services/user-stats.service");
@@ -18,6 +19,7 @@ describe("manage-users org assignment e2e", () => {
       const userStatsServiceLayer = UserStatsServiceLive.pipe(Layer.provide(UserStatsRepositoryLive));
 
       return Layer.mergeAll(
+        TechnicianTeamDepsLive,
         UserDepsLive,
         UserStatsRepositoryLive,
         userStatsServiceLayer,

--- a/packages/shared/src/contracts/server/index.ts
+++ b/packages/shared/src/contracts/server/index.ts
@@ -24,6 +24,7 @@ export * as StatsContracts from "./stats";
 export * as StripeContracts from "./stripe";
 export * as SubscriptionsContracts from "./subscriptions";
 export * as SuppliersContracts from "./suppliers";
+export * as TechnicianTeamsContracts from "./technician-teams";
 export * as UsersContracts from "./users";
 export * as WalletsContracts from "./wallets";
 

--- a/packages/shared/src/contracts/server/routes/index.ts
+++ b/packages/shared/src/contracts/server/routes/index.ts
@@ -15,6 +15,7 @@ import { statsRoutes } from "./stats";
 import { stripeRoutes } from "./stripe";
 import { subscriptionsRoutes } from "./subscriptions";
 import { suppliersRoutes } from "./suppliers";
+import { technicianTeamsRoutes } from "./technician-teams";
 import { usersRoutes } from "./users";
 import { walletsRoutes } from "./wallets";
 
@@ -35,6 +36,7 @@ export * from "./stats";
 export * from "./stripe";
 export * from "./subscriptions";
 export * from "./suppliers";
+export * from "./technician-teams";
 export * from "./users";
 export * from "./wallets";
 
@@ -58,6 +60,7 @@ export const serverRoutes = {
   stripe: stripeRoutes,
   incidents: incidentsRoutes,
   redistribution: redistributionRoutes,
+  technicianTeams: technicianTeamsRoutes,
 } as const;
 
 export type ServerRouteKey = keyof typeof serverRoutes;

--- a/packages/shared/src/contracts/server/routes/technician-teams/index.ts
+++ b/packages/shared/src/contracts/server/routes/technician-teams/index.ts
@@ -1,0 +1,11 @@
+import { technicianTeamMutations } from "./mutations";
+import { technicianTeamQueries } from "./queries";
+
+export * from "./mutations";
+export * from "./queries";
+export * from "./shared";
+
+export const technicianTeamsRoutes = {
+  ...technicianTeamQueries,
+  ...technicianTeamMutations,
+} as const;

--- a/packages/shared/src/contracts/server/routes/technician-teams/mutations.ts
+++ b/packages/shared/src/contracts/server/routes/technician-teams/mutations.ts
@@ -1,0 +1,60 @@
+import { createRoute } from "@hono/zod-openapi";
+
+import { forbiddenResponse, unauthorizedResponse } from "../helpers";
+import {
+  TechnicianTeamCreateBodySchema,
+  TechnicianTeamErrorCodeSchema,
+  TechnicianTeamErrorResponseSchema,
+  TechnicianTeamSummarySchema,
+} from "./shared";
+
+export const adminCreateTechnicianTeamRoute = createRoute({
+  method: "post",
+  path: "/v1/admin/technician-teams",
+  tags: ["Technician Teams"],
+  security: [{ bearerAuth: [] }],
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: TechnicianTeamCreateBodySchema,
+        },
+      },
+    },
+  },
+  responses: {
+    201: {
+      description: "Technician team created",
+      content: {
+        "application/json": {
+          schema: TechnicianTeamSummarySchema,
+        },
+      },
+    },
+    400: {
+      description: "Invalid payload or station not found",
+      content: {
+        "application/json": {
+          schema: TechnicianTeamErrorResponseSchema,
+          examples: {
+            StationNotFound: {
+              value: {
+                error: "Station not found for technician team",
+                details: {
+                  code: TechnicianTeamErrorCodeSchema.enum.TECHNICIAN_TEAM_STATION_NOT_FOUND,
+                  stationId: "019d1c26-9d34-7f97-ae3c-4c3f0c2d2210",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    401: unauthorizedResponse(),
+    403: forbiddenResponse("Admin"),
+  },
+});
+
+export const technicianTeamMutations = {
+  adminCreate: adminCreateTechnicianTeamRoute,
+} as const;

--- a/packages/shared/src/contracts/server/routes/technician-teams/mutations.ts
+++ b/packages/shared/src/contracts/server/routes/technician-teams/mutations.ts
@@ -5,7 +5,9 @@ import {
   TechnicianTeamCreateBodySchema,
   TechnicianTeamErrorCodeSchema,
   TechnicianTeamErrorResponseSchema,
+  TechnicianTeamIdParamSchema,
   TechnicianTeamSummarySchema,
+  TechnicianTeamUpdateBodySchema,
 } from "./shared";
 
 export const adminCreateTechnicianTeamRoute = createRoute({
@@ -65,6 +67,55 @@ export const adminCreateTechnicianTeamRoute = createRoute({
   },
 });
 
+export const adminUpdateTechnicianTeamRoute = createRoute({
+  method: "patch",
+  path: "/v1/admin/technician-teams/{teamId}",
+  tags: ["Technician Teams"],
+  security: [{ bearerAuth: [] }],
+  request: {
+    params: TechnicianTeamIdParamSchema,
+    body: {
+      content: {
+        "application/json": {
+          schema: TechnicianTeamUpdateBodySchema,
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "Technician team updated",
+      content: {
+        "application/json": {
+          schema: TechnicianTeamSummarySchema,
+        },
+      },
+    },
+    404: {
+      description: "Technician team not found",
+      content: {
+        "application/json": {
+          schema: TechnicianTeamErrorResponseSchema,
+          examples: {
+            TeamNotFound: {
+              value: {
+                error: "Technician team not found",
+                details: {
+                  code: TechnicianTeamErrorCodeSchema.enum.TECHNICIAN_TEAM_NOT_FOUND,
+                  teamId: "019d1c26-9d34-7f97-ae3c-4c3f0c2d2210",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    401: unauthorizedResponse(),
+    403: forbiddenResponse("Admin"),
+  },
+});
+
 export const technicianTeamMutations = {
   adminCreate: adminCreateTechnicianTeamRoute,
+  adminUpdate: adminUpdateTechnicianTeamRoute,
 } as const;

--- a/packages/shared/src/contracts/server/routes/technician-teams/mutations.ts
+++ b/packages/shared/src/contracts/server/routes/technician-teams/mutations.ts
@@ -37,6 +37,16 @@ export const adminCreateTechnicianTeamRoute = createRoute({
         "application/json": {
           schema: TechnicianTeamErrorResponseSchema,
           examples: {
+            InternalStationRequired: {
+              value: {
+                error: "Technician teams require an internal station",
+                details: {
+                  code: TechnicianTeamErrorCodeSchema.enum.TECHNICIAN_TEAM_INTERNAL_STATION_REQUIRED,
+                  stationId: "019d1c26-9d34-7f97-ae3c-4c3f0c2d2210",
+                  stationType: "AGENCY",
+                },
+              },
+            },
             StationNotFound: {
               value: {
                 error: "Station not found for technician team",

--- a/packages/shared/src/contracts/server/routes/technician-teams/queries.ts
+++ b/packages/shared/src/contracts/server/routes/technician-teams/queries.ts
@@ -1,0 +1,59 @@
+import { createRoute, z } from "@hono/zod-openapi";
+
+import { forbiddenResponse, unauthorizedResponse } from "../helpers";
+import {
+  TechnicianTeamAvailableListResponseSchema,
+  TechnicianTeamListQuerySchema,
+  TechnicianTeamListResponseSchema,
+} from "./shared";
+
+export const adminListTechnicianTeamsRoute = createRoute({
+  method: "get",
+  path: "/v1/admin/technician-teams",
+  tags: ["Technician Teams"],
+  security: [{ bearerAuth: [] }],
+  request: {
+    query: TechnicianTeamListQuerySchema,
+  },
+  responses: {
+    200: {
+      description: "Admin list of technician teams",
+      content: {
+        "application/json": {
+          schema: TechnicianTeamListResponseSchema,
+        },
+      },
+    },
+    401: unauthorizedResponse(),
+    403: forbiddenResponse("Admin"),
+  },
+});
+
+export const adminAvailableTechnicianTeamsRoute = createRoute({
+  method: "get",
+  path: "/v1/admin/technician-teams/available",
+  tags: ["Technician Teams"],
+  security: [{ bearerAuth: [] }],
+  request: {
+    query: z.object({
+      stationId: z.uuidv7().optional(),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Admin list of available technician teams for assignment",
+      content: {
+        "application/json": {
+          schema: TechnicianTeamAvailableListResponseSchema,
+        },
+      },
+    },
+    401: unauthorizedResponse(),
+    403: forbiddenResponse("Admin"),
+  },
+});
+
+export const technicianTeamQueries = {
+  adminAvailable: adminAvailableTechnicianTeamsRoute,
+  adminList: adminListTechnicianTeamsRoute,
+} as const;

--- a/packages/shared/src/contracts/server/routes/technician-teams/shared.ts
+++ b/packages/shared/src/contracts/server/routes/technician-teams/shared.ts
@@ -11,6 +11,10 @@ import {
   TechnicianTeamSummarySchema,
 } from "../../technician-teams";
 
+export const TechnicianTeamIdParamSchema = z.object({
+  teamId: z.uuidv7(),
+}).openapi("TechnicianTeamIdParam");
+
 export const TechnicianTeamListQuerySchema = z.object({
   stationId: z.uuidv7().optional(),
   availabilityStatus: TechnicianTeamAvailabilitySchema.optional(),
@@ -27,6 +31,24 @@ export const TechnicianTeamCreateBodySchema = z.object({
     availabilityStatus: "AVAILABLE",
   },
 });
+
+export const TechnicianTeamUpdateBodySchema = z
+  .object({
+    name: z.string().trim().min(1).optional(),
+    availabilityStatus: TechnicianTeamAvailabilitySchema.optional(),
+  })
+  .refine(
+    value => value.name !== undefined || value.availabilityStatus !== undefined,
+    {
+      message: "At least one field must be provided",
+    },
+  )
+  .openapi("TechnicianTeamUpdateBody", {
+    example: {
+      name: "Team Alpha Night Shift",
+      availabilityStatus: "UNAVAILABLE",
+    },
+  });
 
 export const TechnicianTeamListResponseSchema = z.object({
   data: z.array(TechnicianTeamSummarySchema),

--- a/packages/shared/src/contracts/server/routes/technician-teams/shared.ts
+++ b/packages/shared/src/contracts/server/routes/technician-teams/shared.ts
@@ -1,0 +1,49 @@
+import { z } from "../../../../zod";
+
+import {
+  ServerErrorResponseSchema,
+} from "../../schemas";
+import {
+  TechnicianTeamAvailabilitySchema,
+  TechnicianTeamAvailableOptionSchema,
+  TechnicianTeamErrorCodeSchema,
+  TechnicianTeamErrorResponseSchema,
+  TechnicianTeamSummarySchema,
+} from "../../technician-teams";
+
+export const TechnicianTeamListQuerySchema = z.object({
+  stationId: z.uuidv7().optional(),
+  availabilityStatus: TechnicianTeamAvailabilitySchema.optional(),
+}).openapi("TechnicianTeamListQuery");
+
+export const TechnicianTeamCreateBodySchema = z.object({
+  name: z.string().trim().min(1),
+  stationId: z.uuidv7(),
+  availabilityStatus: TechnicianTeamAvailabilitySchema.optional(),
+}).openapi("TechnicianTeamCreateBody", {
+  example: {
+    name: "Team Alpha",
+    stationId: "019d1c26-9d34-7f97-ae3c-4c3f0c2d2210",
+    availabilityStatus: "AVAILABLE",
+  },
+});
+
+export const TechnicianTeamListResponseSchema = z.object({
+  data: z.array(TechnicianTeamSummarySchema),
+}).openapi("TechnicianTeamListResponse");
+
+export const TechnicianTeamAvailableListResponseSchema = z.object({
+  data: z.array(TechnicianTeamAvailableOptionSchema),
+}).openapi("TechnicianTeamAvailableListResponse");
+
+export {
+  ServerErrorResponseSchema,
+  TechnicianTeamAvailabilitySchema,
+  TechnicianTeamAvailableOptionSchema,
+  TechnicianTeamErrorCodeSchema,
+  TechnicianTeamErrorResponseSchema,
+  TechnicianTeamSummarySchema,
+};
+
+export type TechnicianTeamListResponse = z.infer<typeof TechnicianTeamListResponseSchema>;
+export type TechnicianTeamAvailableListResponse = z.infer<typeof TechnicianTeamAvailableListResponseSchema>;

--- a/packages/shared/src/contracts/server/routes/technician-teams/shared.ts
+++ b/packages/shared/src/contracts/server/routes/technician-teams/shared.ts
@@ -1,5 +1,4 @@
 import { z } from "../../../../zod";
-
 import {
   ServerErrorResponseSchema,
 } from "../../schemas";

--- a/packages/shared/src/contracts/server/routes/users/index.ts
+++ b/packages/shared/src/contracts/server/routes/users/index.ts
@@ -11,7 +11,6 @@ import {
 } from "./mutations";
 import {
   adminActiveUsersRoute,
-  adminAvailableTechnicianTeamsRoute,
   adminDashboardStatsRoute,
   adminListUsersRoute,
   adminNewUsersRoute,
@@ -39,7 +38,6 @@ export const usersRoutes = {
   adminList: adminListUsersRoute,
   adminSearch: adminSearchUsersRoute,
   adminTechnicians: adminTechnicianListRoute,
-  adminAvailableTechnicianTeams: adminAvailableTechnicianTeamsRoute,
   adminDetail: adminUserDetailRoute,
   adminUpdate: adminUpdateUserRoute,
   adminCreate: adminCreateUserRoute,

--- a/packages/shared/src/contracts/server/routes/users/index.ts
+++ b/packages/shared/src/contracts/server/routes/users/index.ts
@@ -4,10 +4,10 @@ import {
   adminUpdateUserRoute,
   changePasswordRoute,
   registerPushTokenRoute,
-  uploadMyAvatarRoute,
   unregisterAllPushTokensRoute,
   unregisterPushTokenRoute,
   updateMeRoute,
+  uploadMyAvatarRoute,
 } from "./mutations";
 import {
   adminActiveUsersRoute,

--- a/packages/shared/src/contracts/server/routes/users/queries.ts
+++ b/packages/shared/src/contracts/server/routes/users/queries.ts
@@ -17,7 +17,6 @@ import { forbiddenResponse, unauthorizedResponse } from "../helpers";
 import {
   ActiveUsersQuerySchema,
   ActiveUsersSeriesResponseSchema,
-  AdminAvailableTechnicianTeamListResponseSchema,
   AdminTechnicianListResponseSchema,
   AdminUserDetailResponseSchema,
   AdminUserListResponseSchema,
@@ -170,43 +169,6 @@ export const adminTechnicianListRoute = createRoute({
                   {
                     id: "019d1b15-0f9a-73e7-9800-4af1e9887d72",
                     fullName: "Le Field Technician",
-                  },
-                ],
-              },
-            },
-          },
-        },
-      },
-    },
-    401: unauthorizedResponse(),
-    403: forbiddenResponse("Admin"),
-  },
-});
-
-export const adminAvailableTechnicianTeamsRoute = createRoute({
-  method: "get",
-  path: "/v1/admin/technician-teams/available",
-  tags: ["Users"],
-  security: [{ bearerAuth: [] }],
-  request: {
-    query: z.object({
-      stationId: z.uuidv7().optional(),
-    }),
-  },
-  responses: {
-    200: {
-      description: "Admin list of available technician teams for assignment",
-      content: {
-        "application/json": {
-          schema: AdminAvailableTechnicianTeamListResponseSchema,
-          examples: {
-            AvailableTeams: {
-              value: {
-                data: [
-                  {
-                    id: "019d1b15-0f9a-73e7-9800-4af1e9887d72",
-                    name: "Team A",
-                    stationId: "019d1c26-9d34-7f97-ae3c-4c3f0c2d2210",
                   },
                 ],
               },

--- a/packages/shared/src/contracts/server/routes/users/shared.ts
+++ b/packages/shared/src/contracts/server/routes/users/shared.ts
@@ -7,7 +7,6 @@ import {
   PaginationSchema,
 } from "../../schemas";
 import {
-  TechnicianTeamAvailableOptionSchema,
   UserSummarySchema,
 } from "../../users/models";
 import {
@@ -92,10 +91,6 @@ export const AdminUserSearchResponseSchema = z.object({
 export const AdminTechnicianListResponseSchema = z.object({
   data: z.array(UserSummarySchema),
 }).openapi("AdminTechnicianListResponse");
-
-export const AdminAvailableTechnicianTeamListResponseSchema = z.object({
-  data: z.array(TechnicianTeamAvailableOptionSchema),
-}).openapi("AdminAvailableTechnicianTeamListResponse");
 
 export const AdminUserDetailResponseSchema = UserDetailSchema.openapi("AdminUserDetailResponse");
 
@@ -304,7 +299,6 @@ export type PushTokenSummary = z.infer<typeof PushTokenSummarySchema>;
 export type AdminUserListResponse = z.infer<typeof AdminUserListResponseSchema>;
 export type AdminUserSearchResponse = z.infer<typeof AdminUserSearchResponseSchema>;
 export type AdminTechnicianListResponse = z.infer<typeof AdminTechnicianListResponseSchema>;
-export type AdminAvailableTechnicianTeamListResponse = z.infer<typeof AdminAvailableTechnicianTeamListResponseSchema>;
 export type AdminUserDetailResponse = z.infer<typeof AdminUserDetailResponseSchema>;
 export type AdminCreateUserRequest = z.infer<typeof AdminCreateUserRequestSchema>;
 export type AdminUpdateUserRequest = z.infer<typeof AdminUpdateUserRequestSchema>;

--- a/packages/shared/src/contracts/server/technician-teams/errors.ts
+++ b/packages/shared/src/contracts/server/technician-teams/errors.ts
@@ -1,0 +1,21 @@
+import { z } from "../../../zod";
+
+export const TechnicianTeamErrorCodeSchema = z.enum([
+  "TECHNICIAN_TEAM_STATION_NOT_FOUND",
+]);
+
+export const technicianTeamErrorMessages = {
+  TECHNICIAN_TEAM_STATION_NOT_FOUND: "Station not found for technician team",
+} as const satisfies Record<z.infer<typeof TechnicianTeamErrorCodeSchema>, string>;
+
+export const TechnicianTeamErrorDetailSchema = z.object({
+  code: TechnicianTeamErrorCodeSchema,
+  stationId: z.uuidv7().optional(),
+});
+
+export const TechnicianTeamErrorResponseSchema = z.object({
+  error: z.string(),
+  details: TechnicianTeamErrorDetailSchema,
+});
+
+export type TechnicianTeamErrorResponse = z.infer<typeof TechnicianTeamErrorResponseSchema>;

--- a/packages/shared/src/contracts/server/technician-teams/errors.ts
+++ b/packages/shared/src/contracts/server/technician-teams/errors.ts
@@ -1,16 +1,19 @@
 import { z } from "../../../zod";
 
 export const TechnicianTeamErrorCodeSchema = z.enum([
+  "TECHNICIAN_TEAM_INTERNAL_STATION_REQUIRED",
   "TECHNICIAN_TEAM_STATION_NOT_FOUND",
 ]);
 
 export const technicianTeamErrorMessages = {
+  TECHNICIAN_TEAM_INTERNAL_STATION_REQUIRED: "Technician teams require an internal station",
   TECHNICIAN_TEAM_STATION_NOT_FOUND: "Station not found for technician team",
 } as const satisfies Record<z.infer<typeof TechnicianTeamErrorCodeSchema>, string>;
 
 export const TechnicianTeamErrorDetailSchema = z.object({
   code: TechnicianTeamErrorCodeSchema,
   stationId: z.uuidv7().optional(),
+  stationType: z.enum(["INTERNAL", "AGENCY"]).optional(),
 });
 
 export const TechnicianTeamErrorResponseSchema = z.object({

--- a/packages/shared/src/contracts/server/technician-teams/errors.ts
+++ b/packages/shared/src/contracts/server/technician-teams/errors.ts
@@ -2,11 +2,13 @@ import { z } from "../../../zod";
 
 export const TechnicianTeamErrorCodeSchema = z.enum([
   "TECHNICIAN_TEAM_INTERNAL_STATION_REQUIRED",
+  "TECHNICIAN_TEAM_NOT_FOUND",
   "TECHNICIAN_TEAM_STATION_NOT_FOUND",
 ]);
 
 export const technicianTeamErrorMessages = {
   TECHNICIAN_TEAM_INTERNAL_STATION_REQUIRED: "Technician teams require an internal station",
+  TECHNICIAN_TEAM_NOT_FOUND: "Technician team not found",
   TECHNICIAN_TEAM_STATION_NOT_FOUND: "Station not found for technician team",
 } as const satisfies Record<z.infer<typeof TechnicianTeamErrorCodeSchema>, string>;
 
@@ -14,6 +16,7 @@ export const TechnicianTeamErrorDetailSchema = z.object({
   code: TechnicianTeamErrorCodeSchema,
   stationId: z.uuidv7().optional(),
   stationType: z.enum(["INTERNAL", "AGENCY"]).optional(),
+  teamId: z.uuidv7().optional(),
 });
 
 export const TechnicianTeamErrorResponseSchema = z.object({

--- a/packages/shared/src/contracts/server/technician-teams/index.ts
+++ b/packages/shared/src/contracts/server/technician-teams/index.ts
@@ -1,5 +1,4 @@
 import { z } from "../../../zod";
-
 import { TechnicianTeamAvailableOptionSchema, TechnicianTeamSummarySchema } from "./models";
 
 export * from "./errors";

--- a/packages/shared/src/contracts/server/technician-teams/index.ts
+++ b/packages/shared/src/contracts/server/technician-teams/index.ts
@@ -1,0 +1,22 @@
+import { z } from "../../../zod";
+
+import { TechnicianTeamAvailableOptionSchema, TechnicianTeamSummarySchema } from "./models";
+
+export * from "./errors";
+export * from "./models";
+
+export const TechnicianTeamListResponseSchema = z.object({
+  data: z.array(TechnicianTeamSummarySchema),
+});
+
+export const TechnicianTeamAvailableListResponseSchema = z.object({
+  data: z.array(TechnicianTeamAvailableOptionSchema),
+});
+
+export type TechnicianTeamListResponse = {
+  data: z.infer<typeof TechnicianTeamSummarySchema>[];
+};
+
+export type TechnicianTeamAvailableListResponse = {
+  data: z.infer<typeof TechnicianTeamAvailableOptionSchema>[];
+};

--- a/packages/shared/src/contracts/server/technician-teams/models.ts
+++ b/packages/shared/src/contracts/server/technician-teams/models.ts
@@ -1,0 +1,28 @@
+import { z } from "../../../zod";
+
+export const TechnicianTeamAvailabilitySchema = z.enum(["AVAILABLE", "UNAVAILABLE"]);
+
+export const TechnicianTeamStationRefSchema = z.object({
+  id: z.uuidv7(),
+  name: z.string(),
+});
+
+export const TechnicianTeamSummarySchema = z.object({
+  id: z.uuidv7(),
+  name: z.string(),
+  station: TechnicianTeamStationRefSchema,
+  availabilityStatus: TechnicianTeamAvailabilitySchema,
+  memberCount: z.number(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+});
+
+export const TechnicianTeamAvailableOptionSchema = z.object({
+  id: z.uuidv7(),
+  name: z.string(),
+  stationId: z.uuidv7(),
+});
+
+export type TechnicianTeamSummary = z.infer<typeof TechnicianTeamSummarySchema>;
+export type TechnicianTeamAvailableOption = z.infer<typeof TechnicianTeamAvailableOptionSchema>;
+export type TechnicianTeamAvailability = z.infer<typeof TechnicianTeamAvailabilitySchema>;

--- a/packages/shared/src/contracts/server/users/models.ts
+++ b/packages/shared/src/contracts/server/users/models.ts
@@ -17,12 +17,6 @@ export const UserSummarySchema = z.object({
   fullName: z.string(),
 });
 
-export const TechnicianTeamAvailableOptionSchema = z.object({
-  id: z.uuidv7(),
-  name: z.string(),
-  stationId: z.uuidv7(),
-});
-
 export const UserDetailSchema = z.object({
   id: z.uuidv7(),
   fullName: z.string(),
@@ -41,7 +35,6 @@ export const UserDetailSchema = z.object({
 });
 
 export type UserSummary = z.infer<typeof UserSummarySchema>;
-export type TechnicianTeamAvailableOption = z.infer<typeof TechnicianTeamAvailableOptionSchema>;
 export type UserDetail = z.infer<typeof UserDetailSchema>;
 export type UserOrgAssignment = z.infer<typeof UserOrgAssignmentSchema>;
 


### PR DESCRIPTION
## Summary
- add dedicated admin technician team routes for list, available list, create, and update operations
- split technician team contracts and server wiring into a dedicated resource module with query/command services and tests
- restrict technician team creation to internal stations and add targeted e2e and repository coverage

## Testing
- pnpm --dir ../../packages/shared build
- pnpm prisma generate
- pnpm tsc --noEmit
- pnpm vitest run --config vitest.int.config.ts src/domain/technician-teams/repository/test/read/technician-team.read.repository.int.test.ts src/domain/technician-teams/repository/test/write/technician-team.write.repository.int.test.ts
- pnpm vitest run --config vitest.int.config.ts src/http/test/e2e/admin-technician-teams-routing.e2e.int.test.ts
- pnpm eslint <branch-touched files>