### PR TITLE
feat(server): scope station access for staff and managers

### DIFF
--- a/apps/server/src/domain/rentals/models.ts
+++ b/apps/server/src/domain/rentals/models.ts
@@ -48,6 +48,7 @@ export type AdminRentalFilter = {
   bikeId?: string;
   startStationId?: string;
   endStationId?: string;
+  stationScopeId?: string;
   status?: RentalStatus;
 };
 

--- a/apps/server/src/domain/rentals/repository/rental.repository.query.ts
+++ b/apps/server/src/domain/rentals/repository/rental.repository.query.ts
@@ -2,6 +2,8 @@ import type { PageRequest } from "@/domain/shared/pagination";
 import type { BikeSwapStatus } from "generated/kysely/types";
 import type { Prisma as PrismaTypes } from "generated/prisma/client";
 
+import { pickDefined } from "@/domain/shared";
+
 import type {
   AdminRentalFilter,
   BikeSwapRequestRow,
@@ -29,12 +31,28 @@ export function toMyRentalsWhere(
 export function toAdminRentalsWhere(
   filter: AdminRentalFilter,
 ): PrismaTypes.RentalWhereInput {
+  const baseWhere = pickDefined({
+    userId: filter.userId,
+    bikeId: filter.bikeId,
+    startStationId: filter.startStationId,
+    endStationId: filter.endStationId,
+    status: filter.status,
+  });
+
+  const stationScope = filter.stationScopeId
+    ? {
+        OR: [
+          { startStationId: filter.stationScopeId },
+          { endStationId: filter.stationScopeId },
+        ],
+      }
+    : undefined;
+
   return {
-    ...(filter.userId ? { userId: filter.userId } : {}),
-    ...(filter.bikeId ? { bikeId: filter.bikeId } : {}),
-    ...(filter.startStationId ? { startStationId: filter.startStationId } : {}),
-    ...(filter.endStationId ? { endStationId: filter.endStationId } : {}),
-    ...(filter.status ? { status: filter.status } : {}),
+    AND: [
+      baseWhere,
+      ...(stationScope ? [stationScope] : []),
+    ],
   };
 }
 

--- a/apps/server/src/domain/stations/models.ts
+++ b/apps/server/src/domain/stations/models.ts
@@ -3,6 +3,14 @@ import type { StationType } from "generated/prisma/client";
 
 export type StationSortField = "name" | "totalCapacity" | "updatedAt";
 
+export type StationWorkerRow = {
+  userId: string;
+  fullName: string;
+  role: "STAFF" | "MANAGER" | "TECHNICIAN";
+  technicianTeamId: string | null;
+  technicianTeamName: string | null;
+};
+
 export type StationRow = {
   id: string;
   name: string;
@@ -25,6 +33,7 @@ export type StationRow = {
   activeReturnSlots: number;
   availableReturnSlots: number;
   emptySlots: number;
+  workers?: readonly StationWorkerRow[];
 };
 
 export type CreateStationInput = {

--- a/apps/server/src/domain/stations/repository/read/station.read.repository.ts
+++ b/apps/server/src/domain/stations/repository/read/station.read.repository.ts
@@ -12,6 +12,7 @@ import type {
   NearestSearchArgs,
   NearestStationRow,
   StationRevenueRow,
+  StationWorkerRow,
 } from "../../models";
 import type { StationQueryRepo } from "../station.repository.types";
 
@@ -66,6 +67,73 @@ export function makeStationReadRepository(
           }),
         ));
     });
