### PR TITLE
feat(iot): add USB provisioning and tidy runtime wiring

### DIFF
--- a/apps/iot/include/MQTTManager.h
+++ b/apps/iot/include/MQTTManager.h
@@ -17,8 +17,8 @@ public:
                 std::string_view password);
     bool connect();
     void loop();
-    bool publish(const char *topic, const char *message, bool retained = false);
-    bool publish(std::string_view topic, std::string_view message, bool retained = false);
+    bool publish(const char *topic, const char *message, bool retained = false, bool logMessage = true);
+    bool publish(std::string_view topic, std::string_view message, bool retained = false, bool logMessage = true);
     bool subscribe(const char *topic);
     bool subscribe(std::string_view topic);
     void setCallback(void (*callback)(char *, byte *, unsigned int));

--- a/apps/iot/include/app/App.h
+++ b/apps/iot/include/app/App.h
@@ -3,6 +3,7 @@
 
 #include <memory>
 
+#include "Config.h"
 #include "NFCManager.h"
 #include "app/DeviceContext.h"
 #include "app/RuntimeState.h"
@@ -10,6 +11,8 @@
 #include "services/CommandConsumer.h"
 #include "services/ConnectivityService.h"
 #include "services/FeedbackController.h"
+#include "services/ProvisioningService.h"
+#include "services/RuntimeStatusPublisher.h"
 #include "services/TapPublisher.h"
 
 class App
@@ -21,12 +24,14 @@ public:
     void loop();
 
 private:
+    void initializeLogging();
+    bool loadRuntimeConfig();
+    void initializeRuntimeServices();
+    void applyFeedback();
     void setRuntimeState(RuntimeState state);
-    void publishStatusIfNeeded(bool force = false);
-    bool configLooksValid() const;
 
+    AppConfig config;
     RuntimeState runtimeState = RuntimeState::Booting;
-    RuntimeState lastPublishedState = RuntimeState::Booting;
     DeviceContext deviceContext;
     LedController ledController;
     std::unique_ptr<NFCManager> nfcManager;
@@ -34,7 +39,8 @@ private:
     std::unique_ptr<TapPublisher> tapPublisher;
     std::unique_ptr<CommandConsumer> commandConsumer;
     std::unique_ptr<FeedbackController> feedbackController;
-    unsigned long lastStatusPublishAt = 0;
+    std::unique_ptr<ProvisioningService> provisioningService;
+    std::unique_ptr<RuntimeStatusPublisher> statusPublisher;
     bool setupFailed = false;
 };
 

--- a/apps/iot/include/services/CommandConsumer.h
+++ b/apps/iot/include/services/CommandConsumer.h
@@ -3,7 +3,9 @@
 
 #include <Arduino.h>
 
+#include <optional>
 #include <string>
+#include <string_view>
 
 #include "app/DeviceContext.h"
 
@@ -14,7 +16,7 @@ struct DeviceCommand
 {
     std::string action;
     std::string requestId;
-    std::string reason;
+    std::optional<std::string> reason;
     uint32_t durationMs = 0;
 };
 
@@ -33,7 +35,7 @@ private:
     void publishAck(MQTTManager &mqttManager,
                     const DeviceCommand &command,
                     const char *status,
-                    const char *detail = nullptr);
+                    std::optional<std::string_view> detail = std::nullopt);
 
     static CommandConsumer *activeInstance;
 

--- a/apps/iot/include/services/ConnectivityService.h
+++ b/apps/iot/include/services/ConnectivityService.h
@@ -1,7 +1,7 @@
 #ifndef SERVICES_CONNECTIVITY_SERVICE_H
 #define SERVICES_CONNECTIVITY_SERVICE_H
 
-#include <memory>
+#include <optional>
 #include <string>
 
 #include <WiFiClient.h>
@@ -32,7 +32,7 @@ private:
     DeviceContext deviceContext;
     WiFiClient wifiClient;
     MQTTManager mqttManager;
-    std::string commandTopic;
+    std::optional<std::string> commandTopic;
     unsigned long lastWifiAttemptAt = 0;
     unsigned long lastMqttAttemptAt = 0;
     bool wifiStarted = false;

