### PR TITLE
feat(mobile): migrate change password screen

### DIFF
--- a/apps/mobile/presenters/users/user-error-presenter.ts
+++ b/apps/mobile/presenters/users/user-error-presenter.ts
@@ -12,6 +12,7 @@ const userErrorMessages = {
   avatarImageDimensionsTooLarge: "Kích thước ảnh quá lớn. Vui lòng chọn ảnh nhỏ hơn để tiếp tục.",
   avatarUploadUnavailable: "Dịch vụ tải ảnh tạm thời không khả dụng. Vui lòng thử lại sau.",
   duplicatePhoneNumber: "Số điện thoại đã được sử dụng.",
+  invalidCurrentPassword: "Mật khẩu hiện tại không đúng.",
   invalidAvatarImage: "Ảnh đại diện không hợp lệ. Hãy chọn ảnh JPG, PNG hoặc WEBP.",
   networkError: "Không thể kết nối tới máy chủ. Vui lòng thử lại.",
   unauthorized: "Phiên đăng nhập đã hết hạn. Vui lòng đăng nhập lại.",
@@ -35,6 +36,8 @@ export function presentUserError(
         return userErrorMessages.avatarUploadUnavailable;
       case "DUPLICATE_PHONE_NUMBER":
         return userErrorMessages.duplicatePhoneNumber;
+      case "INVALID_CURRENT_PASSWORD":
+        return userErrorMessages.invalidCurrentPassword;
       case "USER_NOT_FOUND":
         return userErrorMessages.userNotFound;
       case "UNAUTHORIZED":

--- a/apps/mobile/screen/account/change-password/change-password.schema.ts
+++ b/apps/mobile/screen/account/change-password/change-password.schema.ts
@@ -1,0 +1,20 @@
+import * as z from "zod";
+
+export const changePasswordSchema = z
+  .object({
+    oldPassword: z.string()
+      .min(1, { message: "Vui lòng nhập mật khẩu hiện tại." })
+      .min(8, { message: "Mật khẩu hiện tại phải có ít nhất 8 ký tự." }),
+    newPassword: z.string()
+      .min(1, { message: "Vui lòng nhập mật khẩu mới." })
+      .min(8, { message: "Mật khẩu mới phải có ít nhất 8 ký tự." }),
+    confirmPassword: z.string()
+      .min(1, { message: "Vui lòng xác nhận mật khẩu mới." })
+      .min(8, { message: "Mật khẩu xác nhận phải có ít nhất 8 ký tự." }),
+  })
+  .refine(data => data.newPassword === data.confirmPassword, {
+    message: "Mật khẩu xác nhận không khớp.",
+    path: ["confirmPassword"],
+  });
+
+export type ChangePasswordFormValues = z.infer<typeof changePasswordSchema>;

--- a/apps/mobile/screen/account/change-password/components/change-password-form.tsx
+++ b/apps/mobile/screen/account/change-password/components/change-password-form.tsx
@@ -54,8 +54,10 @@ export function ChangePasswordForm({
               <AppInput
                 autoCapitalize="none"
                 autoCorrect={false}
+                fieldSize="large"
+                fontWeight="400"
                 invalid={Boolean(errors.oldPassword?.message)}
-                leadingIcon={<IconSymbol color={theme.textSecondary.val} name="lock" size="input" />}
+                leadingIcon={<IconSymbol color={theme.textSecondary.val} name="lock" size="md" />}
                 onBlur={onBlur}
                 onChangeText={onChange}
                 placeholder="Nhập mật khẩu hiện tại"
@@ -76,8 +78,10 @@ export function ChangePasswordForm({
               <AppInput
                 autoCapitalize="none"
                 autoCorrect={false}
+                fieldSize="large"
+                fontWeight="400"
                 invalid={Boolean(errors.newPassword?.message)}
-                leadingIcon={<IconSymbol color={theme.textSecondary.val} name="lock" size="input" />}
+                leadingIcon={<IconSymbol color={theme.textSecondary.val} name="lock" size="md" />}
                 onBlur={onBlur}
                 onChangeText={onChange}
                 placeholder="Nhập mật khẩu mới"
@@ -102,8 +106,10 @@ export function ChangePasswordForm({
               <AppInput
                 autoCapitalize="none"
                 autoCorrect={false}
+                fieldSize="large"
+                fontWeight="400"
                 invalid={Boolean(errors.confirmPassword?.message)}
-                leadingIcon={<IconSymbol color={theme.textSecondary.val} name="lock" size="input" />}
+                leadingIcon={<IconSymbol color={theme.textSecondary.val} name="lock" size="md" />}
                 onBlur={onBlur}
                 onChangeText={onChange}
                 onSubmitEditing={onSubmit}

--- a/apps/mobile/screen/account/change-password/components/change-password-form.tsx
+++ b/apps/mobile/screen/account/change-password/components/change-password-form.tsx
@@ -1,0 +1,123 @@
+import type { Control, FieldErrors } from "react-hook-form";
+
+import { IconSymbol } from "@components/IconSymbol";
+import { AppInput } from "@ui/primitives/app-input";
+import { Field } from "@ui/primitives/field";
+import { Controller } from "react-hook-form";
+import { Pressable } from "react-native";
+import { useTheme, YStack } from "tamagui";
+
+import type { ChangePasswordFormValues } from "../change-password.schema";
+
+type PasswordField = "oldPassword" | "newPassword" | "confirmPassword";
+
+type ChangePasswordFormProps = {
+  control: Control<ChangePasswordFormValues>;
+  errors: FieldErrors<ChangePasswordFormValues>;
+  onSubmit: () => void;
+  visibleFields: Record<PasswordField, boolean>;
+  onToggleFieldVisibility: (field: PasswordField) => void;
+};
+
+export function ChangePasswordForm({
+  control,
+  errors,
+  onSubmit,
+  visibleFields,
+  onToggleFieldVisibility,
+}: ChangePasswordFormProps) {
+  const theme = useTheme();
+
+  const buildVisibilityToggle = (field: PasswordField) => (
+    <Pressable
+      accessibilityLabel={visibleFields[field] ? "Ẩn mật khẩu" : "Hiện mật khẩu"}
+      hitSlop={8}
+      onPress={() => onToggleFieldVisibility(field)}
+      style={({ pressed }) => ({ opacity: pressed ? 0.72 : 1 })}
+    >
+      <IconSymbol
+        color={theme.textSecondary.val}
+        name={visibleFields[field] ? "eye-off" : "eye"}
+        size="input"
+      />
+    </Pressable>
+  );
+
+  return (
+    <YStack gap="$6">
+      <YStack gap="$4">
+        <Field error={errors.oldPassword?.message} label="Mật khẩu hiện tại">
+          <Controller
+            control={control}
+            name="oldPassword"
+            render={({ field: { onBlur, onChange, value } }) => (
+              <AppInput
+                autoCapitalize="none"
+                autoCorrect={false}
+                invalid={Boolean(errors.oldPassword?.message)}
+                leadingIcon={<IconSymbol color={theme.textSecondary.val} name="lock" size="input" />}
+                onBlur={onBlur}
+                onChangeText={onChange}
+                placeholder="Nhập mật khẩu hiện tại"
+                secureTextEntry={!visibleFields.oldPassword}
+                textContentType="password"
+                trailingIcon={buildVisibilityToggle("oldPassword")}
+                value={value}
+              />
+            )}
+          />
+        </Field>
+
+        <Field error={errors.newPassword?.message} label="Mật khẩu mới">
+          <Controller
+            control={control}
+            name="newPassword"
+            render={({ field: { onBlur, onChange, value } }) => (
+              <AppInput
+                autoCapitalize="none"
+                autoCorrect={false}
+                invalid={Boolean(errors.newPassword?.message)}
+                leadingIcon={<IconSymbol color={theme.textSecondary.val} name="lock" size="input" />}
+                onBlur={onBlur}
+                onChangeText={onChange}
+                placeholder="Nhập mật khẩu mới"
+                secureTextEntry={!visibleFields.newPassword}
+                textContentType="newPassword"
+                trailingIcon={buildVisibilityToggle("newPassword")}
+                value={value}
+              />
+            )}
+          />
+        </Field>
+
+        <Field
+          description="Mật khẩu mới nên khác mật khẩu cũ và đủ dễ để bạn ghi nhớ."
+          error={errors.confirmPassword?.message}
+          label="Xác nhận mật khẩu mới"
+        >
+          <Controller
+            control={control}
+            name="confirmPassword"
+            render={({ field: { onBlur, onChange, value } }) => (
+              <AppInput
+                autoCapitalize="none"
+                autoCorrect={false}
+                invalid={Boolean(errors.confirmPassword?.message)}
+                leadingIcon={<IconSymbol color={theme.textSecondary.val} name="lock" size="input" />}
+                onBlur={onBlur}
+                onChangeText={onChange}
+                onSubmitEditing={onSubmit}
+                placeholder="Nhập lại mật khẩu mới"
+                returnKeyType="done"
+                secureTextEntry={!visibleFields.confirmPassword}
+                textContentType="newPassword"
+                trailingIcon={buildVisibilityToggle("confirmPassword")}
+                value={value}
+              />
+            )}
+          />
+        </Field>
+      </YStack>
+    </YStack>
+  );
+}

--- a/apps/mobile/screen/account/change-password/components/change-password-header.tsx
+++ b/apps/mobile/screen/account/change-password/components/change-password-header.tsx
@@ -1,0 +1,54 @@
+import { IconSymbol } from "@components/IconSymbol";
+import { radii, spaceScale } from "@theme/metrics";
+import { AppText } from "@ui/primitives/app-text";
+import { Pressable } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useTheme, XStack, YStack } from "tamagui";
+
+type ChangePasswordHeaderProps = {
+  onBack: () => void;
+};
+
+export function ChangePasswordHeader({ onBack }: ChangePasswordHeaderProps) {
+  const insets = useSafeAreaInsets();
+  const theme = useTheme();
+  const headerTopPadding = insets.top + spaceScale[4];
+  const headerBottomPadding = spaceScale[9] + spaceScale[2];
+
+  return (
+    <YStack
+      backgroundColor="$actionPrimary"
+      borderBottomLeftRadius={radii.xxl}
+      borderBottomRightRadius={radii.xxl}
+      paddingBottom={headerBottomPadding}
+      paddingHorizontal={spaceScale[5]}
+      paddingTop={headerTopPadding}
+    >
+      <XStack alignItems="flex-start" gap="$4">
+        <Pressable
+          onPress={onBack}
+          style={{
+            width: 42,
+            height: 42,
+            borderRadius: radii.round,
+            alignItems: "center",
+            justifyContent: "center",
+            backgroundColor: theme.overlayGlass.val,
+            marginTop: 2,
+          }}
+        >
+          <IconSymbol color={theme.onSurfaceBrand.val} name="arrow-left" size="md" />
+        </Pressable>
+
+        <YStack flex={1} gap="$2" paddingTop="$1">
+          <AppText color="$onSurfaceBrand" fontSize="$11" fontWeight="600" letterSpacing={-0.4} lineHeight={32}>
+            Bảo mật & Mật khẩu
+          </AppText>
+          <AppText color="$onSurfaceBrand" fontWeight="400" maxWidth={320} opacity={0.9} variant="body">
+            Cập nhật mật khẩu để giữ tài khoản của bạn an toàn.
+          </AppText>
+        </YStack>
+      </XStack>
+    </YStack>
+  );
+}

--- a/apps/mobile/screen/account/change-password/hooks/use-change-password.ts
+++ b/apps/mobile/screen/account/change-password/hooks/use-change-password.ts
@@ -1,0 +1,93 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useAuthNext } from "@providers/auth-provider-next";
+import { useNavigation } from "@react-navigation/native";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { Alert } from "react-native";
+
+import { presentUserError } from "@/presenters/users/user-error-presenter";
+import { userService } from "@/services/users/user-service";
+
+import type { ChangePasswordNavigationProp } from "../../../../types/navigation";
+import type { ChangePasswordFormValues } from "../change-password.schema";
+
+import { changePasswordSchema } from "../change-password.schema";
+
+type PasswordField = "oldPassword" | "newPassword" | "confirmPassword";
+
+export function useChangePassword() {
+  const navigation = useNavigation<ChangePasswordNavigationProp>();
+  const { isAuthenticated, status } = useAuthNext();
+  const [visibleFields, setVisibleFields] = useState<Record<PasswordField, boolean>>({
+    oldPassword: false,
+    newPassword: false,
+    confirmPassword: false,
+  });
+
+  const {
+    control,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<ChangePasswordFormValues>({
+    resolver: zodResolver(changePasswordSchema),
+    defaultValues: {
+      oldPassword: "",
+      newPassword: "",
+      confirmPassword: "",
+    },
+    mode: "onBlur",
+  });
+
+  const toggleFieldVisibility = (field: PasswordField) => {
+    setVisibleFields(current => ({
+      ...current,
+      [field]: !current[field],
+    }));
+  };
+
+  const goBack = () => {
+    navigation.goBack();
+  };
+
+  const submit = handleSubmit(async (data) => {
+    if (status === "loading") {
+      return;
+    }
+
+    if (!isAuthenticated) {
+      navigation.navigate("Login");
+      return;
+    }
+
+    try {
+      const result = await userService.changePassword({
+        currentPassword: data.oldPassword,
+        newPassword: data.newPassword,
+      });
+
+      if (result.ok) {
+        Alert.alert("Thành công", "Đổi mật khẩu thành công");
+        reset();
+        navigation.goBack();
+        return;
+      }
+
+      Alert.alert("Lỗi", presentUserError(result.error, "Đổi mật khẩu thất bại"));
+    }
+    catch (error) {
+      const message = error instanceof Error ? error.message : "Đổi mật khẩu thất bại";
+      Alert.alert("Lỗi", message);
+    }
+  });
+
+  return {
+    control,
+    errors,
+    goBack,
+    isSubmitting,
+    submit,
+    toggleFieldVisibility,
+    visibleFields,
+  };
+}

--- a/apps/mobile/screen/account/change-password/index.tsx
+++ b/apps/mobile/screen/account/change-password/index.tsx
@@ -1,320 +1,105 @@
-import { Ionicons } from "@expo/vector-icons";
-import fetchHttpClient from "@lib/httpClient";
-import { useAuthNext } from "@providers/auth-provider-next";
-import { useNavigation } from "@react-navigation/native";
-import { LinearGradient } from "expo-linear-gradient";
-import React, { useState } from "react";
-import {
-  Alert,
-  KeyboardAvoidingView,
-  Platform,
-  Pressable,
-  ScrollView,
-  StyleSheet,
-  Text,
-  TextInput,
-  TouchableOpacity,
-  View,
-} from "react-native";
+import { borderWidths, spaceScale } from "@theme/metrics";
+import { AppHeroHeader } from "@ui/patterns/app-hero-header";
+import { AppButton } from "@ui/primitives/app-button";
+import { AppCard } from "@ui/primitives/app-card";
+import { Screen } from "@ui/primitives/screen";
+import { StatusBar } from "expo-status-bar";
+import { KeyboardAvoidingView, Platform, ScrollView } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { YStack } from "tamagui";
 
-import type { ChangePasswordNavigationProp } from "../../../types/navigation";
+import { ChangePasswordForm } from "./components/change-password-form";
+import { useChangePassword } from "./hooks/use-change-password";
 
-import { IconSymbol } from "../../../components/IconSymbol";
-import { BikeColors } from "../../../constants/BikeColors";
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: BikeColors.background,
-  },
-  scrollContent: {
-    flexGrow: 1,
-  },
-  header: {
-    paddingTop: 60,
-    paddingBottom: 40,
-    paddingHorizontal: 20,
-  },
-  headerContent: {
-    alignItems: "center",
-  },
-  headerTitle: {
-    fontSize: 28,
-    fontWeight: "bold",
-    color: "white",
-    marginTop: 16,
-    marginBottom: 8,
-  },
-  headerSubtitle: {
-    fontSize: 16,
-    color: "rgba(255, 255, 255, 0.9)",
-  },
-  formContainer: {
-    flex: 1,
-    padding: 20,
-  },
-  inputLabel: {
-    fontSize: 16,
-    fontWeight: "600",
-    color: BikeColors.textPrimary,
-    marginBottom: 8,
-  },
-  inputContainer: {
-    flexDirection: "row",
-    alignItems: "center",
-    borderWidth: 1,
-    borderColor: BikeColors.lightGray,
-    borderRadius: 12,
-    paddingHorizontal: 16,
-    paddingVertical: 16,
-    marginBottom: 16,
-    backgroundColor: "white",
-  },
-  input: {
-    flex: 1,
-    marginLeft: 12,
-    fontSize: 16,
-    color: BikeColors.textPrimary,
-  },
-  eyeButton: {
-    padding: 4,
-  },
-  button: {
-    backgroundColor: BikeColors.primary,
-    paddingVertical: 16,
-    borderRadius: 12,
-    alignItems: "center",
-    marginTop: 8,
-    marginBottom: 24,
-  },
-  buttonDisabled: {
-    opacity: 0.7,
-  },
-  buttonText: {
-    color: "white",
-    fontSize: 18,
-    fontWeight: "600",
-  },
-});
+const actionBarPaddingTop = spaceScale[4];
+const actionBarGap = spaceScale[3];
+const actionButtonHeight = spaceScale[7];
+const actionBarMinBottomPadding = spaceScale[5];
+const actionBarReservedHeight = actionBarPaddingTop + actionBarGap + actionButtonHeight * 2;
 
 function ChangePasswordScreen() {
   const insets = useSafeAreaInsets();
-  const navigation = useNavigation<ChangePasswordNavigationProp>();
-  const [oldPassword, setOldPassword] = useState("");
-  const [newPassword, setNewPassword] = useState("");
-  const [confirmPassword, setConfirmPassword] = useState("");
-  const { status, isAuthenticated } = useAuthNext();
-  const [isChangingPassword, setIsChangingPassword] = useState(false);
-  const [showOldPassword, setShowOldPassword] = useState(false);
-  const [showPassword, setShowPassword] = useState(false);
-  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
-  const handleChangePassword = async () => {
-    if (status === "loading") {
-      return;
-    }
+  const {
+    control,
+    errors,
+    goBack,
+    isSubmitting,
+    submit,
+    toggleFieldVisibility,
+    visibleFields,
+  } = useChangePassword();
 
-    if (!isAuthenticated) {
-      navigation.navigate("Login");
-      return;
-    }
-    if (!oldPassword || !newPassword || !confirmPassword) {
-      Alert.alert("Lỗi", "Vui lòng nhập đầy đủ thông tin");
-      return;
-    }
-    if (newPassword !== confirmPassword) {
-      Alert.alert("Lỗi", "Mật khẩu mới và xác nhận không khớp");
-      return;
-    }
-    try {
-      setIsChangingPassword(true);
-      const response = await fetchHttpClient.put<{ message?: string }>(
-        "/users/change-password",
-        {
-          old_password: oldPassword,
-          password: newPassword,
-          confirm_password: confirmPassword,
-        },
-      );
-
-      if (response.status === 200) {
-        Alert.alert("Thành công", response.data?.message ?? "Đổi mật khẩu thành công");
-      }
-      else {
-        Alert.alert("Lỗi", response.data?.message ?? "Đổi mật khẩu thất bại");
-        return;
-      }
-      // Chỉ quay lại khi changePassword thành công
-      navigation.goBack();
-    }
-    catch (error) {
-      const message = error instanceof Error ? error.message : "Đổi mật khẩu thất bại";
-      Alert.alert("Lỗi", message);
-    }
-    finally {
-      setIsChangingPassword(false);
-    }
-  };
+  const contentBottomPadding = actionBarReservedHeight + Math.max(insets.bottom, actionBarMinBottomPadding);
 
   return (
-    <KeyboardAvoidingView
-      style={styles.container}
-      behavior={Platform.OS === "ios" ? "padding" : "height"}
-    >
-      <ScrollView
-        contentContainerStyle={styles.scrollContent}
-        showsVerticalScrollIndicator={false}
+    <Screen backgroundColor="$actionPrimary" tone="canvas">
+      <StatusBar style="light" />
+
+      <KeyboardAvoidingView
+        behavior={Platform.OS === "ios" ? "padding" : "height"}
+        style={{ flex: 1 }}
       >
-        <LinearGradient
-          colors={[BikeColors.primary, BikeColors.secondary]}
-          start={{ x: 0, y: 0 }}
-          end={{ x: 1, y: 1 }}
-          style={{
-            paddingTop: insets.top + 32,
-            paddingBottom: 38,
-            paddingHorizontal: 24,
-            borderBottomLeftRadius: 32,
-            borderBottomRightRadius: 32,
-            marginBottom: 8,
-            alignItems: "center",
-            elevation: 8,
-            shadowColor: BikeColors.primary,
-          }}
-        >
-          {/* Nút back nổi, căn vị trí xa nội dung */}
-          <TouchableOpacity
-            style={{
-              position: "absolute",
-              top: insets.top + 10,
-              left: 16,
-              zIndex: 12,
-              borderRadius: 30,
-              padding: 6,
-            }}
-            onPress={() => navigation.goBack()}
-          >
-            <Ionicons name="chevron-back" size={20} color="#fff" />
-          </TouchableOpacity>
+        <YStack backgroundColor="$actionPrimary" flex={1}>
+          <AppHeroHeader
+            onBack={goBack}
+            size="compact"
+            subtitle="Cập nhật mật khẩu để giữ tài khoản của bạn an toàn."
+            title="Bảo mật & Mật khẩu"
+          />
 
-          {/* Text header căn giữa, spacing đều */}
-          <View style={{ alignItems: "center", marginTop: 14 }}>
-            <Text
-              style={{
-                fontSize: 24, // to hơn cho đều với profile
-                color: "#fff",
-                fontWeight: "700",
-                marginBottom: 6,
-                letterSpacing: 0.5,
-              }}
+          <YStack flex={1} marginTop="$-5" position="relative">
+            <AppCard
+              borderBottomLeftRadius="$0"
+              borderBottomRightRadius="$0"
+              borderTopLeftRadius="$5"
+              borderTopRightRadius="$5"
+              elevated={false}
+              flex={1}
+              overflow="hidden"
+              padding="$0"
             >
-              Đổi mật khẩu
-            </Text>
-            <Text
-              style={{
-                fontSize: 15,
-                color: "#e0eaff",
-                fontWeight: "500",
-                marginBottom: 4,
-                textAlign: "center",
-              }}
-            >
-              Vui lòng nhập thông tin để đổi mật khẩu
-            </Text>
-          </View>
-        </LinearGradient>
+              <ScrollView keyboardShouldPersistTaps="handled" showsVerticalScrollIndicator={false}>
+                <YStack
+                  gap="$6"
+                  paddingBottom={contentBottomPadding}
+                  paddingHorizontal="$6"
+                  paddingTop="$6"
+                >
+                  <ChangePasswordForm
+                    control={control}
+                    errors={errors}
+                    onSubmit={submit}
+                    onToggleFieldVisibility={toggleFieldVisibility}
+                    visibleFields={visibleFields}
+                  />
+                </YStack>
+              </ScrollView>
+            </AppCard>
 
-        <View style={styles.formContainer}>
-          <View style={styles.inputContainer}>
-            <IconSymbol
-              name="lock"
-              size="md"
-              color={BikeColors.textSecondary}
-            />
-            <TextInput
-              style={styles.input}
-              placeholder="Nhập mật khẩu cũ"
-              placeholderTextColor={BikeColors.textSecondary}
-              secureTextEntry={!showOldPassword}
-              value={oldPassword}
-              onChangeText={setOldPassword}
-              autoCapitalize="none"
-              autoCorrect={false}
-            />
-            <Pressable
-              onPress={() => setShowOldPassword(!showOldPassword)}
-              style={styles.eyeButton}
+            <YStack
+              backgroundColor="$surfaceDefault"
+              borderTopColor="$borderSubtle"
+              borderTopWidth={borderWidths.subtle}
+              bottom={0}
+              gap="$3"
+              left={0}
+              paddingBottom={Math.max(insets.bottom, spaceScale[5])}
+              paddingHorizontal="$5"
+              paddingTop="$4"
+              position="absolute"
+              right={0}
             >
-              <IconSymbol
-                name={showOldPassword ? "eye-off" : "eye"}
-                size="md"
-                color={BikeColors.textSecondary}
-              />
-            </Pressable>
-          </View>
-          <View style={styles.inputContainer}>
-            <IconSymbol
-              name="lock"
-              size="md"
-              color={BikeColors.textSecondary}
-            />
-            <TextInput
-              style={styles.input}
-              placeholder="Nhập mật khẩu mới"
-              placeholderTextColor={BikeColors.textSecondary}
-              secureTextEntry={!showPassword}
-              value={newPassword}
-              onChangeText={setNewPassword}
-              autoCapitalize="none"
-              autoCorrect={false}
-            />
-            <Pressable
-              onPress={() => setShowPassword(!showPassword)}
-              style={styles.eyeButton}
-            >
-              <IconSymbol
-                name={showPassword ? "eye-off" : "eye"}
-                size="md"
-                color={BikeColors.textSecondary}
-              />
-            </Pressable>
-          </View>
-          <View style={styles.inputContainer}>
-            <IconSymbol
-              name="lock"
-              size="md"
-              color={BikeColors.textSecondary}
-            />
-            <TextInput
-              style={styles.input}
-              placeholder="Nhập lại mật khẩu mới"
-              placeholderTextColor={BikeColors.textSecondary}
-              secureTextEntry={!showConfirmPassword}
-              value={confirmPassword}
-              onChangeText={setConfirmPassword}
-              autoCapitalize="none"
-              autoCorrect={false}
-            />
-            <Pressable
-              onPress={() => setShowConfirmPassword(!showConfirmPassword)}
-              style={styles.eyeButton}
-            >
-              <IconSymbol
-                name={showConfirmPassword ? "eye-off" : "eye"}
-                size="md"
-                color={BikeColors.textSecondary}
-              />
-            </Pressable>
-          </View>
-          <Pressable
-            disabled={isChangingPassword}
-            onPress={handleChangePassword}
-            style={[styles.button, isChangingPassword ? styles.buttonDisabled : null]}
-          >
-            <Text style={styles.buttonText}>{isChangingPassword ? "Đang xử lý..." : "Xác nhận"}</Text>
-          </Pressable>
-        </View>
-      </ScrollView>
-    </KeyboardAvoidingView>
+              <AppButton buttonSize="large" loading={isSubmitting} onPress={submit}>
+                Xác nhận thay đổi
+              </AppButton>
+              <AppButton buttonSize="large" disabled={isSubmitting} onPress={goBack} tone="outline">
+                Quay lại
+              </AppButton>
+            </YStack>
+          </YStack>
+        </YStack>
+      </KeyboardAvoidingView>
+    </Screen>
   );
 }
 

--- a/apps/mobile/screen/account/change-password/index.tsx
+++ b/apps/mobile/screen/account/change-password/index.tsx
@@ -1,7 +1,5 @@
 import { borderWidths, spaceScale } from "@theme/metrics";
-import { AppHeroHeader } from "@ui/patterns/app-hero-header";
 import { AppButton } from "@ui/primitives/app-button";
-import { AppCard } from "@ui/primitives/app-card";
 import { Screen } from "@ui/primitives/screen";
 import { StatusBar } from "expo-status-bar";
 import { KeyboardAvoidingView, Platform, ScrollView } from "react-native";
@@ -9,6 +7,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { YStack } from "tamagui";
 
 import { ChangePasswordForm } from "./components/change-password-form";
+import { ChangePasswordHeader } from "./components/change-password-header";
 import { useChangePassword } from "./hooks/use-change-password";
 
 const actionBarPaddingTop = spaceScale[4];
@@ -32,39 +31,26 @@ function ChangePasswordScreen() {
   const contentBottomPadding = actionBarReservedHeight + Math.max(insets.bottom, actionBarMinBottomPadding);
 
   return (
-    <Screen backgroundColor="$actionPrimary" tone="canvas">
+    <Screen backgroundColor="$surfaceDefault" tone="canvas">
       <StatusBar style="light" />
 
       <KeyboardAvoidingView
         behavior={Platform.OS === "ios" ? "padding" : "height"}
         style={{ flex: 1 }}
       >
-        <YStack backgroundColor="$actionPrimary" flex={1}>
-          <AppHeroHeader
-            onBack={goBack}
-            size="compact"
-            subtitle="Cập nhật mật khẩu để giữ tài khoản của bạn an toàn."
-            title="Bảo mật & Mật khẩu"
-          />
+        <YStack backgroundColor="$surfaceDefault" flex={1}>
+          <ChangePasswordHeader onBack={goBack} />
 
-          <YStack flex={1} marginTop="$-5" position="relative">
-            <AppCard
-              borderBottomLeftRadius="$0"
-              borderBottomRightRadius="$0"
-              borderTopLeftRadius="$5"
-              borderTopRightRadius="$5"
-              elevated={false}
+          <YStack flex={1} marginTop={-spaceScale[6]} position="relative">
+            <YStack
+              backgroundColor="$surfaceDefault"
+              borderTopLeftRadius="$6"
+              borderTopRightRadius="$6"
               flex={1}
               overflow="hidden"
-              padding="$0"
             >
               <ScrollView keyboardShouldPersistTaps="handled" showsVerticalScrollIndicator={false}>
-                <YStack
-                  gap="$6"
-                  paddingBottom={contentBottomPadding}
-                  paddingHorizontal="$6"
-                  paddingTop="$6"
-                >
+                <YStack paddingBottom={contentBottomPadding} paddingHorizontal="$6" paddingTop="$6">
                   <ChangePasswordForm
                     control={control}
                     errors={errors}
@@ -74,7 +60,7 @@ function ChangePasswordScreen() {
                   />
                 </YStack>
               </ScrollView>
-            </AppCard>
+            </YStack>
 
             <YStack
               backgroundColor="$surfaceDefault"

--- a/apps/mobile/services/users/user-service.ts
+++ b/apps/mobile/services/users/user-service.ts
@@ -1,14 +1,12 @@
+import type { Result } from "@lib/result";
 import type { UsersContracts } from "@mebike/shared";
 import type { z } from "zod";
-
-import { StatusCodes } from "http-status-codes";
-
-import type { Result } from "@lib/result";
 
 import { decodeWithSchema, readJson } from "@lib/api-decode";
 import { kyClient } from "@lib/ky-client";
 import { err, ok } from "@lib/result";
 import { routePath, ServerRoutes } from "@lib/server-routes";
+import { StatusCodes } from "http-status-codes";
 
 import type { UserError } from "./user-error";
 
@@ -16,12 +14,14 @@ import { asNetworkError, parseUserError } from "./user-error";
 
 export type UserDetail = z.output<typeof UsersContracts.UserDetailSchema>;
 type MeStatus = keyof typeof ServerRoutes.users.me.responses;
+type ChangePasswordStatus = keyof typeof ServerRoutes.users.changePassword.responses;
 type UpdateMeStatus = keyof typeof ServerRoutes.users.updateMe.responses;
 type UploadMyAvatarStatus = keyof typeof ServerRoutes.users.uploadMyAvatar.responses;
 type RegisterPushTokenStatus = keyof typeof ServerRoutes.users.registerPushToken.responses;
 type UnregisterPushTokenStatus = keyof typeof ServerRoutes.users.unregisterPushToken.responses;
 type UnregisterAllPushTokensStatus = keyof typeof ServerRoutes.users.unregisterAllPushTokens.responses;
 export type UpdateMeRequest = z.output<typeof UsersContracts.UpdateMeRequestSchema>;
+export type ChangePasswordRequest = z.output<typeof UsersContracts.ChangePasswordRequestSchema>;
 export type RegisterPushTokenRequest = z.output<typeof UsersContracts.RegisterPushTokenRequestSchema>;
 export type PushTokenSummary = z.output<typeof UsersContracts.PushTokenSummarySchema>;
 export type UploadAvatarPayload = {
@@ -59,6 +59,32 @@ export const userService = {
         }
         case StatusCodes.UNAUTHORIZED:
         case StatusCodes.FORBIDDEN:
+        case StatusCodes.NOT_FOUND:
+          return err(await parseUserError(response));
+        default:
+          return err({ _tag: "UnknownError", message: `Unexpected status ${response.status}` });
+      }
+    }
+    catch (error) {
+      return asNetworkError(error);
+    }
+  },
+
+  changePassword: async (
+    payload: ChangePasswordRequest,
+  ): Promise<Result<void, UserError>> => {
+    try {
+      const response = await kyClient.put(routePath(ServerRoutes.users.changePassword), {
+        json: payload,
+        throwHttpErrors: false,
+      });
+
+      const status = response.status as ChangePasswordStatus | number;
+      switch (status) {
+        case StatusCodes.NO_CONTENT:
+          return ok(undefined);
+        case StatusCodes.BAD_REQUEST:
+        case StatusCodes.UNAUTHORIZED:
         case StatusCodes.NOT_FOUND:
           return err(await parseUserError(response));
         default:

--- a/apps/mobile/ui/patterns/app-hero-header.tsx
+++ b/apps/mobile/ui/patterns/app-hero-header.tsx
@@ -8,7 +8,7 @@ import { Pressable } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTheme, XStack, YStack } from "tamagui";
 
-type AppHeroHeaderSize = "default" | "compact";
+type AppHeroHeaderSize = "default" | "compact" | "prominent";
 type AppHeroHeaderVariant = "gradient" | "surface";
 
 type AppHeroHeaderProps = {
@@ -23,16 +23,32 @@ type AppHeroHeaderProps = {
 };
 
 const sizeStyles: Record<AppHeroHeaderSize, {
+  backButtonSize: number;
   bottomPadding: number;
+  contentGap: "$3" | "$4";
+  subtitleVariant: "body" | "bodySmall";
   titleVariant: "title" | "xlTitle";
 }> = {
   default: {
+    backButtonSize: 40,
     bottomPadding: spacingRules.hero.paddingBottomDefault,
+    contentGap: "$3",
+    subtitleVariant: "bodySmall",
     titleVariant: "title",
   },
   compact: {
+    backButtonSize: 40,
     bottomPadding: spacingRules.hero.paddingBottomCompact,
+    contentGap: "$3",
+    subtitleVariant: "bodySmall",
     titleVariant: "xlTitle",
+  },
+  prominent: {
+    backButtonSize: 48,
+    bottomPadding: spacingRules.hero.paddingBottomDefault + spacingRules.hero.paddingBottomCompact,
+    contentGap: "$4",
+    subtitleVariant: "body",
+    titleVariant: "title",
   },
 };
 
@@ -59,19 +75,20 @@ export function AppHeroHeader({
 
   const headerContent = (
     <>
-      <XStack alignItems="center" gap="$3" justifyContent="space-between">
-        <XStack alignItems="center" flex={1} gap="$3" paddingRight={accessory ? "$2" : "$0"}>
+      <XStack alignItems={size === "prominent" ? "flex-start" : "center"} gap={sizeStyle.contentGap} justifyContent="space-between">
+        <XStack alignItems={size === "prominent" ? "flex-start" : "center"} flex={1} gap={sizeStyle.contentGap} paddingRight={accessory ? "$2" : "$0"}>
           {onBack
             ? (
                 <Pressable
                   onPress={onBack}
                   style={{
-                    width: 40,
-                    height: 40,
+                    width: sizeStyle.backButtonSize,
+                    height: sizeStyle.backButtonSize,
                     borderRadius: radii.round,
                     alignItems: "center",
                     justifyContent: "center",
                     backgroundColor: isSurface ? "transparent" : theme.overlayGlass.val,
+                    marginTop: size === "prominent" ? 4 : 0,
                   }}
                 >
                   <IconSymbol
@@ -83,10 +100,9 @@ export function AppHeroHeader({
               )
             : null}
 
-          <YStack flex={1} gap="$1">
+          <YStack flex={1} gap={size === "prominent" ? "$2" : "$1"}>
             <AppText
               selectable
-              numberOfLines={1}
               tone={isSurface ? "default" : "inverted"}
               variant={resolvedTitleVariant}
             >
@@ -96,9 +112,10 @@ export function AppHeroHeader({
               ? (
                   <AppText
                     selectable
+                    maxWidth={size === "prominent" ? 320 : undefined}
                     opacity={isSurface ? 1 : 0.9}
                     tone={isSurface ? "muted" : "inverted"}
-                    variant="bodySmall"
+                    variant={sizeStyle.subtitleVariant}
                   >
                     {subtitle}
                   </AppText>

--- a/apps/mobile/ui/patterns/app-hero-header.tsx
+++ b/apps/mobile/ui/patterns/app-hero-header.tsx
@@ -8,7 +8,7 @@ import { Pressable } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTheme, XStack, YStack } from "tamagui";
 
-type AppHeroHeaderSize = "default" | "compact" | "prominent";
+type AppHeroHeaderSize = "default" | "compact";
 type AppHeroHeaderVariant = "gradient" | "surface";
 
 type AppHeroHeaderProps = {
@@ -23,32 +23,16 @@ type AppHeroHeaderProps = {
 };
 
 const sizeStyles: Record<AppHeroHeaderSize, {
-  backButtonSize: number;
   bottomPadding: number;
-  contentGap: "$3" | "$4";
-  subtitleVariant: "body" | "bodySmall";
   titleVariant: "title" | "xlTitle";
 }> = {
   default: {
-    backButtonSize: 40,
     bottomPadding: spacingRules.hero.paddingBottomDefault,
-    contentGap: "$3",
-    subtitleVariant: "bodySmall",
     titleVariant: "title",
   },
   compact: {
-    backButtonSize: 40,
     bottomPadding: spacingRules.hero.paddingBottomCompact,
-    contentGap: "$3",
-    subtitleVariant: "bodySmall",
     titleVariant: "xlTitle",
-  },
-  prominent: {
-    backButtonSize: 48,
-    bottomPadding: spacingRules.hero.paddingBottomDefault + spacingRules.hero.paddingBottomCompact,
-    contentGap: "$4",
-    subtitleVariant: "body",
-    titleVariant: "title",
   },
 };
 
@@ -75,20 +59,19 @@ export function AppHeroHeader({
 
   const headerContent = (
     <>
-      <XStack alignItems={size === "prominent" ? "flex-start" : "center"} gap={sizeStyle.contentGap} justifyContent="space-between">
-        <XStack alignItems={size === "prominent" ? "flex-start" : "center"} flex={1} gap={sizeStyle.contentGap} paddingRight={accessory ? "$2" : "$0"}>
+      <XStack alignItems="center" gap="$3" justifyContent="space-between">
+        <XStack alignItems="center" flex={1} gap="$3" paddingRight={accessory ? "$2" : "$0"}>
           {onBack
             ? (
                 <Pressable
                   onPress={onBack}
                   style={{
-                    width: sizeStyle.backButtonSize,
-                    height: sizeStyle.backButtonSize,
+                    width: 40,
+                    height: 40,
                     borderRadius: radii.round,
                     alignItems: "center",
                     justifyContent: "center",
                     backgroundColor: isSurface ? "transparent" : theme.overlayGlass.val,
-                    marginTop: size === "prominent" ? 4 : 0,
                   }}
                 >
                   <IconSymbol
@@ -100,9 +83,10 @@ export function AppHeroHeader({
               )
             : null}
 
-          <YStack flex={1} gap={size === "prominent" ? "$2" : "$1"}>
+          <YStack flex={1} gap="$1">
             <AppText
               selectable
+              numberOfLines={1}
               tone={isSurface ? "default" : "inverted"}
               variant={resolvedTitleVariant}
             >
@@ -112,10 +96,9 @@ export function AppHeroHeader({
               ? (
                   <AppText
                     selectable
-                    maxWidth={size === "prominent" ? 320 : undefined}
                     opacity={isSurface ? 1 : 0.9}
                     tone={isSurface ? "muted" : "inverted"}
-                    variant={sizeStyle.subtitleVariant}
+                    variant="bodySmall"
                   >
                     {subtitle}
                   </AppText>

--- a/apps/mobile/ui/primitives/app-input.tsx
+++ b/apps/mobile/ui/primitives/app-input.tsx
@@ -8,19 +8,15 @@ import { View } from "react-native";
 import { Input, XStack } from "tamagui";
 
 type AppInputProps = GetProps<typeof Input> & {
+  fieldSize?: "default" | "large";
   leadingIcon?: ReactNode;
   trailingIcon?: ReactNode;
   invalid?: boolean;
   readOnly?: boolean;
 };
 
-const iconSlotStyle = {
-  width: 24,
-  alignItems: "center" as const,
-  justifyContent: "center" as const,
-};
-
 export function AppInput({
+  fieldSize = "default",
   leadingIcon,
   trailingIcon,
   invalid = false,
@@ -33,6 +29,12 @@ export function AppInput({
 }: AppInputProps) {
   const [isFocused, setIsFocused] = useState(false);
   const isReadOnly = readOnly || props.disabled === true;
+  const isLarge = fieldSize === "large";
+  const iconSlotStyle = {
+    width: isLarge ? 28 : 24,
+    alignItems: "center" as const,
+    justifyContent: "center" as const,
+  };
 
   const borderColor = invalid
     ? "$borderDanger"
@@ -41,6 +43,7 @@ export function AppInput({
       : isReadOnly
         ? "$borderSubtle"
         : "$borderDefault";
+  const isEmphasized = (isFocused && !isReadOnly) || invalid;
   const shadowColor = invalid ? "$borderDanger" : isFocused && !isReadOnly ? "$actionPrimary" : "transparent";
 
   return (
@@ -48,15 +51,15 @@ export function AppInput({
       alignItems="center"
       backgroundColor={isReadOnly ? "$surfaceMuted" : "$surfaceDefault"}
       borderColor={borderColor}
-      borderRadius="$3"
-      borderWidth={isFocused && !isReadOnly || invalid ? borderWidths.strong : borderWidths.subtle}
+      borderRadius={isLarge ? "$4" : "$3"}
+      borderWidth={isEmphasized ? borderWidths.strong : borderWidths.subtle}
       gap="$3"
-      minHeight="$6"
-      paddingHorizontal="$4"
+      minHeight={isLarge ? "$7" : "$6"}
+      paddingHorizontal={isLarge ? "$5" : "$4"}
       shadowColor={shadowColor}
-      shadowOffset={isFocused && !isReadOnly || invalid ? { width: 0, height: 0 } : { width: 0, height: 0 }}
-      shadowOpacity={isFocused && !isReadOnly || invalid ? 0.14 : 0}
-      shadowRadius={isFocused && !isReadOnly || invalid ? 10 : 0}
+      shadowOffset={isEmphasized ? { width: 0, height: 0 } : { width: 0, height: 0 }}
+      shadowOpacity={isEmphasized ? 0.14 : 0}
+      shadowRadius={isEmphasized ? 10 : 0}
     >
       {leadingIcon
         ? (
@@ -71,7 +74,7 @@ export function AppInput({
         color={isReadOnly ? "$textSecondary" : "$textPrimary"}
         flex={1}
         fontFamily="$body"
-        fontSize={typographyTokens.bodySmall}
+        fontSize={isLarge ? typographyTokens.body : typographyTokens.bodySmall}
         fontWeight="$5"
         readOnly={isReadOnly}
         onBlur={(event) => {


### PR DESCRIPTION
## Summary
- migrate the mobile change-password flow onto the shared design system with `react-hook-form` and a dedicated screen hook
- wire the screen to the typed users service so it uses the correct backend change-password route and error handling
- polish the screen layout with a custom header treatment and larger input variant to better match the updated mobile account UI