+
+  const loadWorkers = (stationId: string) =>
+    Effect.tryPromise({
+      try: () =>
+        client.userOrgAssignment.findMany({
+          where: {
+            OR: [
+              {
+                stationId,
+                user: {
+                  role: { in: ["STAFF", "MANAGER"] },
+                },
+              },
+              {
+                technicianTeam: { stationId },
+                user: {
+                  role: "TECHNICIAN",
+                },
+              },
+            ],
+          },
+          select: {
+            user: {
+              select: {
+                id: true,
+                fullName: true,
+                role: true,
+              },
+            },
+            technicianTeam: {
+              select: {
+                id: true,
+                name: true,
+              },
+            },
+          },
+        }),
+      catch: cause =>
+        new StationRepositoryError({
+          operation: "getById.loadWorkers",
+          cause,
+        }),
+    }).pipe(
+      Effect.map((rows): StationWorkerRow[] => {
+        const roleRank = {
+          MANAGER: 0,
+          STAFF: 1,
+          TECHNICIAN: 2,
+        } as const;
+
+        return rows
+          .map(row => ({
+            userId: row.user.id,
+            fullName: row.user.fullName,
+            role: row.user.role as StationWorkerRow["role"],
+            technicianTeamId: row.technicianTeam?.id ?? null,
+            technicianTeamName: row.technicianTeam?.name ?? null,
+          }))
+          .sort((left, right) => {
+            const rankDiff = roleRank[left.role] - roleRank[right.role];
+
+            return rankDiff !== 0
+              ? rankDiff
+              : left.fullName.localeCompare(right.fullName);
+          });
+      }),
+    );
 
   return {
     listWithOffset(filter, pageReq) {
@@ -126,10 +194,15 @@ export function makeStationReadRepository(
           return Option.none();
         }
 
-        const [station] = yield* attachCounts([row], (item, counts) =>
-          applyCounts(item, counts));
+        const [[station], workers] = yield* Effect.all([
+          attachCounts([row], (item, counts) => applyCounts(item, counts)),
+          loadWorkers(id),
+        ]);
 
-        return Option.some(station);
+        return Option.some({
+          ...station,
+          workers,
+        });
       }).pipe(defectOn(StationRepositoryError));
     },
 

--- a/apps/server/src/domain/users/models.ts
+++ b/apps/server/src/domain/users/models.ts
@@ -10,10 +10,14 @@ export type AgencyOrgUnitRef = OrgUnitRef & {
   readonly stationId: string | null;
 };
 
+export type TechnicianTeamOrgUnitRef = OrgUnitRef & {
+  readonly stationId: string;
+};
+
 export type UserOrgAssignment = {
   readonly station: OrgUnitRef | null;
   readonly agency: AgencyOrgUnitRef | null;
-  readonly technicianTeam: OrgUnitRef | null;
+  readonly technicianTeam: TechnicianTeamOrgUnitRef | null;
 };
 
 export type UserOrgAssignmentPatch = {

--- a/apps/server/src/domain/users/repository/user.mappers.ts
+++ b/apps/server/src/domain/users/repository/user.mappers.ts
@@ -38,6 +38,7 @@ export const selectUserRow = {
         select: {
           id: true,
           name: true,
+          stationId: true,
         },
       },
     },