--- a/apps/iot/include/services/ProvisioningService.h
+++ b/apps/iot/include/services/ProvisioningService.h
@@ -1,0 +1,33 @@
+#ifndef SERVICES_PROVISIONING_SERVICE_H
+#define SERVICES_PROVISIONING_SERVICE_H
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include "Config.h"
+
+class Stream;
+
+class ProvisioningService
+{
+public:
+    explicit ProvisioningService(Stream &serial);
+
+    void poll(AppConfig &config);
+
+private:
+    void handleLine(const std::string &line, AppConfig &config);
+    void writeResponse(std::optional<std::string_view> requestId,
+                       bool ok,
+                       std::optional<std::string_view> type,
+                       std::optional<std::string_view> message,
+                       std::optional<std::string_view> error = std::nullopt) const;
+    void writeConfigResponse(const AppConfig &config, std::optional<std::string_view> requestId) const;
+    void restartDevice() const;
+
+    Stream &serial;
+    std::string buffer;
+};
+
+#endif // SERVICES_PROVISIONING_SERVICE_H

--- a/apps/iot/include/services/RuntimeStatusPublisher.h
+++ b/apps/iot/include/services/RuntimeStatusPublisher.h
@@ -1,0 +1,35 @@
+#ifndef SERVICES_RUNTIME_STATUS_PUBLISHER_H
+#define SERVICES_RUNTIME_STATUS_PUBLISHER_H
+
+#include <optional>
+
+#include "app/DeviceContext.h"
+#include "app/RuntimeState.h"
+
+class MQTTManager;
+
+class RuntimeStatusPublisher
+{
+public:
+    explicit RuntimeStatusPublisher(const DeviceContext &deviceContext);
+
+    void publishIfNeeded(MQTTManager &mqttManager,
+                         RuntimeState runtimeState,
+                         bool wifiConnected,
+                         bool mqttConnected,
+                         bool nfcHealthy,
+                         bool force = false);
+
+private:
+    void logPublishedStatus(RuntimeState runtimeState,
+                            unsigned long timestampMs,
+                            bool wifiConnected,
+                            bool mqttConnected,
+                            bool nfcHealthy) const;
+
+    DeviceContext deviceContext;
+    RuntimeState lastPublishedState = RuntimeState::Booting;
+    std::optional<unsigned long> lastPublishedAt;
+};
+
+#endif // SERVICES_RUNTIME_STATUS_PUBLISHER_H

--- a/apps/iot/lib/Config/Config.cpp
+++ b/apps/iot/lib/Config/Config.cpp
@@ -3,24 +3,39 @@
 #include "SPIFFS.h"
 #include <ArduinoLog.h>
 
+namespace
+{
+constexpr const char *CONFIG_PATH = "/.env";
+
+bool ensureConfigFilesystemMounted()
+{
+    if (!SPIFFS.begin(true))
+    {
+        Log.error("An error occurred while mounting SPIFFS\n");
+        return false;
+    }
+
+    return true;
+}
+}
+
 AppConfig loadConfig()
 {
     AppConfig config;
 
-    if (!SPIFFS.begin(true))
+    if (!ensureConfigFilesystemMounted())
     {
-        Log.error("An error occurred while mounting SPIFFS");
         return config;
     }
 
-    File file = SPIFFS.open("/.env");
+    File file = SPIFFS.open(CONFIG_PATH);
     if (!file)
     {
-        Log.error("Failed to open .env file for reading");
+        Log.error("Failed to open .env file for reading\n");
         return config;
     }
 
-    Log.info("Reading configuration from .env file:");
+    Log.info("Reading configuration from .env file\n");
 
     while (file.available())
     {
@@ -73,7 +88,47 @@ AppConfig loadConfig()
             }
         }
     }
-    Log.info("Loaded config from .env file:\n");
+    Log.info("Loaded config from .env file\n");
     file.close();
     return config;
