### PR TITLE
feat(server): add operator station context

### DIFF
--- a/apps/server/src/domain/stations/models.ts
+++ b/apps/server/src/domain/stations/models.ts
@@ -11,6 +11,12 @@ export type StationWorkerRow = {
   technicianTeamName: string | null;
 };
 
+export type StationContextRow = {
+  id: string;
+  name: string;
+  address: string;
+};
+
 export type StationRow = {
   id: string;
   name: string;

--- a/apps/server/src/domain/stations/repository/read/station.read.repository.ts
+++ b/apps/server/src/domain/stations/repository/read/station.read.repository.ts
@@ -11,6 +11,7 @@ import { makePageResult, normalizedPage } from "@/domain/shared/pagination";
 import type {
   NearestSearchArgs,
   NearestStationRow,
+  StationContextRow,
   StationRevenueRow,
   StationWorkerRow,
 } from "../../models";
@@ -39,6 +40,7 @@ export type StationReadRepo = Pick<
   | "getById"
   | "getByAgencyId"
   | "findIdNameAddressByIds"
+  | "listContextExcludingId"
   | "listNearest"
   | "getRevenueByStation"
 >;
@@ -253,6 +255,29 @@ export function makeStationReadRepository(
             cause,
           }),
       }).pipe(defectOn(StationRepositoryError));
