### PR TITLE
feat(mobile): add environment impact screens

### DIFF
--- a/apps/mobile/components/IconSymbol.tsx
+++ b/apps/mobile/components/IconSymbol.tsx
@@ -2,6 +2,7 @@
 
 import type { ColorValue, StyleProp, ViewStyle } from "react-native";
 
+import { iconSizes } from "@theme/metrics";
 import {
   ArrowDown,
   ArrowLeft,
@@ -30,6 +31,7 @@ import {
   Footprints,
   Home,
   Info,
+  Leaf,
   List,
   Lock,
   Mail,
@@ -49,12 +51,11 @@ import {
   TriangleAlert,
   User,
   Wallet,
+  Wind,
   Wrench,
   X,
 } from "lucide-react-native";
 import React from "react";
-
-import { iconSizes } from "@theme/metrics";
 
 type LucideIconComponent = typeof ArrowLeft;
 
@@ -96,6 +97,7 @@ const ICONS = {
   "footprints": { outline: { icon: Footprints } },
   "home": { outline: { icon: Home }, filled: { icon: Home, fill: true } },
   "info": { outline: { icon: Info } },
+  "leaf": { outline: { icon: Leaf }, filled: { icon: Leaf, fill: true } },
   "location": { outline: { icon: MapPin }, filled: { icon: MapPin, fill: true } },
   "lock": { outline: { icon: Lock } },
   "list": { outline: { icon: List } },
@@ -118,6 +120,7 @@ const ICONS = {
   "tools": { outline: { icon: Wrench } },
   "wallet": { outline: { icon: Wallet } },
   "warning": { outline: { icon: TriangleAlert }, filled: { icon: TriangleAlert, fill: true } },
+  "wind": { outline: { icon: Wind } },
 } as const satisfies Record<string, IconVariantConfig>;
 
 type IconRegistry = typeof ICONS;

--- a/apps/mobile/contracts/server.ts
+++ b/apps/mobile/contracts/server.ts
@@ -60,3 +60,11 @@ export type CreateFixedSlotTemplatePayload = z.output<
 export type UpdateFixedSlotTemplatePayload = z.output<
   typeof serverRoutes.fixedSlotTemplates.updateFixedSlotTemplate.request.body.content["application/json"]["schema"]
 >;
+
+export type EnvironmentSummary = ServerContracts.EnvironmentContracts.EnvironmentSummary;
+export type EnvironmentImpactHistoryItem = ServerContracts.EnvironmentContracts.EnvironmentImpactHistoryItem;
+export type EnvironmentImpactHistoryResponse = ServerContracts.EnvironmentContracts.EnvironmentImpactHistoryResponse;
+export type EnvironmentImpactDetail = ServerContracts.EnvironmentContracts.EnvironmentImpactDetail;
+export type EnvironmentImpactHistoryQuery = z.output<
+  typeof serverRoutes.environment.getMyEnvironmentImpactHistory.request.query
+>;

--- a/apps/mobile/hooks/query/environment/environment-query-keys.ts
+++ b/apps/mobile/hooks/query/environment/environment-query-keys.ts
@@ -1,0 +1,19 @@
+export const environmentKeys = {
+  all: () => ["environment"] as const,
+  summary: () => ["environment", "summary"] as const,
+  historyRoot: () => ["environment", "history"] as const,
+  history: (args: {
+    pageSize: number;
+    sortOrder?: "asc" | "desc";
+    dateFrom?: string;
+    dateTo?: string;
+  }) => [
+    "environment",
+    "history",
+    args.pageSize,
+    args.sortOrder ?? null,
+    args.dateFrom ?? null,
+    args.dateTo ?? null,
+  ] as const,
+  detail: (rentalId: string) => ["environment", "detail", rentalId] as const,
+};

--- a/apps/mobile/hooks/query/environment/use-environment-impact-detail-query.ts
+++ b/apps/mobile/hooks/query/environment/use-environment-impact-detail-query.ts
@@ -1,0 +1,25 @@
+import type { EnvironmentError } from "@services/environment";
+
+import { environmentService } from "@services/environment";
+import { useQuery } from "@tanstack/react-query";
+
+import type { EnvironmentImpactDetail } from "@/contracts/server";
+
+import { environmentKeys } from "./environment-query-keys";
+
+export function useEnvironmentImpactDetailQuery(
+  rentalId: string,
+  enabled: boolean = true,
+) {
+  return useQuery<EnvironmentImpactDetail, EnvironmentError>({
+    queryKey: environmentKeys.detail(rentalId),
+    enabled: enabled && Boolean(rentalId),
+    queryFn: async () => {
+      const result = await environmentService.getDetail(rentalId);
+      if (!result.ok) {
+        throw result.error;
+      }
+      return result.value;
+    },
+  });
+}

--- a/apps/mobile/hooks/query/environment/use-environment-impact-history-query.ts
+++ b/apps/mobile/hooks/query/environment/use-environment-impact-history-query.ts
@@ -1,0 +1,56 @@
+import type { EnvironmentError } from "@services/environment";
+
+import { environmentService } from "@services/environment";
+import { useInfiniteQuery } from "@tanstack/react-query";
+
+import type {
+  EnvironmentImpactHistoryQuery,
+  EnvironmentImpactHistoryResponse,
+} from "@/contracts/server";
+
+import { environmentKeys } from "./environment-query-keys";
+
+const DEFAULT_PAGE_SIZE = 20;
+
+export function useEnvironmentImpactHistoryQuery(
+  params: EnvironmentImpactHistoryQuery = {},
+  enabled: boolean = true,
+) {
+  const {
+    pageSize = DEFAULT_PAGE_SIZE,
+    sortOrder,
+    dateFrom,
+    dateTo,
+  } = params;
+
+  return useInfiniteQuery<EnvironmentImpactHistoryResponse, EnvironmentError>({
+    queryKey: environmentKeys.history({
+      pageSize,
+      sortOrder,
+      dateFrom,
+      dateTo,
+    }),
+    enabled,
+    initialPageParam: 1,
+    queryFn: async ({ pageParam }) => {
+      const page = typeof pageParam === "number" ? pageParam : 1;
+      const result = await environmentService.getHistory({
+        page,
+        pageSize,
+        sortOrder,
+        dateFrom,
+        dateTo,
+      });
+      if (!result.ok) {
+        throw result.error;
+      }
+      return result.value;
+    },
+    getNextPageParam: (lastPage) => {
+      if (lastPage.pagination.page < lastPage.pagination.totalPages) {
+        return lastPage.pagination.page + 1;
+      }
+      return undefined;
+    },
+  });
+}

--- a/apps/mobile/hooks/query/environment/use-environment-summary-query.ts
+++ b/apps/mobile/hooks/query/environment/use-environment-summary-query.ts
@@ -1,0 +1,22 @@
+import type { EnvironmentError } from "@services/environment";
+
+import { environmentService } from "@services/environment";
+import { useQuery } from "@tanstack/react-query";
+
+import type { EnvironmentSummary } from "@/contracts/server";
+
+import { environmentKeys } from "./environment-query-keys";
+
+export function useEnvironmentSummaryQuery(enabled: boolean = true) {
+  return useQuery<EnvironmentSummary, EnvironmentError>({
+    queryKey: environmentKeys.summary(),
+    enabled,
+    queryFn: async () => {
+      const result = await environmentService.getSummary();
+      if (!result.ok) {
+        throw result.error;
+      }
+      return result.value;
+    },
+  });
+}

--- a/apps/mobile/navigation/root-navigator.tsx
+++ b/apps/mobile/navigation/root-navigator.tsx
@@ -8,6 +8,8 @@ import {
   BookingHistoryDetailScreen,
   ChangePasswordScreen,
   EmailVerificationScreen,
+  EnvironmentImpactDetailScreen,
+  EnvironmentImpactScreen,
   FixedSlotDetailScreen,
   FixedSlotEditorScreen,
   FixedSlotTemplatesScreen,
@@ -144,6 +146,16 @@ function RootNavigator() {
       <Stack.Screen
         name="ReservationFlow"
         component={ReservationFlowScreen}
+        options={{ headerShown: false, gestureEnabled: false }}
+      />
+      <Stack.Screen
+        name="EnvironmentImpact"
+        component={EnvironmentImpactScreen}
+        options={{ headerShown: false, gestureEnabled: false }}
+      />
+      <Stack.Screen
+        name="EnvironmentImpactDetail"
+        component={EnvironmentImpactDetailScreen}
         options={{ headerShown: false, gestureEnabled: false }}
       />
       <Stack.Screen

--- a/apps/mobile/presenters/environment/environment-error-presenter.ts
+++ b/apps/mobile/presenters/environment/environment-error-presenter.ts
@@ -1,0 +1,49 @@
+import type { EnvironmentError } from "@services/environment";
+
+const environmentErrorMessages = {
+  activePolicyMissing: "Hệ thống chưa có chính sách môi trường đang áp dụng.",
+  impactNotFound: "Chuyến đi này chưa có dữ liệu tác động môi trường.",
+  rentalNotFound: "Không tìm thấy chuyến đi tương ứng để xem tác động môi trường.",
+  rentalNotCompleted: "Tác động môi trường chỉ khả dụng sau khi chuyến đi đã hoàn tất.",
+  unauthorized: "Phiên đăng nhập đã hết hạn. Vui lòng đăng nhập lại.",
+  validationError: "Bộ lọc ngày chưa hợp lệ. Vui lòng chọn lại.",
+  networkError: "Không thể kết nối tới máy chủ.",
+  unknownError: "Không thể tải dữ liệu tác động môi trường lúc này.",
+} as const;
+
+function presentEnvironmentApiError(
+  error: Extract<EnvironmentError, { _tag: "ApiError" }>,
+  fallback: string,
+): string {
+  switch (error.code) {
+    case "ACTIVE_ENVIRONMENT_POLICY_NOT_FOUND":
+      return environmentErrorMessages.activePolicyMissing;
+    case "ENVIRONMENT_IMPACT_NOT_FOUND":
+      return environmentErrorMessages.impactNotFound;
+    case "ENVIRONMENT_IMPACT_RENTAL_NOT_FOUND":
+      return environmentErrorMessages.rentalNotFound;
+    case "ENVIRONMENT_IMPACT_RENTAL_NOT_COMPLETED":
+      return environmentErrorMessages.rentalNotCompleted;
+    case "UNAUTHORIZED":
+      return environmentErrorMessages.unauthorized;
+    case "VALIDATION_ERROR":
+      return environmentErrorMessages.validationError;
+    default:
+      return error.message ?? fallback;
+  }
+}
+
+export function presentEnvironmentError(
+  error: EnvironmentError,
+  fallback: string = environmentErrorMessages.unknownError,
+): string {
+  if (error._tag === "ApiError") {
+    return presentEnvironmentApiError(error, fallback);
+  }
+
+  if (error._tag === "NetworkError") {
+    return environmentErrorMessages.networkError;
+  }
+
+  return fallback;
+}

--- a/apps/mobile/screen/account/profile/hooks/use-profile.ts
+++ b/apps/mobile/screen/account/profile/hooks/use-profile.ts
@@ -111,6 +111,10 @@ export function useProfile() {
     navigation.navigate("Subscriptions" as never);
   };
 
+  const handleEnvironmentImpact = () => {
+    navigation.navigate("EnvironmentImpact" as never);
+  };
+
   const handleNotifications = () => {
     Alert.alert("Sắp ra mắt", "Quản lý thông báo sẽ sớm được cập nhật.");
   };
@@ -133,6 +137,7 @@ export function useProfile() {
     handleUpdateProfile,
     handleReservations,
     handleSubscriptions,
+    handleEnvironmentImpact,
     handleNotifications,
     handleResendOtp,
     handleVerifyEmail,

--- a/apps/mobile/screen/account/profile/index.tsx
+++ b/apps/mobile/screen/account/profile/index.tsx
@@ -72,6 +72,7 @@ function ProfileScreen() {
     handleUpdateProfile,
     handleReservations,
     handleSubscriptions,
+    handleEnvironmentImpact,
     handleNotifications,
     handleVerifyEmail,
   } = useProfile();
@@ -101,8 +102,26 @@ function ProfileScreen() {
       onPress: handleSubscriptions,
     });
 
+    items.push({
+      icon: "footprints",
+      title: "Tác động môi trường",
+      subtitle: "Theo dõi CO2 và quãng đường đã tiết kiệm",
+      iconColor: theme.statusSuccess.val,
+      iconBackground: theme.surfaceSuccess.val,
+      onPress: handleEnvironmentImpact,
+    });
+
     return items;
-  }, [handleReservations, handleSubscriptions, isCustomer, theme.actionPrimary.val, theme.surfaceAccent.val]);
+  }, [
+    handleEnvironmentImpact,
+    handleReservations,
+    handleSubscriptions,
+    isCustomer,
+    theme.actionPrimary.val,
+    theme.statusSuccess.val,
+    theme.surfaceAccent.val,
+    theme.surfaceSuccess.val,
+  ]);
 
   const accountItems = useMemo<MenuItem[]>(() => [
     {

--- a/apps/mobile/screen/environment/components/environment-detail-row.tsx
+++ b/apps/mobile/screen/environment/components/environment-detail-row.tsx
@@ -1,0 +1,36 @@
+import { AppText } from "@ui/primitives/app-text";
+import { XStack, YStack } from "tamagui";
+
+type EnvironmentDetailRowProps = {
+  label: string;
+  value: string;
+  subValue?: string;
+  tone?: "default" | "brand" | "danger" | "success";
+};
+
+export function EnvironmentDetailRow({
+  label,
+  value,
+  subValue,
+  tone = "default",
+}: EnvironmentDetailRowProps) {
+  return (
+    <XStack alignItems="flex-start" justifyContent="space-between" minHeight={72} paddingVertical="$3">
+      <AppText flex={1} numberOfLines={2} tone="muted" variant="body">
+        {label}
+      </AppText>
+      <YStack alignItems="flex-end" flex={1} gap="$1" justifyContent="center" minHeight={40}>
+        <AppText align="right" tone={tone} variant="cardTitle">
+          {value}
+        </AppText>
+        {subValue
+          ? (
+              <AppText align="right" tone="subtle" variant="bodySmall">
+                {subValue}
+              </AppText>
+            )
+          : null}
+      </YStack>
+    </XStack>
+  );
+}

--- a/apps/mobile/screen/environment/components/environment-history-filter-sheet.tsx
+++ b/apps/mobile/screen/environment/components/environment-history-filter-sheet.tsx
@@ -1,0 +1,245 @@
+import type { DateTimePickerEvent } from "@react-native-community/datetimepicker";
+
+import { IconSymbol } from "@components/IconSymbol";
+import DateTimePicker from "@react-native-community/datetimepicker";
+import { borderWidths } from "@theme/metrics";
+import { AppBottomModalCard } from "@ui/patterns/app-bottom-modal-card";
+import { AppButton } from "@ui/primitives/app-button";
+import { AppCard } from "@ui/primitives/app-card";
+import { AppText } from "@ui/primitives/app-text";
+import { Pressable, ScrollView } from "react-native";
+import { useTheme, XStack, YStack } from "tamagui";
+
+import type { QuickHistoryRangeOption } from "../hooks/use-environment-impact-screen";
+
+function formatFilterDate(value: Date) {
+  return new Intl.DateTimeFormat("vi-VN", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  }).format(value);
+}
+
+type EnvironmentHistoryFilterSheetProps = {
+  activeDateField: "from" | "to";
+  draftRange: "all" | "last7Days" | "thisMonth" | "custom";
+  draftCustomRange: {
+    from: Date;
+    to: Date;
+  };
+  isVisible: boolean;
+  onClose: () => void;
+  onApply: () => void;
+  onChangeDate: (field: "from" | "to", date: Date) => void;
+  onSelect: (key: "all" | "last7Days" | "thisMonth" | "custom") => void;
+  onSelectDateField: (field: "from" | "to") => void;
+  options: ReadonlyArray<QuickHistoryRangeOption>;
+};
+
+export function EnvironmentHistoryFilterSheet({
+  activeDateField,
+  draftRange,
+  draftCustomRange,
+  isVisible,
+  onClose,
+  onApply,
+  onChangeDate,
+  onSelect,
+  onSelectDateField,
+  options,
+}: EnvironmentHistoryFilterSheetProps) {
+  const theme = useTheme();
+  const pickerValue = activeDateField === "from" ? draftCustomRange.from : draftCustomRange.to;
+  const resolvedOptions = [
+    ...options,
+    {
+      key: "custom" as const,
+      label: "Tùy chỉnh khoảng ngày",
+      description: "Chọn ngày bắt đầu và kết thúc theo ý muốn.",
+    },
+  ];
+
+  return (
+    <AppBottomModalCard
+      isVisible={isVisible}
+      maxHeight="82%"
+      onClose={onClose}
+      variant="sheet"
+    >
+      <ScrollView
+        bounces={false}
+        contentContainerStyle={{ paddingBottom: 20 }}
+        showsVerticalScrollIndicator={false}
+      >
+        <YStack gap="$4" padding="$5">
+          <XStack alignItems="center" justifyContent="center" paddingTop="$1">
+            <YStack backgroundColor="$backgroundSubtle" borderRadius="$round" height={6} width={80} />
+          </XStack>
+
+          <XStack alignItems="center" justifyContent="space-between">
+            <AppText variant="xlTitle">
+              Lọc theo thời gian
+            </AppText>
+
+            <Pressable onPress={onClose} style={({ pressed }) => ({ opacity: pressed ? 0.92 : 1 })}>
+              <XStack
+                alignItems="center"
+                backgroundColor="$surfaceMuted"
+                borderRadius="$round"
+                height={44}
+                justifyContent="center"
+                width={44}
+              >
+                <IconSymbol color={theme.textSecondary.val} name="close" size="md" />
+              </XStack>
+            </Pressable>
+          </XStack>
+
+          <YStack gap="$3">
+            {resolvedOptions.map((option) => {
+              const isActive = draftRange === option.key;
+
+              return (
+                <Pressable
+                  key={option.key}
+                  onPress={() => onSelect(option.key)}
+                  style={({ pressed }) => ({ opacity: pressed ? 0.94 : 1 })}
+                >
+                  <AppCard
+                    borderColor={isActive ? "$statusSuccess" : "$borderSubtle"}
+                    borderRadius="$5"
+                    borderWidth={borderWidths.subtle}
+                    chrome="flat"
+                    tone={isActive ? "accent" : "default"}
+                    padding="$4"
+                  >
+                    <XStack alignItems="center" gap="$3" justifyContent="space-between">
+                      <YStack flex={1} gap="$1">
+                        <AppText variant="sectionTitle">
+                          {option.label}
+                        </AppText>
+                        {option.key === "custom"
+                          ? (
+                              <AppText tone="muted" variant="bodySmall">
+                                {formatFilterDate(draftCustomRange.from)}
+                                {" "}
+                                -
+                                {formatFilterDate(draftCustomRange.to)}
+                              </AppText>
+                            )
+                          : null}
+                      </YStack>
+                      <XStack
+                        alignItems="center"
+                        backgroundColor={isActive ? "$surfaceSuccess" : "$surfaceDefault"}
+                        borderColor={isActive ? "$statusSuccess" : "$borderSubtle"}
+                        borderRadius="$round"
+                        borderWidth={borderWidths.subtle}
+                        height={36}
+                        justifyContent="center"
+                        width={36}
+                      >
+                        <IconSymbol
+                          color={isActive ? theme.statusSuccess.val : theme.textDisabled.val}
+                          name={isActive ? "check-circle" : "circle"}
+                          size="sm"
+                        />
+                      </XStack>
+                    </XStack>
+                  </AppCard>
+                </Pressable>
+              );
+            })}
+          </YStack>
+
+          {draftRange === "custom"
+            ? (
+                <YStack gap="$3">
+                  <XStack gap="$3">
+                    <Pressable
+                      onPress={() => onSelectDateField("from")}
+                      style={({ pressed }) => ({ opacity: pressed ? 0.94 : 1, flex: 1 })}
+                    >
+                      <AppCard
+                        borderColor={activeDateField === "from" ? "$borderFocus" : "$borderSubtle"}
+                        borderRadius="$4"
+                        borderWidth={borderWidths.subtle}
+                        chrome="flat"
+                        tone={activeDateField === "from" ? "accent" : "default"}
+                      >
+                        <YStack gap="$1">
+                          <AppText tone="subtle" variant="eyebrow">
+                            Từ ngày
+                          </AppText>
+                          <AppText variant="cardTitle">
+                            {formatFilterDate(draftCustomRange.from)}
+                          </AppText>
+                        </YStack>
+                      </AppCard>
+                    </Pressable>
+
+                    <Pressable
+                      onPress={() => onSelectDateField("to")}
+                      style={({ pressed }) => ({ opacity: pressed ? 0.94 : 1, flex: 1 })}
+                    >
+                      <AppCard
+                        borderColor={activeDateField === "to" ? "$borderFocus" : "$borderSubtle"}
+                        borderRadius="$4"
+                        borderWidth={borderWidths.subtle}
+                        chrome="flat"
+                        tone={activeDateField === "to" ? "accent" : "default"}
+                      >
+                        <YStack gap="$1">
+                          <AppText tone="subtle" variant="eyebrow">
+                            Đến ngày
+                          </AppText>
+                          <AppText variant="cardTitle">
+                            {formatFilterDate(draftCustomRange.to)}
+                          </AppText>
+                        </YStack>
+                      </AppCard>
+                    </Pressable>
+                  </XStack>
+
+                  <AppCard
+                    borderColor="$borderSubtle"
+                    borderRadius="$5"
+                    borderWidth={borderWidths.subtle}
+                    chrome="flat"
+                    padding="$4"
+                  >
+                    <YStack gap="$2">
+                      <XStack alignItems="center" gap="$2">
+                        <IconSymbol color={theme.textBrand.val} name="calendar" size="sm" />
+                        <AppText variant="cardTitle">
+                          {activeDateField === "from" ? "Chọn ngày bắt đầu" : "Chọn ngày kết thúc"}
+                        </AppText>
+                      </XStack>
+
+                      <DateTimePicker
+                        accentColor={theme.actionPrimary.val}
+                        display="spinner"
+                        mode="date"
+                        onChange={(event: DateTimePickerEvent, date?: Date) => {
+                          if (event.type === "dismissed" || !date) {
+                            return;
+                          }
+
+                          onChangeDate(activeDateField, date);
+                        }}
+                        value={pickerValue}
+                      />
+                    </YStack>
+                  </AppCard>
+                </YStack>
+              )
+            : null}
+
+          <AppButton onPress={onApply} tone="primary">
+            Áp dụng bộ lọc
+          </AppButton>
+        </YStack>
+      </ScrollView>
+    </AppBottomModalCard>
+  );
+}

--- a/apps/mobile/screen/environment/components/environment-history-item-row.tsx
+++ b/apps/mobile/screen/environment/components/environment-history-item-row.tsx
@@ -1,0 +1,62 @@
+import { IconSymbol } from "@components/IconSymbol";
+import { AppText } from "@ui/primitives/app-text";
+import { Pressable } from "react-native";
+import { useTheme, XStack, YStack } from "tamagui";
+
+import type { EnvironmentImpactHistoryItem } from "@/contracts/server";
+
+import {
+  formatCo2Saved,
+  getEnvironmentHistorySubtitle,
+  getEnvironmentHistoryTitle,
+} from "../helpers/formatters";
+
+type EnvironmentHistoryItemRowProps = {
+  item: EnvironmentImpactHistoryItem;
+  onPress: (rentalId: string) => void;
+};
+
+export function EnvironmentHistoryItemRow({
+  item,
+  onPress,
+}: EnvironmentHistoryItemRowProps) {
+  const theme = useTheme();
+
+  return (
+    <Pressable onPress={() => onPress(item.rental_id)} style={({ pressed }) => ({ opacity: pressed ? 0.96 : 1 })}>
+      <XStack alignItems="center" gap="$3" paddingHorizontal="$4" paddingVertical="$3">
+        <YStack
+          alignItems="center"
+          backgroundColor="$surfaceSuccess"
+          borderRadius="$round"
+          borderWidth={1}
+          borderColor="$borderSubtle"
+          height={48}
+          justifyContent="center"
+          width={48}
+        >
+          <IconSymbol color={theme.statusSuccess.val} name="leaf" size="sm" />
+        </YStack>
+
+        <YStack flex={1} gap="$1" minWidth={0}>
+          <AppText numberOfLines={1} variant="cardTitle">
+            {getEnvironmentHistoryTitle(item)}
+          </AppText>
+          <AppText numberOfLines={1} tone="muted" variant="bodySmall">
+            {getEnvironmentHistorySubtitle(item)}
+          </AppText>
+        </YStack>
+
+        <YStack alignItems="flex-end" gap="$1">
+          <AppText tone="success" variant="sectionTitle">
+            +
+            {formatCo2Saved(item.co2_saved)}
+          </AppText>
+          <AppText tone="subtle" variant="bodySmall">
+            {item.co2_saved_unit}
+          </AppText>
+        </YStack>
+      </XStack>
+    </Pressable>
+  );
+}

--- a/apps/mobile/screen/environment/components/environment-impact-hero-card.tsx
+++ b/apps/mobile/screen/environment/components/environment-impact-hero-card.tsx
@@ -1,0 +1,77 @@
+import type { IconSymbolName } from "@components/IconSymbol";
+
+import { IconSymbol } from "@components/IconSymbol";
+import { elevations, radii } from "@theme/metrics";
+import { AppText } from "@ui/primitives/app-text";
+import { LinearGradient } from "expo-linear-gradient";
+import { memo } from "react";
+import { useTheme, XStack, YStack } from "tamagui";
+
+type HeroMetric = {
+  icon: IconSymbolName;
+  label: string;
+};
+
+type EnvironmentImpactHeroCardProps = {
+  eyebrow: string;
+  value: string;
+  unit: string;
+  metrics?: ReadonlyArray<HeroMetric | undefined>;
+};
+
+export const EnvironmentImpactHeroCard = memo(({
+  eyebrow,
+  value,
+  unit,
+  metrics = [],
+}: EnvironmentImpactHeroCardProps) => {
+  const theme = useTheme();
+
+  return (
+    <LinearGradient
+      colors={["#0F766E", "#10B981"]}
+      end={{ x: 1, y: 1 }}
+      start={{ x: 0, y: 0 }}
+      style={{
+        borderRadius: radii.xxl,
+        padding: 24,
+        ...elevations.medium,
+      }}
+    >
+      <YStack gap="$5">
+        <YStack gap="$2">
+          <AppText opacity={0.86} tone="inverted" variant="eyebrow">
+            {eyebrow}
+          </AppText>
+          <XStack alignItems="flex-end" gap="$2" flexWrap="wrap">
+            <AppText selectable style={{ fontVariant: ["tabular-nums"] }} tone="inverted" variant="hero">
+              {value}
+            </AppText>
+            <AppText tone="inverted" variant="sectionTitle">
+              {unit}
+            </AppText>
+          </XStack>
+        </YStack>
+
+        <XStack alignItems="center" flexWrap="wrap" gap="$3">
+          {metrics.filter(Boolean).map(metric => (
+            <XStack
+              key={metric!.label}
+              alignItems="center"
+              backgroundColor="rgba(0,0,0,0.12)"
+              borderRadius="$4"
+              gap="$2"
+              paddingHorizontal="$4"
+              paddingVertical="$3"
+            >
+              <IconSymbol color={theme.onSurfaceBrand.val} name={metric!.icon} size="sm" />
+              <AppText tone="inverted" variant="subhead">
+                {metric!.label}
+              </AppText>
+            </XStack>
+          ))}
+        </XStack>
+      </YStack>
+    </LinearGradient>
+  );
+});

--- a/apps/mobile/screen/environment/components/environment-screen-state.tsx
+++ b/apps/mobile/screen/environment/components/environment-screen-state.tsx
@@ -1,0 +1,58 @@
+import { IconSymbol } from "@components/IconSymbol";
+import { AppButton } from "@ui/primitives/app-button";
+import { AppCard } from "@ui/primitives/app-card";
+import { AppText } from "@ui/primitives/app-text";
+import { ActivityIndicator } from "react-native";
+import { useTheme, YStack } from "tamagui";
+
+type EnvironmentScreenStateProps = {
+  title: string;
+  description: string;
+  onRetry?: () => void;
+  mode?: "loading" | "error";
+};
+
+export function EnvironmentScreenState({
+  title,
+  description,
+  onRetry,
+  mode = "error",
+}: EnvironmentScreenStateProps) {
+  const theme = useTheme();
+
+  return (
+    <YStack flex={1} justifyContent="center" padding="$5">
+      <AppCard alignItems="center" borderRadius="$5" gap="$4" padding="$6">
+        <YStack
+          alignItems="center"
+          backgroundColor="$surfaceAccent"
+          borderRadius="$round"
+          height={64}
+          justifyContent="center"
+          width={64}
+        >
+          {mode === "loading"
+            ? <ActivityIndicator color={theme.actionPrimary.val} size="large" />
+            : <IconSymbol color={theme.actionPrimary.val} name="warning" size="chip" />}
+        </YStack>
+
+        <YStack alignItems="center" gap="$2">
+          <AppText align="center" variant="headline">
+            {title}
+          </AppText>
+          <AppText align="center" tone="muted" variant="bodySmall">
+            {description}
+          </AppText>
+        </YStack>
+
+        {mode === "error" && onRetry
+          ? (
+              <AppButton onPress={onRetry} width="100%">
+                Thử lại
+              </AppButton>
+            )
+          : null}
+      </AppCard>
+    </YStack>
+  );
+}

--- a/apps/mobile/screen/environment/components/environment-summary-stat-card.tsx
+++ b/apps/mobile/screen/environment/components/environment-summary-stat-card.tsx
@@ -1,0 +1,57 @@
+import { IconSymbol } from "@components/IconSymbol";
+import { borderWidths, elevations } from "@theme/metrics";
+import { AppCard } from "@ui/primitives/app-card";
+import { AppText } from "@ui/primitives/app-text";
+import { useTheme, XStack } from "tamagui";
+
+type EnvironmentSummaryStatCardProps = {
+  icon: "wind" | "bike";
+  label: string;
+  value: string;
+  iconBackground?: string;
+  iconColor?: string;
+};
+
+export function EnvironmentSummaryStatCard({
+  icon,
+  label,
+  value,
+  iconBackground = "$surfaceAccent",
+  iconColor,
+}: EnvironmentSummaryStatCardProps) {
+  const theme = useTheme();
+
+  return (
+    <AppCard
+      borderColor="$borderSubtle"
+      borderRadius="$5"
+      borderWidth={borderWidths.subtle}
+      chrome="flat"
+      flex={1}
+      gap="$3"
+      padding="$4"
+      style={elevations.whisper}
+    >
+      <XStack alignItems="center" gap="$3">
+        <XStack
+          alignItems="center"
+          backgroundColor={iconBackground}
+          borderRadius="$round"
+          height={40}
+          justifyContent="center"
+          width={40}
+        >
+          <IconSymbol color={iconColor ?? theme.actionPrimary.val} name={icon} size="sm" />
+        </XStack>
+
+        <AppText flex={1} tone="subtle" variant="eyebrow">
+          {label}
+        </AppText>
+      </XStack>
+
+      <AppText style={{ fontVariant: ["tabular-nums"] }} variant="cardTitle">
+        {value}
+      </AppText>
+    </AppCard>
+  );
+}

--- a/apps/mobile/screen/environment/environment-impact-detail-screen.tsx
+++ b/apps/mobile/screen/environment/environment-impact-detail-screen.tsx
@@ -1,0 +1,199 @@
+import { IconSymbol } from "@components/IconSymbol";
+import { useRoute } from "@react-navigation/native";
+import { borderWidths, elevations } from "@theme/metrics";
+import { AppHeroHeader } from "@ui/patterns/app-hero-header";
+import { AppButton } from "@ui/primitives/app-button";
+import { AppCard } from "@ui/primitives/app-card";
+import { AppText } from "@ui/primitives/app-text";
+import { Screen } from "@ui/primitives/screen";
+import { RefreshControl, ScrollView, StatusBar } from "react-native";
+import { Separator, useTheme, XStack, YStack } from "tamagui";
+
+import type { EnvironmentImpactDetailRouteProp } from "@/types/navigation";
+
+import { presentEnvironmentError } from "@/presenters/environment/environment-error-presenter";
+
+import { EnvironmentDetailRow } from "./components/environment-detail-row";
+import { EnvironmentImpactHeroCard } from "./components/environment-impact-hero-card";
+import { EnvironmentScreenState } from "./components/environment-screen-state";
+import {
+  formatCo2Saved,
+  formatConfidence,
+  formatDistanceKm,
+  formatMinutes,
+  getEnvironmentRentalCode,
+} from "./helpers/formatters";
+import { useEnvironmentImpactDetailScreen } from "./hooks/use-environment-impact-detail-screen";
+
+export default function EnvironmentImpactDetailScreen() {
+  const route = useRoute<EnvironmentImpactDetailRouteProp>();
+  const theme = useTheme();
+  const vm = useEnvironmentImpactDetailScreen(route.params.rentalId);
+
+  if (vm.isInitialLoading) {
+    return (
+      <Screen tone="subtle">
+        <StatusBar backgroundColor={theme.surfaceDefault.val} barStyle="dark-content" />
+        <AppHeroHeader
+          onBack={vm.actions.goBack}
+          size="compact"
+          title="Chi tiết tác động"
+          variant="surface"
+        />
+        <EnvironmentScreenState
+          description="Đang tải công thức và các chỉ số đã dùng để tính tác động môi trường cho chuyến đi này."
+          mode="loading"
+          title="Đang tải chi tiết"
+        />
+      </Screen>
+    );
+  }
+
+  if (!vm.detail) {
+    return (
+      <Screen tone="subtle">
+        <StatusBar backgroundColor={theme.surfaceDefault.val} barStyle="dark-content" />
+        <AppHeroHeader
+          onBack={vm.actions.goBack}
+          size="compact"
+          title="Chi tiết tác động"
+          variant="surface"
+        />
+        <EnvironmentScreenState
+          description={vm.error ? presentEnvironmentError(vm.error) : "Không có dữ liệu để hiển thị."}
+          onRetry={() => {
+            void vm.actions.onRefresh();
+          }}
+          title="Không thể tải chi tiết tác động"
+        />
+      </Screen>
+    );
+  }
+
+  const detail = vm.detail;
+
+  return (
+    <Screen tone="subtle">
+      <StatusBar backgroundColor={theme.surfaceDefault.val} barStyle="dark-content" />
+
+      <AppHeroHeader
+        onBack={vm.actions.goBack}
+        size="compact"
+        subtitle={`Mã chuyến: ${getEnvironmentRentalCode(detail.rental_id)}`}
+        title="Chi tiết tác động"
+        variant="surface"
+      />
+
+      <ScrollView
+        refreshControl={(
+          <RefreshControl
+            colors={[theme.actionPrimary.val]}
+            onRefresh={vm.actions.onRefresh}
+            refreshing={vm.isRefreshing}
+            tintColor={theme.actionPrimary.val}
+          />
+        )}
+        showsVerticalScrollIndicator={false}
+      >
+        <YStack gap="$5" padding="$5" paddingBottom="$7">
+          <EnvironmentImpactHeroCard
+            eyebrow="CO2 đã tiết kiệm"
+            metrics={[
+              { icon: "map", label: formatDistanceKm(detail.estimated_distance_km) },
+              typeof detail.effective_ride_minutes === "number"
+                ? { icon: "clock", label: formatMinutes(detail.effective_ride_minutes) }
+                : undefined,
+            ]}
+            unit={detail.co2_saved_unit}
+            value={formatCo2Saved(detail.co2_saved)}
+          />
+
+          <AppCard
+            borderColor="$borderSubtle"
+            borderRadius="$5"
+            borderWidth={borderWidths.subtle}
+            chrome="flat"
+            gap="$4"
+            padding="$5"
+            style={elevations.whisper}
+          >
+            <XStack alignItems="center" gap="$3">
+              <YStack
+                alignItems="center"
+                backgroundColor="$surfaceAccent"
+                borderRadius="$3"
+                height={36}
+                justifyContent="center"
+                width={36}
+              >
+                <IconSymbol color={theme.actionPrimary.val} name="timer" size="sm" />
+              </YStack>
+              <AppText variant="sectionTitle">
+                Cách chúng tôi tính toán
+              </AppText>
+            </XStack>
+
+            <Separator borderColor="$backgroundSubtle" />
+
+            <YStack>
+              <EnvironmentDetailRow label="Tổng thời gian thuê" value={formatMinutes(detail.raw_rental_minutes)} />
+              <Separator borderColor="$backgroundSubtle" />
+              <EnvironmentDetailRow
+                label="Trừ hao thời gian trả xe"
+                tone="danger"
+                value={typeof detail.return_scan_buffer_minutes === "number"
+                  ? `-${Math.max(0, Math.round(detail.return_scan_buffer_minutes))} phút`
+                  : "--"}
+              />
+              <Separator borderColor="$backgroundSubtle" />
+              <EnvironmentDetailRow
+                label="Thời gian di chuyển thực tế"
+                tone="brand"
+                value={formatMinutes(detail.effective_ride_minutes)}
+              />
+            </YStack>
+
+            <Separator borderColor="$backgroundSubtle" />
+
+            <YStack>
+              <EnvironmentDetailRow
+                label="Tốc độ trung bình ước tính"
+                subValue={detail.distance_source ? `Nguồn: ${detail.distance_source}` : undefined}
+                value={typeof detail.average_speed_kmh === "number"
+                  ? `${detail.average_speed_kmh.toLocaleString("vi-VN", { maximumFractionDigits: 1 })} km/h`
+                  : "--"}
+              />
+              <Separator borderColor="$backgroundSubtle" />
+              <EnvironmentDetailRow
+                label="Quãng đường ước tính"
+                tone="brand"
+                value={formatDistanceKm(detail.estimated_distance_km)}
+              />
+            </YStack>
+
+            <Separator borderColor="$backgroundSubtle" />
+
+            <YStack>
+              <EnvironmentDetailRow
+                label="Hệ số CO2 tiết kiệm"
+                value={typeof detail.co2_saved_per_km === "number" && detail.co2_saved_per_km_unit
+                  ? `${detail.co2_saved_per_km.toLocaleString("vi-VN", { maximumFractionDigits: 1 })} ${detail.co2_saved_per_km_unit}`
+                  : "--"}
+              />
+              <Separator borderColor="$backgroundSubtle" />
+              <EnvironmentDetailRow
+                label="Hệ số tin cậy"
+                tone={typeof detail.confidence_factor === "number" && detail.confidence_factor >= 0.8 ? "success" : "default"}
+                value={formatConfidence(detail.confidence_factor)}
+              />
+            </YStack>
+          </AppCard>
+
+          <AppButton onPress={vm.actions.openRentalDetail} tone="outline">
+            Xem chi tiết chuyến đi
+          </AppButton>
+        </YStack>
+      </ScrollView>
+    </Screen>
+  );
+}

--- a/apps/mobile/screen/environment/environment-impact-screen.tsx
+++ b/apps/mobile/screen/environment/environment-impact-screen.tsx
@@ -1,0 +1,349 @@
+import { IconSymbol } from "@components/IconSymbol";
+import { borderWidths, elevations, radii, spaceScale, spacingRules } from "@theme/metrics";
+import { AppButton } from "@ui/primitives/app-button";
+import { AppCard } from "@ui/primitives/app-card";
+import { AppText } from "@ui/primitives/app-text";
+import { Screen } from "@ui/primitives/screen";
+import { LinearGradient } from "expo-linear-gradient";
+import { Pressable, RefreshControl, ScrollView, StatusBar } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Separator, useTheme, XStack, YStack } from "tamagui";
+
+import { presentEnvironmentError } from "@/presenters/environment/environment-error-presenter";
+
+import { EnvironmentHistoryFilterSheet } from "./components/environment-history-filter-sheet";
+import { EnvironmentHistoryItemRow } from "./components/environment-history-item-row";
+import { EnvironmentScreenState } from "./components/environment-screen-state";
+import { EnvironmentSummaryStatCard } from "./components/environment-summary-stat-card";
+import { formatCo2Saved, formatDistanceKm } from "./helpers/formatters";
+import { useEnvironmentImpactScreen } from "./hooks/use-environment-impact-screen";
+
+const environmentHeroColors = ["#0F766E", "#22C58B"] as const;
+const environmentHeroCornerRadius = radii.xxl + spaceScale[2];
+const environmentHeroIconShellSize = 56;
+const environmentHeroCardOverlap = spaceScale[5] + spaceScale[1];
+
+function EnvironmentOverviewHeader({
+  onBack,
+  title,
+  co2Saved,
+  unit,
+}: {
+  onBack: () => void;
+  title: string;
+  co2Saved: string;
+  unit: string;
+}) {
+  const theme = useTheme();
+  const insets = useSafeAreaInsets();
+
+  return (
+    <LinearGradient
+      colors={[...environmentHeroColors]}
+      end={{ x: 1, y: 1 }}
+      start={{ x: 0, y: 0 }}
+      style={{
+        borderBottomLeftRadius: environmentHeroCornerRadius,
+        borderBottomRightRadius: environmentHeroCornerRadius,
+        paddingTop: insets.top + spacingRules.hero.paddingTop,
+        paddingBottom: spaceScale[8],
+      }}
+    >
+      <YStack gap="$5" paddingHorizontal="$5">
+        <XStack alignItems="center" justifyContent="space-between" gap="$4">
+          <XStack alignItems="center" flex={1} gap="$4">
+            <Pressable
+              onPress={onBack}
+              style={{
+                width: 48,
+                height: 48,
+                borderRadius: radii.round,
+                alignItems: "center",
+                justifyContent: "center",
+                backgroundColor: theme.overlayGlass.val,
+              }}
+            >
+              <IconSymbol color={theme.onSurfaceBrand.val} name="arrow-left" size="md" />
+            </Pressable>
+
+            <AppText flex={1} numberOfLines={1} tone="inverted" variant="xlTitle">
+              {title}
+            </AppText>
+          </XStack>
+
+          <XStack
+            alignItems="center"
+            backgroundColor={theme.overlayGlass.val}
+            borderRadius="$round"
+            height={environmentHeroIconShellSize}
+            justifyContent="center"
+            marginTop={spaceScale[4]}
+            width={environmentHeroIconShellSize}
+          >
+            <IconSymbol color={theme.onSurfaceBrand.val} name="leaf" size="lg" variant="filled" />
+          </XStack>
+        </XStack>
+
+        <YStack gap="$2">
+          <AppText opacity={0.88} tone="inverted" variant="eyebrow">
+            Tổng CO2 tiết kiệm
+          </AppText>
+          <XStack alignItems="flex-end" flexWrap="wrap" gap="$2">
+            <AppText selectable style={{ fontVariant: ["tabular-nums"] }} tone="inverted" variant="metricValue">
+              {co2Saved}
+            </AppText>
+            <AppText marginBottom="$2" opacity={0.92} tone="inverted" variant="sectionTitle">
+              {unit}
+            </AppText>
+          </XStack>
+        </YStack>
+      </YStack>
+    </LinearGradient>
+  );
+}
+
+function EnvironmentOverviewEmptyHeader({ onBack }: { onBack: () => void }) {
+  return (
+    <EnvironmentOverviewHeader
+      co2Saved="--"
+      onBack={onBack}
+      title="Tác động môi trường"
+      unit="gCO2e"
+    />
+  );
+}
+
+function EnvironmentOverviewLoadedHeader({
+  onBack,
+  co2Saved,
+  unit,
+}: {
+  onBack: () => void;
+  co2Saved: string;
+  unit: string;
+}) {
+  return (
+    <EnvironmentOverviewHeader
+      co2Saved={co2Saved}
+      onBack={onBack}
+      title="Tác động môi trường"
+      unit={unit}
+    />
+  );
+}
+
+function EnvironmentOverviewStats({
+  distance,
+  trips,
+}: {
+  distance: string;
+  trips: string;
+}) {
+  const theme = useTheme();
+
+  return (
+    <XStack gap="$3">
+      <EnvironmentSummaryStatCard
+        icon="wind"
+        iconBackground="$surfaceDefault"
+        iconColor={theme.actionPrimary.val}
+        label="Quãng đường"
+        value={distance}
+      />
+      <EnvironmentSummaryStatCard
+        icon="bike"
+        iconBackground="$surfaceDefault"
+        iconColor="#4F46E5"
+        label="Chuyến đi"
+        value={trips}
+      />
+    </XStack>
+  );
+}
+
+export default function EnvironmentImpactScreen() {
+  const theme = useTheme();
+  const vm = useEnvironmentImpactScreen();
+  const summaryUnit = vm.summary?.co2_saved_unit ?? "gCO2e";
+  const summaryCo2Value = vm.summary
+    ? formatCo2Saved(vm.summary.total_co2_saved)
+    : "--";
+  const summaryDistanceValue = vm.summary
+    ? formatDistanceKm(vm.summary.total_estimated_distance_km)
+    : "--";
+  const summaryTripValue = vm.summary
+    ? `${vm.summary.total_trips_counted} chuyến`
+    : "--";
+
+  if (vm.isInitialLoading) {
+    return (
+      <Screen tone="subtle">
+        <StatusBar backgroundColor={environmentHeroColors[0]} barStyle="light-content" />
+        <EnvironmentOverviewEmptyHeader onBack={vm.actions.goBack} />
+        <EnvironmentScreenState
+          description="Đang tổng hợp lịch sử đóng góp và CO2 tiết kiệm của bạn."
+          mode="loading"
+          title="Đang tải tác động môi trường"
+        />
+      </Screen>
+    );
+  }
+
+  if (vm.initialError && vm.historyItems.length === 0) {
+    return (
+      <Screen tone="subtle">
+        <StatusBar backgroundColor={environmentHeroColors[0]} barStyle="light-content" />
+        <EnvironmentOverviewEmptyHeader onBack={vm.actions.goBack} />
+        <EnvironmentScreenState
+          description={presentEnvironmentError(vm.initialError)}
+          onRetry={() => {
+            void vm.actions.onRefresh();
+          }}
+          title="Không thể tải tác động môi trường"
+        />
+      </Screen>
+    );
+  }
+
+  return (
+    <Screen tone="subtle">
+      <StatusBar backgroundColor={environmentHeroColors[0]} barStyle="light-content" />
+
+      <ScrollView
+        refreshControl={(
+          <RefreshControl
+            colors={[theme.actionPrimary.val]}
+            onRefresh={vm.actions.onRefresh}
+            refreshing={vm.isRefreshing}
+            tintColor={theme.actionPrimary.val}
+          />
+        )}
+        showsVerticalScrollIndicator={false}
+      >
+        <YStack paddingBottom="$7">
+          <EnvironmentOverviewLoadedHeader
+            co2Saved={summaryCo2Value}
+            onBack={vm.actions.goBack}
+            unit={summaryUnit}
+          />
+
+          <YStack gap="$5" marginTop={-environmentHeroCardOverlap} paddingHorizontal="$5">
+            <EnvironmentOverviewStats
+              distance={summaryDistanceValue}
+              trips={summaryTripValue}
+            />
+
+            {!vm.summary && vm.summaryError
+              ? (
+                  <AppCard tone="warning">
+                    <AppText variant="cardTitle">
+                      Không thể tải số tổng quan
+                    </AppText>
+                    <AppText tone="muted" variant="bodySmall">
+                      {presentEnvironmentError(vm.summaryError)}
+                    </AppText>
+                  </AppCard>
+                )
+              : null}
+
+            <AppCard
+              borderColor="$borderSubtle"
+              borderRadius="$5"
+              borderWidth={borderWidths.subtle}
+              chrome="flat"
+              overflow="hidden"
+              padding="$0"
+              style={elevations.whisper}
+            >
+              <XStack alignItems="center" justifyContent="space-between" padding="$4">
+                <AppText variant="sectionTitle">
+                  Lịch sử đóng góp
+                </AppText>
+                <Pressable onPress={vm.filter.open} style={({ pressed }) => ({ opacity: pressed ? 0.92 : 1 })}>
+                  <XStack alignItems="center" gap="$2">
+                    <AppText tone="success" variant="actionLabel">
+                      {vm.filter.customRangeLabel ?? vm.activeRange.label}
+                    </AppText>
+                    <IconSymbol color={theme.statusSuccess.val} name="sliders" size="sm" />
+                  </XStack>
+                </Pressable>
+              </XStack>
+
+              <Separator borderColor="$backgroundSubtle" />
+
+              {vm.historyItems.length === 0
+                ? (
+                    <YStack alignItems="center" gap="$2" padding="$6">
+                      <AppText align="center" variant="cardTitle">
+                        Chưa có đóng góp nào để hiển thị
+                      </AppText>
+                      <AppText align="center" tone="muted" variant="bodySmall">
+                        Sau khi hoàn tất chuyến đi, hệ thống sẽ tự ghi nhận CO2 và quãng đường tiết kiệm tại đây.
+                      </AppText>
+                    </YStack>
+                  )
+                : (
+                    <YStack>
+                      {vm.historyItems.map((item, index) => (
+                        <YStack key={item.id}>
+                          <EnvironmentHistoryItemRow
+                            item={item}
+                            onPress={vm.actions.openDetail}
+                          />
+                          {index < vm.historyItems.length - 1
+                            ? <Separator borderColor="$backgroundSubtle" />
+                            : null}
+                        </YStack>
+                      ))}
+                    </YStack>
+                  )}
+
+              {vm.history.hasNextPage
+                ? (
+                    <YStack padding="$4">
+                      <AppButton
+                        buttonSize="compact"
+                        loading={vm.history.isFetchingNextPage}
+                        onPress={() => {
+                          void vm.history.fetchNextPage();
+                        }}
+                        tone="ghost"
+                      >
+                        Tải thêm lịch sử
+                      </AppButton>
+                    </YStack>
+                  )
+                : null}
+            </AppCard>
+
+            {vm.hasHistoryRefreshError && vm.historyRefreshError
+              ? (
+                  <AppCard tone="warning">
+                    <AppText variant="cardTitle">
+                      Không thể làm mới toàn bộ lịch sử
+                    </AppText>
+                    <AppText tone="muted" variant="bodySmall">
+                      {presentEnvironmentError(vm.historyRefreshError)}
+                    </AppText>
+                  </AppCard>
+                )
+              : null}
+          </YStack>
+        </YStack>
+      </ScrollView>
+
+      <EnvironmentHistoryFilterSheet
+        activeDateField={vm.filter.activeDateField}
+        draftCustomRange={vm.filter.draftCustomRange}
+        draftRange={vm.filter.draftRange}
+        isVisible={vm.filter.isOpen}
+        onApply={vm.filter.applyCustomRange}
+        onChangeDate={vm.filter.changeCustomDate}
+        onClose={vm.filter.close}
+        onSelect={vm.filter.select}
+        onSelectDateField={vm.filter.selectDateField}
+        options={vm.filter.options}
+      />
+    </Screen>
+  );
+}

--- a/apps/mobile/screen/environment/helpers/formatters.ts
+++ b/apps/mobile/screen/environment/helpers/formatters.ts
@@ -1,0 +1,70 @@
+import { formatSupportCode } from "@utils/id";
+
+import type { EnvironmentImpactHistoryItem } from "@/contracts/server";
+
+function formatNumber(value: number, maximumFractionDigits: number) {
+  return new Intl.NumberFormat("vi-VN", {
+    maximumFractionDigits,
+    minimumFractionDigits: Number.isInteger(value) ? 0 : Math.min(1, maximumFractionDigits),
+  }).format(value);
+}
+
+export function formatEnvironmentDate(value?: string) {
+  if (!value) {
+    return "--/--/----";
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat("vi-VN", {
+    timeZone: "Asia/Ho_Chi_Minh",
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  }).format(date);
+}
+
+export function formatCo2Saved(value: number) {
+  return formatNumber(Math.round(value), 0);
+}
+
+export function formatDistanceKm(value: number) {
+  return `${formatNumber(value, 1)} km`;
+}
+
+export function formatMinutes(value: number | null | undefined) {
+  if (typeof value !== "number") {
+    return "--";
+  }
+
+  return `${Math.max(0, Math.round(value))} phút`;
+}
+
+export function formatConfidence(value: number | null | undefined) {
+  if (typeof value !== "number") {
+    return "--";
+  }
+
+  return `${Math.round(value * 100)}%`;
+}
+
+export function getEnvironmentHistoryTitle(item: EnvironmentImpactHistoryItem) {
+  return formatEnvironmentDate(item.calculated_at);
+}
+
+export function getEnvironmentHistorySubtitle(item: EnvironmentImpactHistoryItem) {
+  const parts = [formatDistanceKm(item.estimated_distance_km)];
+
+  if (typeof item.effective_ride_minutes === "number") {
+    parts.push(formatMinutes(item.effective_ride_minutes));
+  }
+
+  return parts.join(" • ");
+}
+
+export function getEnvironmentRentalCode(rentalId: string) {
+  return formatSupportCode(rentalId);
+}

--- a/apps/mobile/screen/environment/hooks/use-environment-impact-detail-screen.ts
+++ b/apps/mobile/screen/environment/hooks/use-environment-impact-detail-screen.ts
@@ -1,0 +1,37 @@
+import { useEnvironmentImpactDetailQuery } from "@hooks/query/environment/use-environment-impact-detail-query";
+import { useNavigation } from "@react-navigation/native";
+import { useCallback, useState } from "react";
+
+import type { EnvironmentImpactDetailNavigationProp } from "@/types/navigation";
+
+export function useEnvironmentImpactDetailScreen(rentalId: string) {
+  const navigation = useNavigation<EnvironmentImpactDetailNavigationProp>();
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const detailQuery = useEnvironmentImpactDetailQuery(rentalId);
+
+  const handleRefresh = useCallback(async () => {
+    setIsRefreshing(true);
+    try {
+      await detailQuery.refetch();
+    }
+    finally {
+      setIsRefreshing(false);
+    }
+  }, [detailQuery]);
+
+  const handleOpenRentalDetail = useCallback(() => {
+    navigation.navigate("BookingHistoryDetail", { bookingId: rentalId });
+  }, [navigation, rentalId]);
+
+  return {
+    detail: detailQuery.data,
+    error: detailQuery.error,
+    isInitialLoading: !detailQuery.data && detailQuery.isLoading,
+    isRefreshing: isRefreshing || detailQuery.isRefetching,
+    actions: {
+      goBack: () => navigation.goBack(),
+      onRefresh: handleRefresh,
+      openRentalDetail: handleOpenRentalDetail,
+    },
+  };
+}

--- a/apps/mobile/screen/environment/hooks/use-environment-impact-screen.ts
+++ b/apps/mobile/screen/environment/hooks/use-environment-impact-screen.ts
@@ -1,0 +1,329 @@
+import { useEnvironmentImpactHistoryQuery } from "@hooks/query/environment/use-environment-impact-history-query";
+import { useEnvironmentSummaryQuery } from "@hooks/query/environment/use-environment-summary-query";
+import { useNavigation } from "@react-navigation/native";
+import { useCallback, useMemo, useState } from "react";
+
+import type {
+  EnvironmentImpactHistoryItem,
+  EnvironmentImpactHistoryQuery,
+} from "@/contracts/server";
+import type { EnvironmentImpactNavigationProp } from "@/types/navigation";
+
+export type HistoryRangeKey = "all" | "last7Days" | "thisMonth" | "custom";
+
+export type HistoryRangeOption = {
+  key: HistoryRangeKey;
+  label: string;
+  description: string;
+};
+
+export type QuickHistoryRangeOption = {
+  key: "all" | "last7Days" | "thisMonth";
+  label: string;
+  description: string;
+};
+
+type CustomDateRange = {
+  from: Date;
+  to: Date;
+};
+
+const VIETNAM_UTC_OFFSET_MS = 7 * 60 * 60 * 1000;
+const VIETNAM_TIME_ZONE = "Asia/Ho_Chi_Minh";
+
+export const HISTORY_RANGE_OPTIONS: readonly HistoryRangeOption[] = [
+  {
+    key: "all",
+    label: "Tất cả thời gian",
+    description: "Hiển thị toàn bộ lịch sử đóng góp đã được tính toán.",
+  },
+  {
+    key: "last7Days",
+    label: "7 ngày qua",
+    description: "Chỉ xem các chuyến đi trong 7 ngày gần đây.",
+  },
+  {
+    key: "thisMonth",
+    label: "Tháng này",
+    description: "Chỉ xem các chuyến đi trong tháng hiện tại.",
+  },
+  {
+    key: "custom",
+    label: "Tùy chọn",
+    description: "Chọn khoảng ngày bắt đầu và kết thúc theo ý muốn.",
+  },
+] as const;
+
+function buildCustomDateRange(now: Date): CustomDateRange {
+  return {
+    from: new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000),
+    to: now,
+  };
+}
+
+function getVietnamDateParts(date: Date) {
+  const formatter = new Intl.DateTimeFormat("en-CA", {
+    timeZone: VIETNAM_TIME_ZONE,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+
+  const parts = formatter.formatToParts(date);
+
+  return {
+    year: Number(parts.find(part => part.type === "year")?.value ?? "0"),
+    month: Number(parts.find(part => part.type === "month")?.value ?? "1"),
+    day: Number(parts.find(part => part.type === "day")?.value ?? "1"),
+  };
+}
+
+function shiftCalendarDate(
+  parts: { year: number; month: number; day: number },
+  days: number,
+) {
+  const shifted = new Date(Date.UTC(parts.year, parts.month - 1, parts.day));
+  shifted.setUTCDate(shifted.getUTCDate() + days);
+
+  return {
+    year: shifted.getUTCFullYear(),
+    month: shifted.getUTCMonth() + 1,
+    day: shifted.getUTCDate(),
+  };
+}
+
+function toVietnamUtcBoundaryFromParts(
+  parts: { year: number; month: number; day: number },
+  boundary: "start" | "end",
+) {
+  const utcBase = Date.UTC(
+    parts.year,
+    parts.month - 1,
+    parts.day,
+    boundary === "start" ? 0 : 23,
+    boundary === "start" ? 0 : 59,
+    boundary === "start" ? 0 : 59,
+    boundary === "start" ? 0 : 999,
+  );
+
+  return new Date(utcBase - VIETNAM_UTC_OFFSET_MS).toISOString();
+}
+
+function buildHistoryParams(
+  range: HistoryRangeKey,
+  customRange: CustomDateRange,
+): EnvironmentImpactHistoryQuery {
+  const params: EnvironmentImpactHistoryQuery = {
+    pageSize: 20,
+    sortOrder: "desc",
+  };
+
+  if (range === "all") {
+    return params;
+  }
+
+  if (range === "custom") {
+    const fromParts = {
+      year: customRange.from.getFullYear(),
+      month: customRange.from.getMonth() + 1,
+      day: customRange.from.getDate(),
+    };
+    const toParts = {
+      year: customRange.to.getFullYear(),
+      month: customRange.to.getMonth() + 1,
+      day: customRange.to.getDate(),
+    };
+
+    return {
+      ...params,
+      dateFrom: toVietnamUtcBoundaryFromParts(fromParts, "start"),
+      dateTo: toVietnamUtcBoundaryFromParts(toParts, "end"),
+    };
+  }
+
+  if (range === "thisMonth") {
+    const vietnamToday = getVietnamDateParts(new Date());
+    return {
+      ...params,
+      dateFrom: toVietnamUtcBoundaryFromParts(
+        {
+          ...vietnamToday,
+          day: 1,
+        },
+        "start",
+      ),
+      dateTo: toVietnamUtcBoundaryFromParts(vietnamToday, "end"),
+    };
+  }
+
+  const vietnamToday = getVietnamDateParts(new Date());
+  const dateFrom = shiftCalendarDate(vietnamToday, -6);
+
+  return {
+    ...params,
+    dateFrom: toVietnamUtcBoundaryFromParts(dateFrom, "start"),
+    dateTo: toVietnamUtcBoundaryFromParts(vietnamToday, "end"),
+  };
+}
+
+function flattenHistory(pages: Array<{ data: EnvironmentImpactHistoryItem[] }> | undefined) {
+  if (!pages) {
+    return [];
+  }
+
+  const seenIds = new Set<string>();
+  const items: EnvironmentImpactHistoryItem[] = [];
+
+  for (const page of pages) {
+    for (const item of page.data) {
+      if (!seenIds.has(item.id)) {
+        seenIds.add(item.id);
+        items.push(item);
+      }
+    }
+  }
+
+  return items;
+}
+
+export function useEnvironmentImpactScreen() {
+  const navigation = useNavigation<EnvironmentImpactNavigationProp>();
+  const [isFilterOpen, setIsFilterOpen] = useState(false);
+  const [selectedRange, setSelectedRange] = useState<HistoryRangeKey>("all");
+  const [draftRange, setDraftRange] = useState<HistoryRangeKey>("all");
+  const [customRange, setCustomRange] = useState<CustomDateRange>(() => buildCustomDateRange(new Date()));
+  const [draftCustomRange, setDraftCustomRange] = useState<CustomDateRange>(() => buildCustomDateRange(new Date()));
+  const [activeDateField, setActiveDateField] = useState<"from" | "to">("from");
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  const historyParams = useMemo(
+    () => buildHistoryParams(selectedRange, customRange),
+    [customRange, selectedRange],
+  );
+  const summaryQuery = useEnvironmentSummaryQuery();
+  const historyQuery = useEnvironmentImpactHistoryQuery(historyParams);
+  const historyItems = useMemo(() => flattenHistory(historyQuery.data?.pages), [historyQuery.data?.pages]);
+  const activeRange = HISTORY_RANGE_OPTIONS.find(option => option.key === selectedRange) ?? HISTORY_RANGE_OPTIONS[0];
+
+  const handleRefresh = useCallback(async () => {
+    setIsRefreshing(true);
+    try {
+      await Promise.all([
+        summaryQuery.refetch(),
+        historyQuery.refetch(),
+      ]);
+    }
+    finally {
+      setIsRefreshing(false);
+    }
+  }, [historyQuery, summaryQuery]);
+
+  const handleOpenDetail = useCallback((rentalId: string) => {
+    navigation.navigate("EnvironmentImpactDetail", { rentalId });
+  }, [navigation]);
+
+  const handleSelectRange = useCallback((range: HistoryRangeKey) => {
+    setDraftRange(range);
+  }, []);
+
+  const handleCustomDateChange = useCallback((field: "from" | "to", date: Date) => {
+    setDraftCustomRange((current) => {
+      const next = {
+        ...current,
+        [field]: date,
+      };
+
+      if (next.from > next.to) {
+        if (field === "from") {
+          return {
+            from: date,
+            to: date,
+          };
+        }
+
+        return {
+          from: date,
+          to: date,
+        };
+      }
+
+      return next;
+    });
+  }, []);
+
+  const handleApplyCustomRange = useCallback(() => {
+    setCustomRange(draftCustomRange);
+    setSelectedRange(draftRange);
+    setIsFilterOpen(false);
+  }, [draftCustomRange, draftRange]);
+
+  const handleResetFilters = useCallback(() => {
+    const resetRange = buildCustomDateRange(new Date());
+    setCustomRange(resetRange);
+    setDraftCustomRange(resetRange);
+    setSelectedRange("all");
+    setDraftRange("all");
+    setActiveDateField("from");
+    setIsFilterOpen(false);
+  }, []);
+
+  const customRangeLabel = useMemo(() => {
+    if (selectedRange !== "custom") {
+      return null;
+    }
+
+    return `${new Intl.DateTimeFormat("vi-VN", {
+      day: "2-digit",
+      month: "2-digit",
+    }).format(customRange.from)
+    } - ${
+      new Intl.DateTimeFormat("vi-VN", {
+        day: "2-digit",
+        month: "2-digit",
+      }).format(customRange.to)}`;
+  }, [customRange, selectedRange]);
+
+  return {
+    summary: summaryQuery.data ?? null,
+    summaryError: summaryQuery.error,
+    historyItems,
+    activeRange,
+    isInitialLoading: (!summaryQuery.data && summaryQuery.isLoading)
+      || (historyItems.length === 0 && !historyQuery.data && historyQuery.isLoading),
+    initialError: summaryQuery.error ?? historyQuery.error,
+    isRefreshing: isRefreshing || summaryQuery.isRefetching || historyQuery.isRefetching,
+    hasHistoryRefreshError: Boolean(historyQuery.error) && historyItems.length > 0,
+    historyRefreshError: historyQuery.error,
+    history: {
+      hasNextPage: historyQuery.hasNextPage,
+      isFetchingNextPage: historyQuery.isFetchingNextPage,
+      fetchNextPage: historyQuery.fetchNextPage,
+    },
+    filter: {
+      isOpen: isFilterOpen,
+      options: HISTORY_RANGE_OPTIONS.filter(option => option.key !== "custom") as QuickHistoryRangeOption[],
+      customRangeLabel,
+      activeDateField,
+      draftRange,
+      customRange,
+      draftCustomRange,
+      open: () => {
+        setDraftRange(selectedRange);
+        setDraftCustomRange(customRange);
+        setActiveDateField("from");
+        setIsFilterOpen(true);
+      },
+      close: () => setIsFilterOpen(false),
+      select: handleSelectRange,
+      selectDateField: setActiveDateField,
+      changeCustomDate: handleCustomDateChange,
+      applyCustomRange: handleApplyCustomRange,
+      reset: handleResetFilters,
+    },
+    actions: {
+      goBack: () => navigation.goBack(),
+      onRefresh: handleRefresh,
+      openDetail: handleOpenDetail,
+    },
+  };
+}

--- a/apps/mobile/screen/index.ts
+++ b/apps/mobile/screen/index.ts
@@ -7,6 +7,8 @@ export { default as LoginScreen } from "./auth/login";
 export { default as RegisterScreen } from "./auth/register";
 export { default as ResetPasswordFormScreen } from "./auth/reset-password-form";
 export { default as ResetPasswordOTPScreen } from "./auth/reset-password-otp";
+export { default as EnvironmentImpactDetailScreen } from "./environment/environment-impact-detail-screen";
+export { default as EnvironmentImpactScreen } from "./environment/environment-impact-screen";
 export { default as FixedSlotDetailScreen } from "./fixed-slot-detail-screen";
 export { default as FixedSlotEditorScreen } from "./fixed-slot-editor-screen";
 export { default as FixedSlotTemplatesScreen } from "./fixed-slot-templates";

--- a/apps/mobile/services/environment/environment-error.ts
+++ b/apps/mobile/services/environment/environment-error.ts
@@ -1,0 +1,56 @@
+import type { Result } from "@lib/result";
+import type { ServiceError } from "@services/shared/service-error";
+import type { z } from "zod";
+
+import { ServerContracts } from "@mebike/shared";
+import {
+  asNetworkError as asSharedNetworkError,
+  isServiceErrorCode,
+  normalizeServiceErrorCode,
+  parseServiceError,
+
+} from "@services/shared/service-error";
+
+type ContractEnvironmentErrorCode = z.infer<
+  typeof ServerContracts.EnvironmentErrorCodeSchema
+>;
+
+export type EnvironmentErrorCode
+  = | ContractEnvironmentErrorCode
+    | "UNAUTHORIZED"
+    | "UNKNOWN"
+    | "VALIDATION_ERROR";
+
+export type EnvironmentError = ServiceError<EnvironmentErrorCode>;
+
+export function isEnvironmentContractErrorCode(
+  code: string,
+): code is ContractEnvironmentErrorCode {
+  return ServerContracts.EnvironmentErrorCodeSchema.safeParse(code).success;
+}
+
+export function isEnvironmentErrorCode(code: string): code is EnvironmentErrorCode {
+  return code === "VALIDATION_ERROR"
+    || isServiceErrorCode(code, isEnvironmentContractErrorCode);
+}
+
+function mapEnvironmentErrorCode(code: string | undefined): EnvironmentErrorCode | null {
+  if (code === "VALIDATION_ERROR") {
+    return code;
+  }
+
+  return normalizeServiceErrorCode(code, isEnvironmentContractErrorCode);
+}
+
+export async function parseEnvironmentError(response: Response): Promise<EnvironmentError> {
+  return parseServiceError(response, {
+    schema: ServerContracts.ServerErrorResponseSchema,
+    mapCode: mapEnvironmentErrorCode,
+    includeUnauthorized: true,
+    includeForbidden: true,
+  });
+}
+
+export function asNetworkError(error: unknown): Result<never, EnvironmentError> {
+  return asSharedNetworkError<Extract<EnvironmentError, { _tag: "NetworkError" }>>(error);
+}

--- a/apps/mobile/services/environment/environment.service.ts
+++ b/apps/mobile/services/environment/environment.service.ts
@@ -1,0 +1,119 @@
+import type { Result } from "@lib/result";
+
+import { decodeWithSchema, readJson } from "@lib/api-decode";
+import { kyClient } from "@lib/ky-client";
+import { err, ok } from "@lib/result";
+import { routePath, ServerRoutes } from "@lib/server-routes";
+import { ServerContracts } from "@mebike/shared";
+import { StatusCodes } from "http-status-codes";
+
+import type {
+  EnvironmentImpactDetail,
+  EnvironmentImpactHistoryQuery,
+  EnvironmentImpactHistoryResponse,
+  EnvironmentSummary,
+} from "@/contracts/server";
+
+import type { EnvironmentError } from "./environment-error";
+
+import { asNetworkError, parseEnvironmentError } from "./environment-error";
+
+function buildHistorySearchParams(params: EnvironmentImpactHistoryQuery = {}) {
+  const searchParams = new URLSearchParams();
+
+  const page = params.page ?? 1;
+  const pageSize = params.pageSize ?? 20;
+
+  searchParams.set("page", String(page));
+  searchParams.set("pageSize", String(pageSize));
+
+  if (params.sortOrder) {
+    searchParams.set("sortOrder", params.sortOrder);
+  }
+
+  if (params.dateFrom) {
+    searchParams.set("dateFrom", params.dateFrom);
+  }
+
+  if (params.dateTo) {
+    searchParams.set("dateTo", params.dateTo);
+  }
+
+  return searchParams;
+}
+
+export const environmentService = {
+  async getSummary(): Promise<Result<EnvironmentSummary, EnvironmentError>> {
+    try {
+      const response = await kyClient.get(
+        routePath(ServerRoutes.environment.getMyEnvironmentSummary),
+        { throwHttpErrors: false },
+      );
+
+      if (response.status === StatusCodes.OK) {
+        const data = await readJson(response);
+        const parsed = decodeWithSchema(
+          ServerContracts.EnvironmentContracts.EnvironmentSummarySchema,
+          data,
+        );
+        return parsed.ok ? ok(parsed.value) : err({ _tag: "DecodeError" });
+      }
+
+      return err(await parseEnvironmentError(response));
+    }
+    catch (error) {
+      return asNetworkError(error);
+    }
+  },
+
+  async getHistory(
+    params: EnvironmentImpactHistoryQuery = {},
+  ): Promise<Result<EnvironmentImpactHistoryResponse, EnvironmentError>> {
+    try {
+      const response = await kyClient.get(
+        routePath(ServerRoutes.environment.getMyEnvironmentImpactHistory),
+        {
+          searchParams: buildHistorySearchParams(params),
+          throwHttpErrors: false,
+        },
+      );
+
+      if (response.status === StatusCodes.OK) {
+        const data = await readJson(response);
+        const parsed = decodeWithSchema(
+          ServerContracts.EnvironmentContracts.EnvironmentImpactHistoryResponseSchema,
+          data,
+        );
+        return parsed.ok ? ok(parsed.value) : err({ _tag: "DecodeError" });
+      }
+
+      return err(await parseEnvironmentError(response));
+    }
+    catch (error) {
+      return asNetworkError(error);
+    }
+  },
+
+  async getDetail(rentalId: string): Promise<Result<EnvironmentImpactDetail, EnvironmentError>> {
+    try {
+      const response = await kyClient.get(
+        routePath(ServerRoutes.environment.getMyEnvironmentImpactByRental, { rentalId }),
+        { throwHttpErrors: false },
+      );
+
+      if (response.status === StatusCodes.OK) {
+        const data = await readJson(response);
+        const parsed = decodeWithSchema(
+          ServerContracts.EnvironmentContracts.EnvironmentImpactDetailSchema,
+          data,
+        );
+        return parsed.ok ? ok(parsed.value) : err({ _tag: "DecodeError" });
+      }
+
+      return err(await parseEnvironmentError(response));
+    }
+    catch (error) {
+      return asNetworkError(error);
+    }
+  },
+};

--- a/apps/mobile/services/environment/index.ts
+++ b/apps/mobile/services/environment/index.ts
@@ -1,0 +1,2 @@
+export * from "./environment-error";
+export * from "./environment.service";

--- a/apps/mobile/types/navigation.ts
+++ b/apps/mobile/types/navigation.ts
@@ -73,6 +73,10 @@ export type RootStackParamList = {
     initialSubscriptionId?: string;
     lockPaymentSelection?: boolean;
   };
+  "EnvironmentImpact": undefined;
+  "EnvironmentImpactDetail": {
+    rentalId: string;
+  };
   "FixedSlotTemplates": {
     stationId?: string;
     stationName?: string;
@@ -189,6 +193,14 @@ export type ReservationFlowNavigationProp = StackNavigationProp<
   RootStackParamList,
   "ReservationFlow"
 >;
+export type EnvironmentImpactNavigationProp = StackNavigationProp<
+  RootStackParamList,
+  "EnvironmentImpact"
+>;
+export type EnvironmentImpactDetailNavigationProp = StackNavigationProp<
+  RootStackParamList,
+  "EnvironmentImpactDetail"
+>;
 export type FixedSlotTemplatesNavigationProp = StackNavigationProp<
   RootStackParamList,
   "FixedSlotTemplates"
@@ -208,6 +220,10 @@ export type ReservationDetailRouteProp = RouteProp<
 export type ReservationFlowRouteProp = RouteProp<
   RootStackParamList,
   "ReservationFlow"
+>;
+export type EnvironmentImpactDetailRouteProp = RouteProp<
+  RootStackParamList,
+  "EnvironmentImpactDetail"
 >;
 export type FixedSlotDetailRouteProp = RouteProp<
   RootStackParamList,

--- a/apps/mobile/ui/patterns/app-bottom-modal-card.tsx
+++ b/apps/mobile/ui/patterns/app-bottom-modal-card.tsx
@@ -1,11 +1,10 @@
 import type { ReactNode } from "react";
 import type { ModalProps, StyleProp, ViewStyle } from "react-native";
 
-import { Modal, Pressable, StyleSheet, View } from "react-native";
-import { useTheme } from "tamagui";
-
 import { elevations, radii } from "@theme/metrics";
 import { AppCard } from "@ui/primitives/app-card";
+import { Modal, Pressable, StyleSheet, View } from "react-native";
+import { useTheme } from "tamagui";
 
 type SheetDimension = number | `${number}%`;
 
@@ -68,22 +67,33 @@ export function AppBottomModalCard({
       transparent
       visible={isVisible}
     >
-      <Pressable
-        onPress={onClose}
+      <View
         style={{
           flex: 1,
-          backgroundColor: theme.overlayScrim.val,
           justifyContent: "flex-end",
         }}
       >
         <Pressable
-          onPress={() => {}}
+          onPress={onClose}
+          style={[
+            StyleSheet.absoluteFillObject,
+            {
+              backgroundColor: theme.overlayScrim.val,
+            },
+          ]}
+        />
+
+        <View
+          pointerEvents="box-none"
           style={isSheet
             ? {
                 flex: 1,
                 justifyContent: "flex-end",
               }
-            : undefined}
+            : {
+                flex: 1,
+                justifyContent: "flex-end",
+              }}
         >
           <View style={resolvedContainerStyle}>
             <AppCard
@@ -101,8 +111,8 @@ export function AppBottomModalCard({
               {children}
             </AppCard>
           </View>
-        </Pressable>
-      </Pressable>
+        </View>
+      </View>
     </Modal>
   );
 }


### PR DESCRIPTION
## Summary
- add customer-facing environment impact overview and detail screens in mobile, including service/query/presenter layers wired to the new server contracts
- expose the feature from the customer profile and support quick time filters plus custom date filtering for impact history
- align the implementation with current mobile patterns and fix shared bottom-sheet backdrop behavior while keeping non-sheet callers on bottom-aligned presentation