+}
+
+bool saveConfig(const AppConfig &config)
+{
+    if (!ensureConfigFilesystemMounted())
+    {
+        return false;
+    }
+
+    File file = SPIFFS.open(CONFIG_PATH, FILE_WRITE, true);
+    if (!file)
+    {
+        Log.error("Failed to open .env file for writing\n");
+        return false;
+    }
+
+    file.seek(0, SeekSet);
+    file.print("BIKE_ID=");
+    file.println(config.bikeId.c_str());
+    file.print("WIFI_SSID=");
+    file.println(config.wifiSsid.c_str());
+    file.print("WIFI_PASS=");
+    file.println(config.wifiPass.c_str());
+    file.print("MQTT_BROKER_IP=");
+    file.println(config.mqttBrokerIP.c_str());
+    file.print("MQTT_PORT=");
+    file.println(config.mqttPort);
+    file.print("MQTT_USERNAME=");
+    file.println(config.mqttUsername.c_str());
+    file.print("MQTT_PASSWORD=");
+    file.println(config.mqttPassword.c_str());
+    file.close();
+
+    Log.notice("Saved runtime config to SPIFFS\n");
+    return true;
+}
+
+bool isConfigValid(const AppConfig &config)
+{
+    return !config.bikeId.empty() && !config.wifiSsid.empty() && !config.mqttBrokerIP.empty() && config.mqttPort > 0;
 }

--- a/apps/iot/lib/Config/Config.h
+++ b/apps/iot/lib/Config/Config.h
@@ -15,5 +15,7 @@ struct AppConfig
 };
 
 AppConfig loadConfig();
+bool saveConfig(const AppConfig &config);
+bool isConfigValid(const AppConfig &config);
 
 #endif

--- a/apps/iot/platformio.ini
+++ b/apps/iot/platformio.ini
@@ -30,7 +30,7 @@ build_flags =
 	-isystem $PROJECT_CORE_DIR/.pio/libdeps/esp32dev/ArduinoLog/src
 	-isystem $PROJECT_CORE_DIR/.pio/libdeps/esp32dev/PubSubClient/src
 monitor_port = /dev/ttyUSB0
-monitor_speed = 74880
+monitor_speed = 115200
 upload_port = /dev/ttyUSB0
 upload_speed = 115200
 board_build.filesystem = spiffs

--- a/apps/iot/src/app/App.cpp
+++ b/apps/iot/src/app/App.cpp
@@ -1,36 +1,25 @@
 #include "app/App.h"
 
-#include <ArduinoJson.h>
+#include <Arduino.h>
 #include <ArduinoLog.h>
 #include <Wire.h>
 
 #include "Config.h"
 #include "HardwareConfig.h"
-#include "NFCManager.h"
-#include "services/CommandConsumer.h"
-#include "services/ConnectivityService.h"
-#include "services/FeedbackController.h"
-#include "services/TapPublisher.h"
-
-namespace
-{
-constexpr unsigned long STATUS_HEARTBEAT_INTERVAL_MS = 15000;
-}
 
 App::~App() = default;
 
 void App::setup()
 {
-    Serial.begin(74880);
-    Log.begin(LOG_LEVEL_VERBOSE, &Serial);
+    initializeLogging();
+    provisioningService = std::make_unique<ProvisioningService>(Serial);
 
     ledController.begin();
     feedbackController = std::make_unique<FeedbackController>();
 
     setRuntimeState(RuntimeState::Booting);
 
-    const AppConfig config = loadConfig();
-    if (config.bikeId.empty() || config.wifiSsid.empty() || config.mqttBrokerIP.empty() || config.mqttPort <= 0)
+    if (!loadRuntimeConfig())
     {
         Log.error("Missing required bike, WiFi, or MQTT configuration\n");
         setupFailed = true;
@@ -38,34 +27,20 @@ void App::setup()
         return;
     }
 
-    deviceContext = makeDeviceContext(config.bikeId);
-    Log.notice("Device adapter booting as bike %s\n", deviceContext.deviceId.c_str());
-
-    Wire.begin(HardwareConfig::I2C_SDA_PIN, HardwareConfig::I2C_SCL_PIN);
-
-    nfcManager = std::make_unique<NFCManager>();
-    if (!nfcManager->begin())
-    {
-        Log.warning("PN532 not available at boot; recovery will continue in background\n");
-    }
-
-    connectivityService = std::make_unique<ConnectivityService>(config, deviceContext);
-    connectivityService->setCommandTopic(deviceContext.topics.commandTopic);
-
-    commandConsumer = std::make_unique<CommandConsumer>(deviceContext);
-    commandConsumer->attach(connectivityService->mqtt());
-
-    tapPublisher = std::make_unique<TapPublisher>(*nfcManager, deviceContext);
-
-    connectivityService->begin();
+    initializeRuntimeServices();
     setRuntimeState(RuntimeState::Offline);
 }
 
 void App::loop()
 {
+    if (provisioningService != nullptr)
+    {
+        provisioningService->poll(config);
+    }
+
     RuntimeState nextState = RuntimeState::Offline;
 
-    if (setupFailed || feedbackController == nullptr)
+    if (setupFailed || feedbackController == nullptr || connectivityService == nullptr || commandConsumer == nullptr || tapPublisher == nullptr)
     {
         nextState = RuntimeState::Error;
     }
@@ -94,7 +69,14 @@ void App::loop()
             }
 
             setRuntimeState(nextState);