+    },
+
+    listContextExcludingId(excludedId) {
+      return Effect.tryPromise({
+        try: () =>
+          client.station.findMany({
+            where: { id: { not: excludedId } },
+            orderBy: { name: "asc" },
+            select: {
+              id: true,
+              name: true,
+              address: true,
+            },
+          }),
+        catch: cause =>
+          new StationRepositoryError({
+            operation: "listContextExcludingId",
+            cause,
+          }),
+      }).pipe(
+        Effect.map((rows): StationContextRow[] => rows),
+        defectOn(StationRepositoryError),
+      );
     },
 
     listNearest({

--- a/apps/server/src/domain/stations/repository/station.repository.types.ts
+++ b/apps/server/src/domain/stations/repository/station.repository.types.ts
@@ -11,6 +11,7 @@ import type {
   CreateStationInput,
   NearestSearchArgs,
   NearestStationRow,
+  StationContextRow,
   StationFilter,
   StationRevenueRow,
   StationRow,
@@ -48,6 +49,9 @@ export type StationQueryRepo = {
   findIdNameAddressByIds: (
     ids: readonly string[],
   ) => Effect.Effect<readonly { id: string; name: string; address: string }[]>;
+  listContextExcludingId: (
+    excludedId: string,
+  ) => Effect.Effect<readonly StationContextRow[]>;
   listNearest: (
     args: NearestSearchArgs,
   ) => Effect.Effect<PageResult<NearestStationRow>>;

--- a/apps/server/src/domain/stations/services/station-query.service.ts
+++ b/apps/server/src/domain/stations/services/station-query.service.ts
@@ -26,6 +26,9 @@ export function makeStationQueryService(repo: StationQueryRepo): StationQuerySer
         return maybe.value;
       }),
 
+    listContextExcludingId: excludedId =>
+      repo.listContextExcludingId(excludedId),
+
     listNearestStations: args =>
       repo.listNearest(args),
 

--- a/apps/server/src/domain/stations/services/station.service.types.ts
+++ b/apps/server/src/domain/stations/services/station.service.types.ts
@@ -19,6 +19,7 @@ import type {
   CreateStationInput,
   NearestSearchArgs,
   NearestStationRow,
+  StationContextRow,
   StationFilter,
   StationRevenueStats,
   StationRow,
@@ -95,6 +96,10 @@ export type StationQueryService = {
    * @returns Effect tra ve tram neu tim thay.
    */
   getStationById: (id: string) => Effect.Effect<StationRow, import("../errors").StationNotFound>;
+
+  listContextExcludingId: (
+    excludedId: string,
+  ) => Effect.Effect<readonly StationContextRow[]>;
 
   /**
    * Tim tram gan nhat theo vi tri hien tai.

--- a/apps/server/src/http/app.ts
+++ b/apps/server/src/http/app.ts
@@ -24,6 +24,7 @@ import { registerEventRoutes } from "./routes/events";
 import { registerFixedSlotTemplateRoutes } from "./routes/fixed-slot-templates";
 import { registerHealthRoutes } from "./routes/health";
 import { registerIncidentRoutes } from "./routes/incidents";
+import { registerOperatorRoutes } from "./routes/operators";
 import { registerRatingRoutes } from "./routes/ratings";
 import { registerRedistributionRoutes } from "./routes/redistribution";
 import { registerRentalRoutes } from "./routes/rentals";
@@ -139,6 +140,7 @@ export function createHttpApp({ runPromise }: { runPromise: RunPromise }) {
   registerWalletRoutes(app);
   registerSubscriptionRoutes(app);
   registerIncidentRoutes(app);
+  registerOperatorRoutes(app);
 
   app.onError((err, c) => {
     const isProd = env.NODE_ENV === "production";

--- a/apps/server/src/http/controllers/operators.controller.ts
+++ b/apps/server/src/http/controllers/operators.controller.ts
@@ -1,0 +1,89 @@
+import type { RouteHandler } from "@hono/zod-openapi";
+
+import {
+  operatorErrorMessages,
+  OperatorsContracts,
+  serverRoutes,
+  UnauthorizedErrorCodeSchema,
+  unauthorizedErrorMessages,
+} from "@mebike/shared";
+import { Effect } from "effect";
+
+import { withLoggedCause } from "@/domain/shared";
+import { StationQueryServiceTag } from "@/domain/stations";
+import { routeContext } from "@/http/shared/route-context";
+
+type OperatorsRoutes = typeof import("@mebike/shared")["serverRoutes"]["operators"];
+const operators = serverRoutes.operators;
+
+const getStationContext: RouteHandler<OperatorsRoutes["stationContext"]> = async (c) => {
+  const currentStationId = c.var.currentUser?.operatorStationId;
+
+  if (!c.var.currentUser) {
+    return c.json(
+      {
+        error: unauthorizedErrorMessages.UNAUTHORIZED,
+        details: { code: UnauthorizedErrorCodeSchema.enum.UNAUTHORIZED },
+      },
+      401,
+    );
+  }
+
+  if (!currentStationId) {
+    return c.json<OperatorsContracts.OperatorErrorResponse, 404>(
+      {
+        error: operatorErrorMessages.OPERATOR_STATION_NOT_FOUND,
+        details: {
+          code: OperatorsContracts.OperatorErrorCodeSchema.enum.OPERATOR_STATION_NOT_FOUND,
+        },
+      },
+      404,
+    );
+  }
+
+  const eff = withLoggedCause(
+    Effect.gen(function* () {
+      const service = yield* StationQueryServiceTag;
+
+      const [currentStation, otherStations] = yield* Effect.all([
+        service.getStationById(currentStationId),
+        service.listContextExcludingId(currentStationId),
+      ]);
+
+      return {
+        currentStation: {
+          id: currentStation.id,
+          name: currentStation.name,
+          address: currentStation.address,
+        },
+        otherStations: otherStations.map(station => ({
+          id: station.id,
+          name: station.name,
+          address: station.address,
+        })),
+      } satisfies OperatorsContracts.OperatorStationContextResponse;
+    }),
+    routeContext(operators.stationContext),
+  );
+
+  const result = await c.var.runPromise(eff.pipe(Effect.either));
+
+  if (result._tag === "Right") {
+    return c.json<OperatorsContracts.OperatorStationContextResponse, 200>(result.right, 200);
+  }
+
+  return c.json<OperatorsContracts.OperatorErrorResponse, 404>(
+    {
+      error: operatorErrorMessages.OPERATOR_STATION_NOT_FOUND,
+      details: {
+        code: OperatorsContracts.OperatorErrorCodeSchema.enum.OPERATOR_STATION_NOT_FOUND,
+        stationId: currentStationId,
+      },
+    },
+    404,
+  );
+};
+
+export const OperatorController = {
+  getStationContext,
+} as const;

--- a/apps/server/src/http/middlewares/auth.ts
+++ b/apps/server/src/http/middlewares/auth.ts
@@ -131,6 +131,7 @@ export const requireStaffMiddleware = requireRoles("STAFF");
 export const requireStaffOrManagerMiddleware = requireRoles("STAFF", "MANAGER");
 export const requireUserMiddleware = requireRoles("USER");
 export const requireTechnicianMiddleware = requireRoles("TECHNICIAN");
+export const requireOperatorMiddleware = requireRoles("STAFF", "MANAGER", "AGENCY", "TECHNICIAN");
 export const requireBackofficeMiddleware = requireRoles("ADMIN", "STAFF");
 export const requireRentalOperatorMiddleware = requireRoles("STAFF", "AGENCY");
 export const requireRentalOperatorManagerMiddleware = requireRoles("STAFF", "MANAGER", "AGENCY");

--- a/apps/server/src/http/routes/operators.ts
+++ b/apps/server/src/http/routes/operators.ts
@@ -1,0 +1,17 @@
+import type { RouteConfig } from "@hono/zod-openapi";
+
+import { serverRoutes } from "@mebike/shared";
+
+import { OperatorController } from "@/http/controllers/operators.controller";
+import { requireOperatorMiddleware } from "@/http/middlewares/auth";
+
+export function registerOperatorRoutes(app: import("@hono/zod-openapi").OpenAPIHono) {
+  const operators = serverRoutes.operators;
+
+  const stationContextRoute = {
+    ...operators.stationContext,
+    middleware: [requireOperatorMiddleware] as const,
+  } satisfies RouteConfig;
+
+  app.openapi(stationContextRoute, OperatorController.getStationContext);
+}

--- a/apps/server/src/http/test/e2e/operator-station-context-routing.e2e.int.test.ts
+++ b/apps/server/src/http/test/e2e/operator-station-context-routing.e2e.int.test.ts
@@ -1,0 +1,101 @@
+import type { OperatorsContracts } from "@mebike/shared";
+
+import { describe, expect, it } from "vitest";
+
+import { setupHttpE2eFixture } from "@/test/http/e2e-fixture";
+
+describe("operator station context routing e2e", () => {
+  const fixture = setupHttpE2eFixture({
+    buildLayer: async () => {
+      const { Layer } = await import("effect");
+      const {
+        StationDepsLive,
+        UserDepsLive,
+      } = await import("@/http/shared/providers");
+
+      return Layer.mergeAll(
+        StationDepsLive,
+        UserDepsLive,
+      );
+    },
+  });
+
+  async function createStaffToken(stationId?: string) {
+    const staff = await fixture.factories.user({ role: "STAFF" });
+
+    if (stationId) {
+      await fixture.factories.userOrgAssignment({ userId: staff.id, stationId });
+    }
+
+    return fixture.auth.makeAccessToken({ userId: staff.id, role: "STAFF" });
+  }
+
+  it("returns current operator station plus all other stations", async () => {
+    const currentStation = await fixture.factories.station({
+      name: "Current Station",
+      address: "1 Current Street, Thu Duc, TP.HCM",
+    });
+    const otherStationA = await fixture.factories.station({
+      name: "Alpha Station",
+      address: "2 Alpha Street, Thu Duc, TP.HCM",
+    });
+    const otherStationB = await fixture.factories.station({
+      name: "Beta Station",
+      address: "3 Beta Street, Thu Duc, TP.HCM",
+    });
+    const token = await createStaffToken(currentStation.id);
+
+    const response = await fixture.app.request("http://test/v1/operators/station-context", {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    const body = await response.json() as OperatorsContracts.OperatorStationContextResponse;
+
+    expect(response.status).toBe(200);
+    expect(body.currentStation).toEqual({
+      id: currentStation.id,
+      name: "Current Station",
+      address: "1 Current Street, Thu Duc, TP.HCM",
+    });
+    expect(body.otherStations).toEqual(expect.arrayContaining([
+      {
+        id: otherStationA.id,
+        name: "Alpha Station",
+        address: "2 Alpha Street, Thu Duc, TP.HCM",
+      },
+      {
+        id: otherStationB.id,
+        name: "Beta Station",
+        address: "3 Beta Street, Thu Duc, TP.HCM",
+      },
+    ]));
+    expect(body.otherStations.some(station => station.id === currentStation.id)).toBe(false);
+  });
+
+  it("returns 404 when operator has no station assignment", async () => {
+    const token = await createStaffToken();
+
+    const response = await fixture.app.request("http://test/v1/operators/station-context", {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    expect(response.status).toBe(404);
+  });
+
+  it("rejects regular users", async () => {
+    const user = await fixture.factories.user({ role: "USER" });
+    const token = fixture.auth.makeAccessToken({ userId: user.id, role: "USER" });
+
+    const response = await fixture.app.request("http://test/v1/operators/station-context", {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    expect(response.status).toBe(403);
+  });
+});

--- a/packages/shared/src/contracts/server/index.ts
+++ b/packages/shared/src/contracts/server/index.ts
@@ -11,6 +11,8 @@ export * from "./fixed-slots";
 export * as IncidentsContracts from "./incidents";
 export * as JobsContracts from "./jobs";
 export * from "./jobs";
+export * as OperatorsContracts from "./operators";
+export * from "./operators";
 export * as RatingsContracts from "./ratings";
 export * as RedistributionContracts from "./redistribution";
 export * as RentalsContracts from "./rentals";

--- a/packages/shared/src/contracts/server/operators/index.ts
+++ b/packages/shared/src/contracts/server/operators/index.ts
@@ -1,0 +1,1 @@
+export * from "./models";

--- a/packages/shared/src/contracts/server/operators/models.ts
+++ b/packages/shared/src/contracts/server/operators/models.ts
@@ -1,0 +1,32 @@
+import { z } from "../../../zod";
+
+export const OperatorStationContextStationSchema = z.object({
+  id: z.uuidv7(),
+  name: z.string(),
+  address: z.string(),
+}).openapi("OperatorStationContextStation");
+
+export const OperatorStationContextResponseSchema = z.object({
+  currentStation: OperatorStationContextStationSchema,
+  otherStations: z.array(OperatorStationContextStationSchema),
+}).openapi("OperatorStationContextResponse");
+
+export const OperatorErrorCodeSchema = z.enum([
+  "OPERATOR_STATION_NOT_FOUND",
+]).openapi("OperatorErrorCode");
+
+export const operatorErrorMessages = {
+  OPERATOR_STATION_NOT_FOUND: "Operator station not found",
+} as const;
+
+export const OperatorErrorResponseSchema = z.object({
+  error: z.string(),
+  details: z.object({
+    code: OperatorErrorCodeSchema,
+    stationId: z.uuidv7().optional(),
+  }),
+}).openapi("OperatorErrorResponse");
+
+export type OperatorStationContextStation = z.infer<typeof OperatorStationContextStationSchema>;
+export type OperatorStationContextResponse = z.infer<typeof OperatorStationContextResponseSchema>;
+export type OperatorErrorResponse = z.infer<typeof OperatorErrorResponseSchema>;

--- a/packages/shared/src/contracts/server/routes/index.ts
+++ b/packages/shared/src/contracts/server/routes/index.ts
@@ -6,6 +6,7 @@ import { environmentRoutes } from "./environment";
 import { fixedSlotTemplatesRoutes } from "./fixed-slots";
 import { healthRoutes } from "./health";
 import { incidentsRoutes } from "./incidents";
+import { operatorsRoutes } from "./operators";
 import { ratingsRoutes } from "./ratings";
 import { redistributionRoutes } from "./redistribution";
 import { rentalsRoutes } from "./rentals";
@@ -27,6 +28,7 @@ export * from "./environment";
 export * from "./fixed-slots";
 export * from "./health";
 export * from "./incidents";
+export * from "./operators";
 export * from "./ratings";
 export * from "./redistribution";
 export * from "./rentals";
@@ -59,6 +61,7 @@ export const serverRoutes = {
   wallets: walletsRoutes,
   stripe: stripeRoutes,
   incidents: incidentsRoutes,
+  operators: operatorsRoutes,
   redistribution: redistributionRoutes,
   technicianTeams: technicianTeamsRoutes,
 } as const;

--- a/packages/shared/src/contracts/server/routes/operators/index.ts
+++ b/packages/shared/src/contracts/server/routes/operators/index.ts
@@ -1,0 +1,7 @@
+import { getOperatorStationContextRoute } from "./queries";
+
+export { getOperatorStationContextRoute as stationContext } from "./queries";
+
+export const operatorsRoutes = {
+  stationContext: getOperatorStationContextRoute,
+} as const;

--- a/packages/shared/src/contracts/server/routes/operators/queries.ts
+++ b/packages/shared/src/contracts/server/routes/operators/queries.ts
@@ -1,0 +1,42 @@
+import { createRoute } from "@hono/zod-openapi";
+
+import {
+  OperatorErrorCodeSchema,
+  operatorErrorMessages,
+  OperatorErrorResponseSchema,
+  OperatorStationContextResponseSchema,
+} from "../../operators";
+import {
+  forbiddenResponse,
+  notFoundResponse,
+  unauthorizedResponse,
+} from "../helpers";
+
+export const getOperatorStationContextRoute = createRoute({
+  method: "get",
+  path: "/v1/operators/station-context",
+  tags: ["Operators"],
+  security: [{ bearerAuth: [] }],
+  responses: {
+    200: {
+      description: "Current operator station plus all other stations",
+      content: {
+        "application/json": {
+          schema: OperatorStationContextResponseSchema,
+        },
+      },
+    },
+    401: unauthorizedResponse(),
+    403: forbiddenResponse("Operator"),
+    404: notFoundResponse({
+      description: "Operator station not found",
+      schema: OperatorErrorResponseSchema,
+      example: {
+        error: operatorErrorMessages.OPERATOR_STATION_NOT_FOUND,
+        details: {
+          code: OperatorErrorCodeSchema.enum.OPERATOR_STATION_NOT_FOUND,
+        },
+      },
+    }),
+  },
+});


### PR DESCRIPTION
## Summary
- add `GET /v1/operators/station-context` so operator screens can default the logged-in worker's station without extra client-side stitching
- return plain `currentStation` and `otherStations` resources with no pagination, using auth-resolved station context
- cover the new operator endpoint with focused e2e checks for success, missing station assignment, and forbidden access

## Verification
- `pnpm --dir ../../packages/shared build && pnpm prisma generate && pnpm tsc --noEmit`
- `pnpm vitest run --config vitest.int.config.ts --mode test src/http/test/e2e/operator-station-context-routing.e2e.int.test.ts`
- `pnpm eslint src/http/controllers/operators.controller.ts src/http/routes/operators.ts src/http/middlewares/auth.ts src/http/app.ts src/domain/stations/models.ts src/domain/stations/repository/station.repository.types.ts src/domain/stations/services/station.service.types.ts src/domain/stations/services/station-query.service.ts src/domain/stations/repository/read/station.read.repository.ts src/http/test/e2e/operator-station-context-routing.e2e.int.test.ts`