@@ -82,6 +83,7 @@ export function toUserRow(row: PrismaTypes.UserGetPayload<{ select: typeof selec
             ? {
                 id: row.orgAssignment.technicianTeam.id,
                 name: row.orgAssignment.technicianTeam.name,
+                stationId: row.orgAssignment.technicianTeam.stationId,
               }
             : null,
         }

--- a/apps/server/src/http/controllers/rentals/staff.controller.ts
+++ b/apps/server/src/http/controllers/rentals/staff.controller.ts
@@ -26,10 +26,47 @@ import {
   rentalErrorMessages,
 } from "./shared";
 
+function getStationScopedRoleScope(currentUser: {
+  role: string;
+  operatorStationId?: string;
+}) {
+  if (currentUser.role === "STAFF" || currentUser.role === "MANAGER") {
+    return currentUser.operatorStationId ?? null;
+  }
+
+  return undefined;
+}
+
+function canAccessRentalInStationScope(
+  rental: { startStation: { id: string }; endStation: { id: string } | null },
+  stationScopeId: string | null | undefined,
+) {
+  if (!stationScopeId) {
+    return stationScopeId === undefined;
+  }
+
+  return rental.startStation.id === stationScopeId || rental.endStation?.id === stationScopeId;
+}
+
 const staffListRentals: RouteHandler<
   RentalsRoutes["staffListRentals"]
 > = async (c) => {
   const query = c.req.valid("query");
+  const stationScopeId = getStationScopedRoleScope(c.var.currentUser!);
+
+  if (stationScopeId === null) {
+    const response: RentalsContracts.AdminRentalsListResponse = {
+      data: [],
+      pagination: {
+        page: Number(query.page ?? 1),
+        pageSize: Number(query.pageSize ?? 50),
+        total: 0,
+        totalPages: 0,
+      },
+    };
+
+    return c.json<RentalsContracts.AdminRentalsListResponse, 200>(response, 200);
+  }
 
   const eff = withLoggedCause(
     Effect.gen(function* () {
@@ -40,6 +77,7 @@ const staffListRentals: RouteHandler<
           bikeId: query.bikeId,
           startStationId: query.startStation,
           endStationId: query.endStation,
+          stationScopeId,
           status: query.status,
         },
         {
@@ -66,6 +104,20 @@ const staffGetRental: RouteHandler<RentalsRoutes["staffGetRental"]> = async (
   c,
 ) => {
   const { rentalId } = c.req.valid("param");
+  const stationScopeId = getStationScopedRoleScope(c.var.currentUser!);
+
+  if (stationScopeId === null) {
+    return c.json(
+      {
+        error: rentalErrorMessages.RENTAL_NOT_FOUND,
+        details: {
+          code: RentalErrorCodeSchema.enum.RENTAL_NOT_FOUND,
+          rentalId,
+        },
+      },
+      404,
+    );
+  }
 
   const eff = withLoggedCause(
     adminGetRentalDetail(rentalId),
@@ -75,8 +127,22 @@ const staffGetRental: RouteHandler<RentalsRoutes["staffGetRental"]> = async (
   const result = await c.var.runPromise(eff.pipe(Effect.either));
 
   return Match.value(result).pipe(
-    Match.tag("Right", ({ right }) =>
-      c.json(toContractAdminRentalDetail(right), 200)),
+    Match.tag("Right", ({ right }) => {
+      if (!canAccessRentalInStationScope(right, stationScopeId)) {
+        return c.json(
+          {
+            error: rentalErrorMessages.RENTAL_NOT_FOUND,
+            details: {
+              code: RentalErrorCodeSchema.enum.RENTAL_NOT_FOUND,
+              rentalId,
+            },
+          },
+          404,
+        );
+      }
+
+      return c.json(toContractAdminRentalDetail(right), 200);
+    }),
     Match.tag("Left", ({ left }) =>
       Match.value(left).pipe(
         Match.tag("AdminRentalNotFound", () =>

--- a/apps/server/src/http/controllers/reservations/staff.controller.ts
+++ b/apps/server/src/http/controllers/reservations/staff.controller.ts
@@ -22,10 +22,37 @@ import {
   reservationErrorMessages,
 } from "./shared";
 
+function getStationScopedRoleScope(currentUser: {
+  role: string;
+  operatorStationId?: string;
+}) {
+  if (currentUser.role === "STAFF" || currentUser.role === "MANAGER") {
+    return currentUser.operatorStationId ?? null;
+  }
+
+  return undefined;
+}
+
 const staffListReservations: RouteHandler<
   ReservationsRoutes["staffListReservations"]
 > = async (c) => {
   const query = c.req.valid("query");
+  const stationScopeId = getStationScopedRoleScope(c.var.currentUser!);
+
+  if (stationScopeId === null) {
+    return c.json<ListStaffReservationsResponse, 200>(
+      {
+        data: [],
+        pagination: {
+          page: query.page ?? 1,
+          pageSize: query.pageSize ?? 50,
+          total: 0,
+          totalPages: 0,
+        },
+      },
+      200,
+    );
+  }
 
   const eff = withLoggedCause(
     Effect.gen(function* () {
@@ -35,7 +62,7 @@ const staffListReservations: RouteHandler<
           userId: query.userId,
           bikeId: query.bikeId,
           status: query.status,
-          stationId: query.stationId,
+          stationId: stationScopeId ?? query.stationId,
           reservationOption: query.reservationOption,
         },
         {
@@ -63,6 +90,20 @@ const staffGetReservation: RouteHandler<
   ReservationsRoutes["staffGetReservation"]
 > = async (c) => {
   const { reservationId } = c.req.valid("param");
+  const stationScopeId = getStationScopedRoleScope(c.var.currentUser!);
+
+  if (stationScopeId === null) {
+    return c.json<ReservationErrorResponse, 404>(
+      {
+        error: reservationErrorMessages.RESERVATION_NOT_FOUND,
+        details: {
+          code: ReservationErrorCodeSchema.enum.RESERVATION_NOT_FOUND,
+          reservationId,
+        },
+      },
+      404,
+    );
+  }
 
   const eff = withLoggedCause(
     Effect.gen(function* () {
@@ -77,6 +118,19 @@ const staffGetReservation: RouteHandler<
   return Match.value(result).pipe(
     Match.tag("Right", ({ right }) => {
       if (Option.isNone(right)) {
+        return c.json<ReservationErrorResponse, 404>(
+          {
+            error: reservationErrorMessages.RESERVATION_NOT_FOUND,
+            details: {
+              code: ReservationErrorCodeSchema.enum.RESERVATION_NOT_FOUND,
+              reservationId,
+            },
+          },
+          404,
+        );
+      }
+
+      if (stationScopeId && right.value.station.id !== stationScopeId) {
         return c.json<ReservationErrorResponse, 404>(
           {
             error: reservationErrorMessages.RESERVATION_NOT_FOUND,

--- a/apps/server/src/http/middlewares/auth.ts
+++ b/apps/server/src/http/middlewares/auth.ts
@@ -9,6 +9,7 @@ import { createMiddleware } from "hono/factory";
 import jwt from "jsonwebtoken";
 
 import type { AccessTokenPayload } from "@/domain/auth";
+import type { UserRow } from "@/domain/users";
 import type { RunPromise } from "@/http/shared/runtime";
 
 import { hasActiveAgencyAccess, requireJwtSecret } from "@/domain/auth";
@@ -39,6 +40,13 @@ function requireRoles(...allowedRoles: readonly Role[]) {
     }
     await next();
   });
+}
+
+function resolveOperatorStationId(row: UserRow) {
+  return row.orgAssignment?.station?.id
+    ?? row.orgAssignment?.technicianTeam?.stationId
+    ?? row.orgAssignment?.agency?.stationId
+    ?? undefined;
 }
 
 function parseBearerToken(header: string | null | undefined): string | null {
@@ -91,9 +99,7 @@ export const currentUserMiddleware = createMiddleware(async (c, next) => {
       }
       else {
         const user = userOpt.value;
-        const operatorStationId = user.orgAssignment?.station?.id
-          ?? user.orgAssignment?.agency?.stationId
-          ?? undefined;
+        const operatorStationId = resolveOperatorStationId(user);
 
         c.set("currentUser", {
           userId: user.id,
@@ -122,10 +128,12 @@ export const requireAdminMiddleware = requireRoles("ADMIN");
 export const requireAgencyMiddleware = requireRoles("AGENCY");
 export const requireManagerMiddleware = requireRoles("MANAGER");
 export const requireStaffMiddleware = requireRoles("STAFF");
+export const requireStaffOrManagerMiddleware = requireRoles("STAFF", "MANAGER");
 export const requireUserMiddleware = requireRoles("USER");
 export const requireTechnicianMiddleware = requireRoles("TECHNICIAN");
 export const requireBackofficeMiddleware = requireRoles("ADMIN", "STAFF");
 export const requireRentalOperatorMiddleware = requireRoles("STAFF", "AGENCY");
+export const requireRentalOperatorManagerMiddleware = requireRoles("STAFF", "MANAGER", "AGENCY");
 export const requireRentalSupportMiddleware = requireRoles(
   "ADMIN",
   "STAFF",

--- a/apps/server/src/http/presenters/stations.presenter.ts
+++ b/apps/server/src/http/presenters/stations.presenter.ts
@@ -37,6 +37,17 @@ export function toContractStationReadSummary(
       active: station.activeReturnSlots,
       available: station.availableReturnSlots,
     },
+    ...(station.workers
+      ? {
+          workers: station.workers.map(worker => ({
+            userId: worker.userId,
+            fullName: worker.fullName,
+            role: worker.role,
+            technicianTeamId: worker.technicianTeamId,
+            technicianTeamName: worker.technicianTeamName,
+          })),
+        }
+      : {}),
     createdAt: station.createdAt,
     updatedAt: station.updatedAt,
   };

--- a/apps/server/src/http/routes/rentals.ts
+++ b/apps/server/src/http/routes/rentals.ts
@@ -12,9 +12,9 @@ import {
 import {
   requireAdminMiddleware,
   requireAgencyMiddleware,
-  requireRentalOperatorMiddleware,
+  requireRentalOperatorManagerMiddleware,
   requireRentalSupportMiddleware,
-  requireStaffMiddleware,
+  requireStaffOrManagerMiddleware,
   requireUserMiddleware,
 } from "@/http/middlewares/auth";
 
@@ -46,21 +46,21 @@ export function registerRentalRoutes(
 
   const staffGetRoute = {
     ...rentals.staffGetRental,
-    middleware: [requireRentalOperatorMiddleware] as const,
+    middleware: [requireRentalOperatorManagerMiddleware] as const,
   } satisfies RouteConfig;
 
   app.openapi(staffGetRoute, RentalStaffController.staffGetRental);
 
   const staffListRoute = {
     ...rentals.staffListRentals,
-    middleware: [requireStaffMiddleware] as const,
+    middleware: [requireStaffOrManagerMiddleware] as const,
   } satisfies RouteConfig;
 
   app.openapi(staffListRoute, RentalStaffController.staffListRentals);
 
   const confirmReturnByOperatorRoute = {
     ...rentals.confirmRentalReturnByOperator,
-    middleware: [requireRentalOperatorMiddleware] as const,
+    middleware: [requireRentalOperatorManagerMiddleware] as const,
   } satisfies RouteConfig;
 
   app.openapi(
@@ -122,7 +122,7 @@ export function registerRentalRoutes(
 
   const operatorListSwapRequestsRoute = {
     ...rentals.operatorListBikeSwapRequests,
-    middleware: [requireRentalOperatorMiddleware] as const,
+    middleware: [requireRentalOperatorManagerMiddleware] as const,
   } satisfies RouteConfig;
 
   app.openapi(
@@ -132,7 +132,7 @@ export function registerRentalRoutes(
 
   const operatorApproveSwapRoute = {
     ...rentals.operatorApproveBikeSwapRequest,
-    middleware: [requireRentalOperatorMiddleware] as const,
+    middleware: [requireRentalOperatorManagerMiddleware] as const,
   } satisfies RouteConfig;
 
   app.openapi(
@@ -142,7 +142,7 @@ export function registerRentalRoutes(
 
   const operatorRejectSwapRequestRoute = {
     ...rentals.operatorRejectBikeSwapRequest,
-    middleware: [requireRentalOperatorMiddleware] as const,
+    middleware: [requireRentalOperatorManagerMiddleware] as const,
   } satisfies RouteConfig;
 
   app.openapi(
@@ -152,7 +152,7 @@ export function registerRentalRoutes(
 
   const operatorGetSwapRequestRoute = {
     ...rentals.operatorGetBikeSwapRequests,
-    middleware: [requireRentalOperatorMiddleware] as const,
+    middleware: [requireRentalOperatorManagerMiddleware] as const,
   } satisfies RouteConfig;
 
   app.openapi(

--- a/apps/server/src/http/routes/reservations.ts
+++ b/apps/server/src/http/routes/reservations.ts
@@ -9,7 +9,7 @@ import {
 } from "@/http/controllers/reservations";
 import {
   requireAdminMiddleware,
-  requireStaffMiddleware,
+  requireStaffOrManagerMiddleware,
 } from "@/http/middlewares/auth";
 
 export function registerReservationRoutes(app: import("@hono/zod-openapi").OpenAPIHono) {
@@ -37,14 +37,14 @@ export function registerReservationRoutes(app: import("@hono/zod-openapi").OpenA
 
   const staffListRoute = {
     ...reservations.staffListReservations,
-    middleware: [requireStaffMiddleware] as const,
+    middleware: [requireStaffOrManagerMiddleware] as const,
   } satisfies RouteConfig;
 
   app.openapi(staffListRoute, ReservationStaffController.staffListReservations);
 
   const staffGetRoute = {
     ...reservations.staffGetReservation,
-    middleware: [requireStaffMiddleware] as const,
+    middleware: [requireStaffOrManagerMiddleware] as const,
   } satisfies RouteConfig;
 
   app.openapi(staffGetRoute, ReservationStaffController.staffGetReservation);

--- a/apps/server/src/http/test/e2e/admin-stations-routing.e2e.int.test.ts
+++ b/apps/server/src/http/test/e2e/admin-stations-routing.e2e.int.test.ts
@@ -123,6 +123,75 @@ describe("admin stations routing e2e", () => {
     expect(body.data.map(station => station.id)).not.toContain(hiddenStation.id);
   });
 
+  it("includes staff, manager, and technicians in station detail workers", async () => {
+    const station = await fixture.factories.station({
+      name: "Worker Station",
+      address: "11 Worker Street, Thu Duc, TP.HCM",
+      latitude: 10.7604,
+      longitude: 106.6604,
+    });
+    const staff = await fixture.factories.user({
+      fullname: "Staff Worker",
+      email: "worker-staff@example.com",
+      role: "STAFF",
+    });
+    const manager = await fixture.factories.user({
+      fullname: "Manager Worker",
+      email: "worker-manager@example.com",
+      role: "MANAGER",
+    });
+    const technician = await fixture.factories.user({
+      fullname: "Technician Worker",
+      email: "worker-technician@example.com",
+      role: "TECHNICIAN",
+    });
+    const technicianTeam = await fixture.factories.technicianTeam({
+      name: "Worker Team",
+      stationId: station.id,
+    });
+
+    await fixture.factories.userOrgAssignment({
+      userId: staff.id,
+      stationId: station.id,
+    });
+    await fixture.factories.userOrgAssignment({
+      userId: manager.id,
+      stationId: station.id,
+    });
+    await fixture.factories.userOrgAssignment({
+      userId: technician.id,
+      technicianTeamId: technicianTeam.id,
+    });
+
+    const response = await fixture.app.request(`http://test/v1/stations/${station.id}`);
+    const body = await response.json() as StationsContracts.StationReadSummary;
+
+    expect(response.status).toBe(200);
+    expect(body.workers).toEqual([
+      {
+        userId: manager.id,
+        fullName: "Manager Worker",
+        role: "MANAGER",
+        technicianTeamId: null,
+        technicianTeamName: null,
+      },
+      {
+        userId: staff.id,
+        fullName: "Staff Worker",
+        role: "STAFF",
+        technicianTeamId: null,
+        technicianTeamName: null,
+      },
+      {
+        userId: technician.id,
+        fullName: "Technician Worker",
+        role: "TECHNICIAN",
+        technicianTeamId: technicianTeam.id,
+        technicianTeamName: "Worker Team",
+      },
+    ]);
+  });
+
   it("rejects creating a station with duplicate exact location", async () => {
     await fixture.factories.station({
       name: "Existing Exact Location",

--- a/apps/server/src/http/test/e2e/operator-reservations-routing.e2e.int.test.ts
+++ b/apps/server/src/http/test/e2e/operator-reservations-routing.e2e.int.test.ts
@@ -1,0 +1,95 @@
+import type { ReservationsContracts } from "@mebike/shared";
+
+import { describe, expect, it } from "vitest";
+
+import { setupHttpE2eFixture } from "@/test/http/e2e-fixture";
+
+describe("operator reservations routing e2e", () => {
+  const fixture = setupHttpE2eFixture({
+    buildLayer: async () => {
+      const { Layer } = await import("effect");
+      const { ReservationDepsLive } = await import("@/http/shared/providers");
+      const { UserDepsLive } = await import("@/http/shared/features/user.layers");
+
+      return Layer.mergeAll(
+        UserDepsLive,
+        ReservationDepsLive,
+      );
+    },
+  });
+
+  async function createStaffToken(stationId?: string) {
+    const staff = await fixture.factories.user({ role: "STAFF" });
+
+    if (stationId) {
+      await fixture.factories.userOrgAssignment({ userId: staff.id, stationId });
+    }
+
+    return fixture.auth.makeAccessToken({ userId: staff.id, role: "STAFF" });
+  }
+
+  async function createManagerToken(stationId?: string) {
+    const manager = await fixture.factories.user({ role: "MANAGER" });
+
+    if (stationId) {
+      await fixture.factories.userOrgAssignment({ userId: manager.id, stationId });
+    }
+
+    return fixture.auth.makeAccessToken({ userId: manager.id, role: "MANAGER" });
+  }
+
+  it("lets manager use the staff reservations list but only for their station", async () => {
+    const visibleStation = await fixture.factories.station({ capacity: 5 });
+    const hiddenStation = await fixture.factories.station({ capacity: 5 });
+    const riderA = await fixture.factories.user({ role: "USER" });
+    const riderB = await fixture.factories.user({ role: "USER" });
+    const bikeA = await fixture.factories.bike({ stationId: visibleStation.id, status: "RESERVED" });
+    const bikeB = await fixture.factories.bike({ stationId: hiddenStation.id, status: "RESERVED" });
+
+    const visibleReservation = await fixture.factories.reservation({
+      userId: riderA.id,
+      bikeId: bikeA.id,
+      stationId: visibleStation.id,
+    });
+    await fixture.factories.reservation({
+      userId: riderB.id,
+      bikeId: bikeB.id,
+      stationId: hiddenStation.id,
+    });
+
+    const managerToken = await createManagerToken(visibleStation.id);
+
+    const response = await fixture.app.request("http://test/v1/staff/reservations?page=1&pageSize=20", {
+      headers: {
+        Authorization: `Bearer ${managerToken}`,
+      },
+    });
+
+    const body = await response.json() as ReservationsContracts.ListStaffReservationsResponse;
+
+    expect(response.status).toBe(200);
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0]?.id).toBe(visibleReservation.id);
+  });
+
+  it("returns 404 when staff requests reservation detail outside their station", async () => {
+    const visibleStation = await fixture.factories.station({ capacity: 5 });
+    const hiddenStation = await fixture.factories.station({ capacity: 5 });
+    const rider = await fixture.factories.user({ role: "USER" });
+    const hiddenBike = await fixture.factories.bike({ stationId: hiddenStation.id, status: "RESERVED" });
+    const reservation = await fixture.factories.reservation({
+      userId: rider.id,
+      bikeId: hiddenBike.id,
+      stationId: hiddenStation.id,
+    });
+    const staffToken = await createStaffToken(visibleStation.id);
+
+    const response = await fixture.app.request(`http://test/v1/staff/reservations/${reservation.id}`, {
+      headers: {
+        Authorization: `Bearer ${staffToken}`,
+      },
+    });
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/apps/server/src/http/test/e2e/rentals-end-routing.e2e.int.test.ts
+++ b/apps/server/src/http/test/e2e/rentals-end-routing.e2e.int.test.ts
@@ -57,6 +57,19 @@ describe("rentals end routing e2e", () => {
     };
   }
 
+  async function createManagerToken(stationId?: string) {
+    const manager = await fixture.factories.user({ role: "MANAGER" });
+
+    if (stationId) {
+      await fixture.factories.userOrgAssignment({ userId: manager.id, stationId });
+    }
+
+    return {
+      manager,
+      token: fixture.auth.makeAccessToken({ userId: manager.id, role: "MANAGER" }),
+    };
+  }
+
   async function createAgencyToken() {
     const agencyUser = await fixture.factories.user({ role: "AGENCY" });
     const agency = await fixture.prisma.agency.create({
@@ -196,6 +209,36 @@ describe("rentals end routing e2e", () => {
     expect(response.status).toBe(200);
     expect(body.id).toBe(rental.id);
     expect(body.status).toBe("RENTED");
+  });
+
+  it("allows a manager to fetch rental detail from the staff route for their station", async () => {
+    const { rental, startStation } = await createActiveRentalGraph();
+    const { token: managerToken } = await createManagerToken(startStation.id);
+
+    const response = await fixture.app.request(`http://test/v1/staff/rentals/${rental.id}`, {
+      headers: {
+        Authorization: `Bearer ${managerToken}`,
+      },
+    });
+
+    const body = await response.json() as RentalsContracts.RentalDetail;
+
+    expect(response.status).toBe(200);
+    expect(body.id).toBe(rental.id);
+  });
+
+  it("hides rental detail from manager when the rental is outside their station", async () => {
+    const { rental } = await createActiveRentalGraph();
+    const otherStation = await fixture.factories.station({ capacity: 5 });
+    const { token: managerToken } = await createManagerToken(otherStation.id);
+
+    const response = await fixture.app.request(`http://test/v1/staff/rentals/${rental.id}`, {
+      headers: {
+        Authorization: `Bearer ${managerToken}`,
+      },
+    });
+
+    expect(response.status).toBe(404);
   });
 
   it("lists my bike swap requests without being shadowed by the rental detail route", async () => {

--- a/packages/shared/src/contracts/server/stations/models.ts
+++ b/packages/shared/src/contracts/server/stations/models.ts
@@ -1,4 +1,5 @@
 import { z } from "../../../zod";
+import { UserRoleSchema } from "../users";
 
 export const StationTypeSchema = z.enum(["INTERNAL", "AGENCY"]);
 
@@ -60,6 +61,13 @@ export const StationReadSummarySchema = z.object({
   capacity: StationCapacitySchema,
   bikes: StationBikesSchema,
   returnSlots: StationReturnSlotsSchema,
+  workers: z.array(z.object({
+    userId: z.uuidv7(),
+    fullName: z.string(),
+    role: UserRoleSchema,
+    technicianTeamId: z.uuidv7().nullable(),
+    technicianTeamName: z.string().nullable(),
+  })).optional(),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),
 });


### PR DESCRIPTION
## Summary
- widen existing staff/operator rental and reservation routes so managers can use them too
- scope staff and manager rental and reservation reads to their assigned station
- add station detail workers payload so clients can see who is assigned at a station

## Verification
- pnpm build
- pnpm prisma generate
- pnpm tsc --noEmit
- pnpm eslint src/http/middlewares/auth.ts src/http/routes/rentals.ts src/http/routes/reservations.ts src/http/controllers/rentals/staff.controller.ts src/http/controllers/reservations/staff.controller.ts src/domain/users/models.ts src/domain/users/repository/user.mappers.ts src/domain/rentals/models.ts src/domain/rentals/repository/rental.repository.query.ts src/domain/stations/models.ts src/domain/stations/repository/read/station.read.repository.ts src/http/presenters/stations.presenter.ts src/http/test/e2e/rentals-end-routing.e2e.int.test.ts src/http/test/e2e/operator-reservations-routing.e2e.int.test.ts src/http/test/e2e/admin-stations-routing.e2e.int.test.ts
- pnpm vitest run --config vitest.int.config.ts --mode test src/http/test/e2e/rentals-end-routing.e2e.int.test.ts src/http/test/e2e/operator-reservations-routing.e2e.int.test.ts src/http/test/e2e/admin-stations-routing.e2e.int.test.ts