-            publishStatusIfNeeded();
+            if (statusPublisher != nullptr)
+            {
+                statusPublisher->publishIfNeeded(connectivityService->mqtt(),
+                                                runtimeState,
+                                                connectivityService->isWifiConnected(),
+                                                connectivityService->isReady(),
+                                                nfcManager != nullptr && nfcManager->isHealthy());
+            }
         }
         else if (nfcManager != nullptr && !nfcManager->isHealthy())
         {
@@ -107,6 +89,50 @@ void App::loop()
         }
     }
 
+    applyFeedback();
+    delay(5);
+}
+
+void App::initializeLogging()
+{
+    Serial.begin(115200);
+    Log.begin(LOG_LEVEL_VERBOSE, &Serial);
+}
+
+bool App::loadRuntimeConfig()
+{
+    config = loadConfig();
+    return isConfigValid(config);
+}
+
+void App::initializeRuntimeServices()
+{
+    deviceContext = makeDeviceContext(config.bikeId);
+    Log.notice("Device adapter booting as bike %s\n", deviceContext.deviceId.c_str());
+
+    statusPublisher = std::make_unique<RuntimeStatusPublisher>(deviceContext);
+
+    Wire.begin(HardwareConfig::I2C_SDA_PIN, HardwareConfig::I2C_SCL_PIN);
+
+    nfcManager = std::make_unique<NFCManager>();
+    if (!nfcManager->begin())
+    {
+        Log.warning("PN532 not available at boot; recovery will continue in background\n");
+    }
+
+    connectivityService = std::make_unique<ConnectivityService>(config, deviceContext);
+    connectivityService->setCommandTopic(deviceContext.topics.commandTopic);
+
+    commandConsumer = std::make_unique<CommandConsumer>(deviceContext);
+    commandConsumer->attach(connectivityService->mqtt());
+
+    tapPublisher = std::make_unique<TapPublisher>(*nfcManager, deviceContext);
+
+    connectivityService->begin();
+}
+
+void App::applyFeedback()
+{
     if (feedbackController != nullptr)
     {
         feedbackController->update(ledController, runtimeState);
@@ -116,50 +142,9 @@ void App::loop()
         ledController.setMode(LedMode::BlinkRed);
         ledController.update();
     }
-
-    delay(5);
 }
 
 void App::setRuntimeState(RuntimeState state)
 {
     runtimeState = state;
-}
-
-void App::publishStatusIfNeeded(bool force)
-{
-    if (connectivityService == nullptr || !connectivityService->isReady())
-    {
-        return;
-    }
-
-    const unsigned long now = millis();
-    const bool stateChanged = runtimeState != lastPublishedState;
-    const bool heartbeatDue = lastStatusPublishAt == 0 || now - lastStatusPublishAt >= STATUS_HEARTBEAT_INTERVAL_MS;
-    if (!force && !stateChanged && !heartbeatDue)
-    {
-        return;
-    }
-
-    StaticJsonDocument<192> doc;
-    doc["deviceId"] = deviceContext.deviceId.c_str();
-    doc["runtimeState"] = runtimeStateName(runtimeState);
-    doc["wifiConnected"] = connectivityService->isWifiConnected();
-    doc["mqttConnected"] = connectivityService->isReady();
-    doc["nfcHealthy"] = nfcManager != nullptr && nfcManager->isHealthy();
-    doc["timestampMs"] = now;
-
-    char payload[192];
-    const size_t payloadLength = serializeJson(doc, payload, sizeof(payload));
-    if (payloadLength == 0 || payloadLength >= sizeof(payload))
-    {
-        Log.error("Failed to serialize runtime status\n");
-        return;
-    }
-
-    if (connectivityService->mqtt().publish(deviceContext.topics.statusTopic, payload, true))
-    {
-        lastPublishedState = runtimeState;
-        lastStatusPublishAt = now;
-        Log.verbose("Published runtime status %s\n", runtimeStateName(runtimeState));
-    }
 }

--- a/apps/iot/src/managers/MQTTManager.cpp
+++ b/apps/iot/src/managers/MQTTManager.cpp
@@ -46,11 +46,14 @@ void MQTTManager::loop()
     _client.loop();
 }
 
-bool MQTTManager::publish(const char *topic, const char *message, bool retained)
+bool MQTTManager::publish(const char *topic, const char *message, bool retained, bool logMessage)
 {
     if (_client.publish(topic, message, retained))
     {
-        Log.info("Published to %s: %s\n", topic, message);
+        if (logMessage)
+        {
+            Log.info("Published to %s: %s\n", topic, message);
+        }
         return true;
     }
     else
@@ -60,11 +63,11 @@ bool MQTTManager::publish(const char *topic, const char *message, bool retained)
     }
 }
 
-bool MQTTManager::publish(std::string_view topic, std::string_view message, bool retained)
+bool MQTTManager::publish(std::string_view topic, std::string_view message, bool retained, bool logMessage)
 {
     std::string topicBuffer(topic);
     std::string messageBuffer(message);
-    return publish(topicBuffer.c_str(), messageBuffer.c_str(), retained);
+    return publish(topicBuffer.c_str(), messageBuffer.c_str(), retained, logMessage);
 }
 
 bool MQTTManager::subscribe(const char *topic)

--- a/apps/iot/src/services/CommandConsumer.cpp
+++ b/apps/iot/src/services/CommandConsumer.cpp
@@ -143,14 +143,15 @@ void CommandConsumer::publishAck(MQTTManager &mqttManager,
                                  std::optional<std::string_view> detail)
 {
     StaticJsonDocument<192> doc;
+    std::optional<std::string> ownedDetail;
     doc["deviceId"] = deviceContext.deviceId.c_str();
     doc["requestId"] = command.requestId.c_str();
     doc["action"] = command.action.c_str();
     doc["status"] = status;
     if (detail.has_value())
     {
-        const std::string detailText(detail->data(), detail->size());
-        doc["detail"] = detailText.c_str();
+        ownedDetail.emplace(detail->data(), detail->size());
+        doc["detail"] = ownedDetail->c_str();
     }
 
     char payload[192];

--- a/apps/iot/src/services/CommandConsumer.cpp
+++ b/apps/iot/src/services/CommandConsumer.cpp
@@ -6,6 +6,26 @@
 #include "MQTTManager.h"
 #include "services/FeedbackController.h"
 
+namespace
+{
+std::optional<std::string> readOptionalStringField(const JsonDocument &doc, const char *key)
+{
+    JsonVariantConst value = doc[key];
+    if (value.isUnbound() || value.isNull())
+    {
+        return std::nullopt;
+    }
+
+    const char *text = value.as<const char *>();
+    if (text == nullptr || text[0] == '\0')
+    {
+        return std::nullopt;
+    }
+
+    return std::string(text);
+}
+}
+
 CommandConsumer *CommandConsumer::activeInstance = nullptr;
 
 CommandConsumer::CommandConsumer(const DeviceContext &deviceContext)
@@ -29,7 +49,7 @@ bool CommandConsumer::processPending(MQTTManager &mqttManager, FeedbackControlle
     DeviceCommand command;
     if (!parsePendingCommand(command))
     {
-        const DeviceCommand invalidCommand{"invalid", "", "invalid_payload", 0};
+        const DeviceCommand invalidCommand{"invalid", "", std::nullopt, 0};
         publishAck(mqttManager, invalidCommand, "rejected", "invalid_payload");
         feedbackController.signalCommandFailed();
         hasPendingMessage = false;
@@ -51,7 +71,10 @@ bool CommandConsumer::processPending(MQTTManager &mqttManager, FeedbackControlle
     if (command.action == "deny")
     {
         feedbackController.signalAccessDenied();
-        publishAck(mqttManager, command, "done", command.reason.empty() ? "denied" : command.reason.c_str());
+        publishAck(mqttManager,
+                   command,
+                   "done",
+                   command.reason.has_value() ? std::optional<std::string_view>(*command.reason) : std::optional<std::string_view>("denied"));
         Log.notice("Executed deny command %s\n", command.requestId.c_str());
         return true;
     }
@@ -101,7 +124,7 @@ bool CommandConsumer::parsePendingCommand(DeviceCommand &command)
     {
         command.action = pendingPayload;
         command.requestId = "";
-        command.reason = "";
+        command.reason = std::nullopt;
         command.durationMs = 0;
         return !command.action.empty();
     }
@@ -109,7 +132,7 @@ bool CommandConsumer::parsePendingCommand(DeviceCommand &command)
     const char *action = doc["action"] | "";
     command.action = action;
     command.requestId = doc["requestId"] | "";
-    command.reason = doc["reason"] | "";
+    command.reason = readOptionalStringField(doc, "reason");
     command.durationMs = doc["durationMs"] | 0;
     return !command.action.empty();
 }
@@ -117,16 +140,17 @@ bool CommandConsumer::parsePendingCommand(DeviceCommand &command)
 void CommandConsumer::publishAck(MQTTManager &mqttManager,
                                  const DeviceCommand &command,
                                  const char *status,
-                                 const char *detail)
+                                 std::optional<std::string_view> detail)
 {
     StaticJsonDocument<192> doc;
     doc["deviceId"] = deviceContext.deviceId.c_str();
     doc["requestId"] = command.requestId.c_str();
     doc["action"] = command.action.c_str();
     doc["status"] = status;
-    if (detail != nullptr)
+    if (detail.has_value())
     {
-        doc["detail"] = detail;
+        const std::string detailText(detail->data(), detail->size());
+        doc["detail"] = detailText.c_str();
     }
 
     char payload[192];

--- a/apps/iot/src/services/ConnectivityService.cpp
+++ b/apps/iot/src/services/ConnectivityService.cpp
@@ -103,9 +103,9 @@ void ConnectivityService::ensureMqttConnected()
 {
     if (mqttManager.isConnected())
     {
-        if (!commandTopicSubscribed && !commandTopic.empty())
+        if (!commandTopicSubscribed && commandTopic.has_value())
         {
-            commandTopicSubscribed = mqttManager.subscribe(commandTopic);
+            commandTopicSubscribed = mqttManager.subscribe(*commandTopic);
         }
         return;
     }
@@ -123,9 +123,9 @@ void ConnectivityService::ensureMqttConnected()
     }
 
     commandTopicSubscribed = false;
-    if (!commandTopic.empty())
+    if (commandTopic.has_value())
     {
-        commandTopicSubscribed = mqttManager.subscribe(commandTopic);
+        commandTopicSubscribed = mqttManager.subscribe(*commandTopic);
     }
     Log.notice("Device MQTT session ready on %s\n", deviceContext.topics.commandTopic.c_str());
 }

--- a/apps/iot/src/services/ProvisioningService.cpp
+++ b/apps/iot/src/services/ProvisioningService.cpp
@@ -1,0 +1,220 @@
+#include "services/ProvisioningService.h"
+
+#include <Arduino.h>
+#include <ArduinoJson.h>
+#include <ArduinoLog.h>
+
+namespace
+{
+constexpr size_t MAX_PROVISIONING_LINE_LENGTH = 512;
+constexpr const char *PROVISIONING_PREFIX = "CFG ";
+
+std::optional<std::string_view> readOptionalStringField(const JsonDocument &doc, const char *key)
+{
+    JsonVariantConst value = doc[key];
+    if (value.isUnbound() || value.isNull())
+    {
+        return std::nullopt;
+    }
+
+    const char *text = value.as<const char *>();
+    if (text == nullptr)
+    {
+        return std::nullopt;
+    }
+
+    return std::string_view(text);
+}
+}
+
+ProvisioningService::ProvisioningService(Stream &serial)
+    : serial(serial)
+{
+}
+
+void ProvisioningService::poll(AppConfig &config)
+{
+    while (serial.available() > 0)
+    {
+        const int nextByte = serial.read();
+        if (nextByte < 0)
+        {
+            break;
+        }
+
+        const char nextChar = static_cast<char>(nextByte);
+        if (nextChar == '\r')
+        {
+            continue;
+        }
+
+        if (nextChar == '\n')
+        {
+            if (!buffer.empty())
+            {
+                handleLine(buffer, config);
+                buffer.clear();
+            }
+            continue;
+        }
+
+        buffer.push_back(nextChar);
+        if (buffer.size() > MAX_PROVISIONING_LINE_LENGTH)
+        {
+            buffer.clear();
+            Log.warning("Provisioning input too long, dropping line\n");
+        }
+    }
+}
+
+void ProvisioningService::handleLine(const std::string &line, AppConfig &config)
+{
+    if (line.rfind(PROVISIONING_PREFIX, 0) != 0)
+    {
+        return;
+    }
+
+    StaticJsonDocument<384> request;
+    const std::string payload = line.substr(strlen(PROVISIONING_PREFIX));
+    const DeserializationError error = deserializeJson(request, payload.c_str());
+    const std::optional<std::string_view> requestId = readOptionalStringField(request, "requestId");
+
+    if (error)
+    {
+        writeResponse(requestId, false, nullptr, error.c_str(), "invalid_json");
+        return;
+    }
+
+    const std::optional<std::string_view> type = readOptionalStringField(request, "type");
+    if (type == "get-config")
+    {
+        writeConfigResponse(config, requestId);
+        return;
+    }
+
+    if (type == "set-config")
+    {
+        AppConfig nextConfig = config;
+
+        if (request.containsKey("bikeId"))
+        {
+            nextConfig.bikeId = request["bikeId"] | "";
+        }
+        if (request.containsKey("wifiSsid"))
+        {
+            nextConfig.wifiSsid = request["wifiSsid"] | "";
+        }
+        if (request.containsKey("wifiPass"))
+        {
+            nextConfig.wifiPass = request["wifiPass"] | "";
+        }
+        if (request.containsKey("mqttBrokerIP"))
+        {
+            nextConfig.mqttBrokerIP = request["mqttBrokerIP"] | "";
+        }
+        if (request.containsKey("mqttPort"))
+        {
+            nextConfig.mqttPort = request["mqttPort"] | 0;
+        }
+        if (request.containsKey("mqttUsername"))
+        {
+            nextConfig.mqttUsername = request["mqttUsername"] | "";
+        }
+        if (request.containsKey("mqttPassword"))
+        {
+            nextConfig.mqttPassword = request["mqttPassword"] | "";
+        }
+
+        if (!isConfigValid(nextConfig))
+        {
+            writeResponse(requestId,
+                          false,
+                          type,
+                          "bikeId, wifiSsid, mqttBrokerIP, and mqttPort are required",
+                          "invalid_config");
+            return;
+        }
+
+        if (!saveConfig(nextConfig))
+        {
+            writeResponse(requestId, false, type, "failed to persist config", "save_failed");
+            return;
+        }
+
+        config = nextConfig;
+        writeResponse(requestId, true, type, "config saved, restarting");
+        restartDevice();
+        return;
+    }
+
+    if (type == "restart")
+    {
+        writeResponse(requestId, true, type, "restarting");
+        restartDevice();
+        return;
+    }
+
+    writeResponse(requestId, false, std::nullopt, type, "unknown_command");
+}
+
+void ProvisioningService::writeResponse(std::optional<std::string_view> requestId,
+                                        bool ok,
+                                        std::optional<std::string_view> type,
+                                        std::optional<std::string_view> message,
+                                        std::optional<std::string_view> error) const
+{
+    StaticJsonDocument<384> response;
+    response["channel"] = "config";
+    response["ok"] = ok;
+
+    if (requestId.has_value())
+    {
+        response["requestId"] = requestId->data();
+    }
+    if (type.has_value())
+    {
+        response["type"] = type->data();
+    }
+    if (error.has_value())
+    {
+        response["error"] = error->data();
+    }
+    if (message.has_value())
+    {
+        response["message"] = message->data();
+    }
+
+    serial.print(PROVISIONING_PREFIX);
+    serializeJson(response, serial);
+    serial.print('\n');
+}
+
+void ProvisioningService::writeConfigResponse(const AppConfig &config, std::optional<std::string_view> requestId) const
+{
+    StaticJsonDocument<384> response;
+    response["channel"] = "config";
+    response["ok"] = true;
+    response["type"] = "get-config";
+    if (requestId.has_value())
+    {
+        response["requestId"] = requestId->data();
+    }
+    response["bikeId"] = config.bikeId.c_str();
+    response["wifiSsid"] = config.wifiSsid.c_str();
+    response["wifiPass"] = config.wifiPass.c_str();
+    response["mqttBrokerIP"] = config.mqttBrokerIP.c_str();
+    response["mqttPort"] = config.mqttPort;
+    response["mqttUsername"] = config.mqttUsername.c_str();
+    response["mqttPassword"] = config.mqttPassword.c_str();
+
+    serial.print(PROVISIONING_PREFIX);
+    serializeJson(response, serial);
+    serial.print('\n');
+}
+
+void ProvisioningService::restartDevice() const
+{
+    serial.flush();
+    delay(200);
+    ESP.restart();
+}

--- a/apps/iot/src/services/RuntimeStatusPublisher.cpp
+++ b/apps/iot/src/services/RuntimeStatusPublisher.cpp
@@ -1,0 +1,80 @@
+#include "services/RuntimeStatusPublisher.h"
+
+#include <Arduino.h>
+#include <ArduinoJson.h>
+#include <ArduinoLog.h>
+
+#include "MQTTManager.h"
+
+namespace
+{
+constexpr unsigned long STATUS_HEARTBEAT_INTERVAL_MS = 15000;
+}
+
+RuntimeStatusPublisher::RuntimeStatusPublisher(const DeviceContext &deviceContext)
+    : deviceContext(deviceContext)
+{
+}
+
+void RuntimeStatusPublisher::publishIfNeeded(MQTTManager &mqttManager,
+                                             RuntimeState runtimeState,
+                                             bool wifiConnected,
+                                             bool mqttConnected,
+                                             bool nfcHealthy,
+                                             bool force)
+{
+    const unsigned long now = millis();
+    const bool stateChanged = runtimeState != lastPublishedState;
+    const bool heartbeatDue = !lastPublishedAt.has_value() || now - *lastPublishedAt >= STATUS_HEARTBEAT_INTERVAL_MS;
+    if (!force && !stateChanged && !heartbeatDue)
+    {
+        return;
+    }
+
+    StaticJsonDocument<192> doc;
+    doc["deviceId"] = deviceContext.deviceId.c_str();
+    doc["runtimeState"] = runtimeStateName(runtimeState);
+    doc["wifiConnected"] = wifiConnected;
+    doc["mqttConnected"] = mqttConnected;
+    doc["nfcHealthy"] = nfcHealthy;
+    doc["timestampMs"] = now;
+
+    char payload[192];
+    const size_t payloadLength = serializeJson(doc, payload, sizeof(payload));
+    if (payloadLength == 0 || payloadLength >= sizeof(payload))
+    {
+        Log.error("Failed to serialize runtime status\n");
+        return;
+    }
+
+    if (mqttManager.publish(deviceContext.topics.statusTopic, payload, true, false))
+    {
+        lastPublishedState = runtimeState;
+        lastPublishedAt = now;
+        logPublishedStatus(runtimeState, now, wifiConnected, mqttConnected, nfcHealthy);
+    }
+}
+
+void RuntimeStatusPublisher::logPublishedStatus(RuntimeState runtimeState,
+                                                unsigned long timestampMs,
+                                                bool wifiConnected,
+                                                bool mqttConnected,
+                                                bool nfcHealthy) const
+{
+    Log.info(
+        "Published runtime status\n"
+        "  topic: %s\n"
+        "  deviceId: %s\n"
+        "  runtimeState: %s\n"
+        "  wifiConnected: %s\n"
+        "  mqttConnected: %s\n"
+        "  nfcHealthy: %s\n"
+        "  timestampMs: %lu\n",
+        deviceContext.topics.statusTopic.c_str(),
+        deviceContext.deviceId.c_str(),
+        runtimeStateName(runtimeState),
+        wifiConnected ? "true" : "false",
+        mqttConnected ? "true" : "false",
+        nfcHealthy ? "true" : "false",
+        timestampMs);
+}


### PR DESCRIPTION
## Summary
- add a USB serial provisioning path so the ESP32 can read, update, and persist bike, Wi-Fi, and MQTT config over the local CLI
- extract provisioning and runtime status publishing out of `App.cpp` so the app file keeps the runtime flow while the protocol and status mechanics live behind dedicated services
- improve firmware ergonomics with readable multiline status logs, standardize serial/monitor baud at `115200`, and replace a few sentinel values with `std::optional` where absence is a real state