### PR TITLE
feat(server): add scoped staff bike and station routes

### DIFF
--- a/apps/server/src/domain/stations/models.ts
+++ b/apps/server/src/domain/stations/models.ts
@@ -65,6 +65,7 @@ export type UpdateStationInput = {
 };
 
 export type StationFilter = {
+  id?: string;
   name?: string;
   address?: string;
   stationType?: StationType;

--- a/apps/server/src/domain/stations/repository/station.repository.helpers.ts
+++ b/apps/server/src/domain/stations/repository/station.repository.helpers.ts
@@ -139,6 +139,7 @@ export function toStationOrderBy(
 export function toStationWhere(filter: StationFilter): PrismaTypes.StationWhereInput {
   return {
     ...pickDefined({
+      id: filter.id,
       name: filter.name
         ? { contains: filter.name, mode: "insensitive" }
         : undefined,

--- a/apps/server/src/http/controllers/bikes/index.ts
+++ b/apps/server/src/http/controllers/bikes/index.ts
@@ -1,4 +1,5 @@
 export * from "./admin.controller";
 export * from "./public.controller";
 export * from "./shared";
+export * from "./staff.controller";
 export * from "./stats.controller";

--- a/apps/server/src/http/controllers/bikes/staff.controller.ts
+++ b/apps/server/src/http/controllers/bikes/staff.controller.ts
@@ -1,0 +1,133 @@
+import type { RouteHandler } from "@hono/zod-openapi";
+
+import { Effect, Match, Option } from "effect";
+
+import { BikeServiceTag } from "@/domain/bikes";
+import { withLoggedCause } from "@/domain/shared";
+
+import type { BikeListResponse, BikeNotFoundResponse, BikesRoutes, BikeSummary } from "./shared";
+
+import {
+  BikeErrorCodeSchema,
+  bikeErrorMessages,
+  loadBikeSummaries,
+  loadBikeSummary,
+} from "./shared";
+
+function getStationScopedRoleScope(currentUser: {
+  role: string;
+  operatorStationId?: string;
+}) {
+  if (
+    currentUser.role === "STAFF"
+    || currentUser.role === "MANAGER"
+    || currentUser.role === "TECHNICIAN"
+  ) {
+    return currentUser.operatorStationId ?? null;
+  }
+
+  return undefined;
+}
+
+const staffListBikes: RouteHandler<BikesRoutes["staffListBikes"]> = async (c) => {
+  const query = c.req.valid("query");
+  const stationScopeId = getStationScopedRoleScope(c.var.currentUser!);
+
+  if (stationScopeId === null) {
+    return c.json<BikeListResponse, 200>({
+      data: [],
+      pagination: {
+        page: query.page ?? 1,
+        pageSize: query.pageSize ?? 50,
+        total: 0,
+        totalPages: 0,
+      },
+    }, 200);
+  }
+
+  const eff = withLoggedCause(
+    Effect.gen(function* () {
+      const service = yield* BikeServiceTag;
+      const page = yield* service.listBikes(
+        {
+          id: query.id,
+          stationId: stationScopeId ?? query.stationId,
+          supplierId: query.supplierId,
+          status: query.status,
+        },
+        {
+          page: query.page ?? 1,
+          pageSize: query.pageSize ?? 50,
+          sortBy: query.sortBy ?? "status",
+          sortDir: query.sortDir ?? "asc",
+        },
+      );
+
+      const data = yield* loadBikeSummaries(page.items);
+      return { page, data };
+    }),
+    "GET /v1/staff/bikes",
+  );
+
+  const value = await c.var.runPromise(eff.pipe(Effect.either));
+
+  return Match.value(value).pipe(
+    Match.tag("Right", ({ right }) =>
+      c.json<BikeListResponse, 200>({
+        data: right.data,
+        pagination: {
+          page: right.page.page,
+          pageSize: right.page.pageSize,
+          total: right.page.total,
+          totalPages: right.page.totalPages,
+        },
+      }, 200)),
+    Match.tag("Left", () =>
+      c.json({
+        error: bikeErrorMessages.INVALID_QUERY_PARAMS,
+        details: { code: BikeErrorCodeSchema.enum.INVALID_QUERY_PARAMS },
+      }, 400)),
+    Match.exhaustive,
+  );
+};
+
+const staffGetBike: RouteHandler<BikesRoutes["staffGetBike"]> = async (c) => {
+  const { id } = c.req.valid("param");
+  const stationScopeId = getStationScopedRoleScope(c.var.currentUser!);
+
+  if (stationScopeId === null) {
+    return c.json<BikeNotFoundResponse, 404>({
+      error: bikeErrorMessages.BIKE_NOT_FOUND,
+      details: { code: BikeErrorCodeSchema.enum.BIKE_NOT_FOUND },
+    }, 404);
+  }
+
+  const eff = Effect.gen(function* () {
+    const service = yield* BikeServiceTag;
+    const bike = yield* service.getBikeDetail(id);
+
+    if (Option.isNone(bike)) {
+      return Option.none<BikeSummary>();
+    }
+
+    if (stationScopeId && bike.value.stationId !== stationScopeId) {
+      return Option.none<BikeSummary>();
+    }
+
+    const summary = yield* loadBikeSummary(bike.value);
+    return Option.some(summary);
+  });
+
+  const value = await c.var.runPromise(withLoggedCause(eff, `GET /v1/staff/bikes/${id}`));
+  return Option.isSome(value)
+    ? c.json<BikeSummary, 200>(value.value, 200)
+    : c.json<BikeNotFoundResponse, 404>({
+        error: bikeErrorMessages.BIKE_NOT_FOUND,
+        details: { code: BikeErrorCodeSchema.enum.BIKE_NOT_FOUND },
+      }, 404);
+};
+
+export const BikeStaffController = {
+  staffListBikes,
+  staffGetBike,
+} as const;

--- a/apps/server/src/http/controllers/stations/index.ts
+++ b/apps/server/src/http/controllers/stations/index.ts
@@ -1,3 +1,4 @@
 export * from "./admin.controller";
 export * from "./public.controller";
 export * from "./shared";
+export * from "./staff.controller";

--- a/apps/server/src/http/controllers/stations/staff.controller.ts
+++ b/apps/server/src/http/controllers/stations/staff.controller.ts
@@ -1,0 +1,161 @@
+import type { RouteHandler } from "@hono/zod-openapi";
+import type { StationsContracts } from "@mebike/shared";
+
+import { Effect, Match } from "effect";
+
+import { withLoggedCause } from "@/domain/shared";
+import { StationQueryServiceTag } from "@/domain/stations";
+import { toContractStationReadSummary } from "@/http/presenters/stations.presenter";
+
+import type {
+  StationErrorResponse,
+  StationListResponse,
+  StationReadSummary,
+  StationsRoutes,
+} from "./shared";
+
+import { StationErrorCodeSchema, stationErrorMessages } from "./shared";
+
+type StationListQuery = StationsContracts.StationListQuery;
+
+function getStationScopedRoleScope(currentUser: {
+  role: string;
+  operatorStationId?: string;
+}) {
+  if (
+    currentUser.role === "STAFF"
+    || currentUser.role === "MANAGER"
+    || currentUser.role === "TECHNICIAN"
+  ) {
+    return currentUser.operatorStationId ?? null;
+  }
+
+  return undefined;
+}
+
+function matchesStationFilters(
+  station: { name: string; address: string; stationType: string; agencyId: string | null; totalCapacity: number },
+  query: StationListQuery,
+) {
+  if (query.name && !station.name.toLowerCase().includes(query.name.toLowerCase())) {
+    return false;
+  }
+
+  if (query.address && !station.address.toLowerCase().includes(query.address.toLowerCase())) {
+    return false;
+  }
+
+  if (query.stationType && station.stationType !== query.stationType) {
+    return false;
+  }
+
+  if (query.agencyId && station.agencyId !== query.agencyId) {
+    return false;
+  }
+
+  if (typeof query.totalCapacity === "number" && station.totalCapacity !== query.totalCapacity) {
+    return false;
+  }
+
+  return true;
+}
+
+const staffListStations: RouteHandler<StationsRoutes["staffListStations"]> = async (c) => {
+  const query = c.req.valid("query");
+  const stationScopeId = getStationScopedRoleScope(c.var.currentUser!);
+
+  if (stationScopeId === null) {
+    return c.json<StationListResponse, 200>({
+      data: [],
+      pagination: {
+        page: query.page ?? 1,
+        pageSize: query.pageSize ?? 50,
+        total: 0,
+        totalPages: 0,
+      },
+    }, 200);
+  }
+
+  const eff = withLoggedCause(
+    Effect.gen(function* () {
+      const service = yield* StationQueryServiceTag;
+      const station = yield* service.getStationById(stationScopeId!);
+
+      return matchesStationFilters(station, query) ? [station] : [];
+    }),
+    "GET /v1/staff/stations",
+  );
+
+  const result = await c.var.runPromise(eff.pipe(Effect.either));
+
+  return Match.value(result).pipe(
+    Match.tag("Right", ({ right }) => {
+      const total = right.length;
+      const page = query.page ?? 1;
+      const pageSize = query.pageSize ?? 50;
+      const data = page === 1 && total > 0 ? right.map(toContractStationReadSummary) : [];
+
+      return c.json<StationListResponse, 200>({
+        data,
+        pagination: {
+          page,
+          pageSize,
+          total,
+          totalPages: total === 0 ? 0 : Math.ceil(total / pageSize),
+        },
+      }, 200);
+    }),
+    Match.tag("Left", () =>
+      c.json<StationErrorResponse, 404>({
+        error: stationErrorMessages.STATION_NOT_FOUND,
+        details: {
+          code: StationErrorCodeSchema.enum.STATION_NOT_FOUND,
+          stationId: stationScopeId!,
+        },
+      }, 404)),
+    Match.exhaustive,
+  );
+};
+
+const staffGetStation: RouteHandler<StationsRoutes["staffGetStation"]> = async (c) => {
+  const { stationId } = c.req.valid("param");
+  const stationScopeId = getStationScopedRoleScope(c.var.currentUser!);
+
+  if (stationScopeId === null || stationId !== stationScopeId) {
+    return c.json<StationErrorResponse, 404>({
+      error: stationErrorMessages.STATION_NOT_FOUND,
+      details: {
+        code: StationErrorCodeSchema.enum.STATION_NOT_FOUND,
+        stationId,
+      },
+    }, 404);
+  }
+
+  const eff = withLoggedCause(
+    Effect.gen(function* () {
+      const service = yield* StationQueryServiceTag;
+      return yield* service.getStationById(stationId);
+    }),
+    `GET /v1/staff/stations/${stationId}`,
+  );
+
+  const result = await c.var.runPromise(eff.pipe(Effect.either));
+
+  return Match.value(result).pipe(
+    Match.tag("Right", ({ right }) => c.json<StationReadSummary, 200>(toContractStationReadSummary(right), 200)),
+    Match.tag("Left", () =>
+      c.json<StationErrorResponse, 404>({
+        error: stationErrorMessages.STATION_NOT_FOUND,
+        details: {
+          code: StationErrorCodeSchema.enum.STATION_NOT_FOUND,
+          stationId,
+        },
+      }, 404)),
+    Match.exhaustive,
+  );
+};
+
+export const StationStaffController = {
+  staffListStations,
+  staffGetStation,
+} as const;

--- a/apps/server/src/http/controllers/stations/staff.controller.ts
+++ b/apps/server/src/http/controllers/stations/staff.controller.ts
@@ -1,5 +1,4 @@
 import type { RouteHandler } from "@hono/zod-openapi";
-import type { StationsContracts } from "@mebike/shared";
 
 import { Effect, Match } from "effect";
 
@@ -16,8 +15,6 @@ import type {
 
 import { StationErrorCodeSchema, stationErrorMessages } from "./shared";
 
-type StationListQuery = StationsContracts.StationListQuery;
-
 function getStationScopedRoleScope(currentUser: {
   role: string;
   operatorStationId?: string;
@@ -31,33 +28,6 @@ function getStationScopedRoleScope(currentUser: {
   }
 
   return undefined;
-}
-
-function matchesStationFilters(
-  station: { name: string; address: string; stationType: string; agencyId: string | null; totalCapacity: number },
-  query: StationListQuery,
-) {
-  if (query.name && !station.name.toLowerCase().includes(query.name.toLowerCase())) {
-    return false;
-  }
-
-  if (query.address && !station.address.toLowerCase().includes(query.address.toLowerCase())) {
-    return false;
-  }
-
-  if (query.stationType && station.stationType !== query.stationType) {
-    return false;
-  }
-
-  if (query.agencyId && station.agencyId !== query.agencyId) {
-    return false;
-  }
-
-  if (typeof query.totalCapacity === "number" && station.totalCapacity !== query.totalCapacity) {
-    return false;
-  }
-
-  return true;
 }
 
 const staffListStations: RouteHandler<StationsRoutes["staffListStations"]> = async (c) => {
@@ -79,9 +49,31 @@ const staffListStations: RouteHandler<StationsRoutes["staffListStations"]> = asy
   const eff = withLoggedCause(
     Effect.gen(function* () {
       const service = yield* StationQueryServiceTag;
-      const station = yield* service.getStationById(stationScopeId!);
 
-      return matchesStationFilters(station, query) ? [station] : [];
+      const page = yield* service.listStations(
+        {
+          id: stationScopeId!,
+          name: query.name,
+          address: query.address,
+          stationType: query.stationType,
+          agencyId: query.agencyId,
+          totalCapacity: query.totalCapacity,
+        },
+        {
+          page: query.page ?? 1,
+          pageSize: query.pageSize ?? 50,
+          sortBy: query.sortBy ?? "name",
+          sortDir: query.sortDir ?? "asc",
+        },
+      );
+
+      if (page.total > 0) {
+        return page;
+      }
+
+      yield* service.getStationById(stationScopeId!);
+
+      return page;
     }),
     "GET /v1/staff/stations",
   );
@@ -89,22 +81,16 @@ const staffListStations: RouteHandler<StationsRoutes["staffListStations"]> = asy
   const result = await c.var.runPromise(eff.pipe(Effect.either));
 
   return Match.value(result).pipe(
-    Match.tag("Right", ({ right }) => {
-      const total = right.length;
-      const page = query.page ?? 1;
-      const pageSize = query.pageSize ?? 50;
-      const data = page === 1 && total > 0 ? right.map(toContractStationReadSummary) : [];
-
-      return c.json<StationListResponse, 200>({
-        data,
+    Match.tag("Right", ({ right }) =>
+      c.json<StationListResponse, 200>({
+        data: right.items.map(toContractStationReadSummary),
         pagination: {
-          page,
-          pageSize,
-          total,
-          totalPages: total === 0 ? 0 : Math.ceil(total / pageSize),
+          page: right.page,
+          pageSize: right.pageSize,
+          total: right.total,
+          totalPages: right.totalPages,
         },
-      }, 200);
-    }),
+      }, 200)),
     Match.tag("Left", () =>
       c.json<StationErrorResponse, 404>({
         error: stationErrorMessages.STATION_NOT_FOUND,

--- a/apps/server/src/http/middlewares/auth.ts
+++ b/apps/server/src/http/middlewares/auth.ts
@@ -129,6 +129,7 @@ export const requireAgencyMiddleware = requireRoles("AGENCY");
 export const requireManagerMiddleware = requireRoles("MANAGER");
 export const requireStaffMiddleware = requireRoles("STAFF");
 export const requireStaffOrManagerMiddleware = requireRoles("STAFF", "MANAGER");
+export const requireStationScopedOperatorMiddleware = requireRoles("STAFF", "MANAGER", "TECHNICIAN");
 export const requireUserMiddleware = requireRoles("USER");
 export const requireTechnicianMiddleware = requireRoles("TECHNICIAN");
 export const requireOperatorMiddleware = requireRoles("STAFF", "MANAGER", "AGENCY", "TECHNICIAN");

--- a/apps/server/src/http/routes/bikes.ts
+++ b/apps/server/src/http/routes/bikes.ts
@@ -5,11 +5,13 @@ import { serverRoutes } from "@mebike/shared";
 import {
   BikeAdminController,
   BikePublicController,
+  BikeStaffController,
   BikeStatsController,
 } from "@/http/controllers/bikes";
 import {
   requireAdminMiddleware,
   requireBackofficeMiddleware,
+  requireStationScopedOperatorMiddleware,
 } from "@/http/middlewares/auth";
 
 export function registerBikeRoutes(app: import("@hono/zod-openapi").OpenAPIHono) {
@@ -22,6 +24,13 @@ export function registerBikeRoutes(app: import("@hono/zod-openapi").OpenAPIHono)
   app.openapi(createBikeRoute, BikeAdminController.createBike);
 
   app.openapi(bikes.listBikes, BikePublicController.listBikes);
+
+  const staffListBikesRoute = {
+    ...bikes.staffListBikes,
+    middleware: [requireStationScopedOperatorMiddleware] as const,
+  } satisfies RouteConfig;
+
+  app.openapi(staffListBikesRoute, BikeStaffController.staffListBikes);
 
   app.openapi(bikes.updateBike, BikeAdminController.updateBike);
 
@@ -74,6 +83,13 @@ export function registerBikeRoutes(app: import("@hono/zod-openapi").OpenAPIHono)
   // Keep single-segment dynamic route last to avoid accidental shadowing
   // if future static endpoints are added under /v1/bikes/*.
   app.openapi(bikes.getBike, BikePublicController.getBike);
+
+  const staffGetBikeRoute = {
+    ...bikes.staffGetBike,
+    middleware: [requireStationScopedOperatorMiddleware] as const,
+  } satisfies RouteConfig;
+
+  app.openapi(staffGetBikeRoute, BikeStaffController.staffGetBike);
 
   // Analytics endpoints implemented above.
 }

--- a/apps/server/src/http/routes/stations.ts
+++ b/apps/server/src/http/routes/stations.ts
@@ -5,8 +5,12 @@ import { serverRoutes } from "@mebike/shared";
 import {
   StationAdminController,
   StationPublicController,
+  StationStaffController,
 } from "@/http/controllers/stations";
-import { requireAdminMiddleware } from "@/http/middlewares/auth";
+import {
+  requireAdminMiddleware,
+  requireStationScopedOperatorMiddleware,
+} from "@/http/middlewares/auth";
 
 export function registerStationRoutes(
   app: import("@hono/zod-openapi").OpenAPIHono,
@@ -31,9 +35,23 @@ export function registerStationRoutes(
 
   app.openapi(stations.listStations, StationPublicController.listStations);
 
+  const staffListStationsRoute = {
+    ...stations.staffListStations,
+    middleware: [requireStationScopedOperatorMiddleware] as const,
+  } satisfies RouteConfig;
+
+  app.openapi(staffListStationsRoute, StationStaffController.staffListStations);
+
   app.openapi(stations.getAllStationsRevenue, StationPublicController.getAllStationsRevenue);
 
   app.openapi(stations.getNearbyStations, StationPublicController.getNearbyStations);
 
   app.openapi(stations.getStation, StationPublicController.getStation);
+
+  const staffGetStationRoute = {
+    ...stations.staffGetStation,
+    middleware: [requireStationScopedOperatorMiddleware] as const,
+  } satisfies RouteConfig;
+
+  app.openapi(staffGetStationRoute, StationStaffController.staffGetStation);
 }

--- a/apps/server/src/http/test/e2e/operator-bikes-routing.e2e.int.test.ts
+++ b/apps/server/src/http/test/e2e/operator-bikes-routing.e2e.int.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { setupHttpE2eFixture } from "@/test/http/e2e-fixture";
+
+describe("operator bikes routing e2e", () => {
+  const fixture = setupHttpE2eFixture({
+    buildLayer: async () => {
+      const { Layer } = await import("effect");
+      const { BikeDepsLive } = await import("@/http/shared/providers");
+      const { UserDepsLive } = await import("@/http/shared/features/user.layers");
+
+      return Layer.mergeAll(
+        UserDepsLive,
+        BikeDepsLive,
+      );
+    },
+  });
+
+  async function createOperatorToken(role: "STAFF" | "MANAGER" | "TECHNICIAN", stationId?: string) {
+    const user = await fixture.factories.user({ role });
+
+    if (stationId) {
+      await fixture.factories.userOrgAssignment({ userId: user.id, stationId });
+    }
+
+    return fixture.auth.makeAccessToken({ userId: user.id, role });
+  }
+
+  it("lists only bikes from the assigned station for technician", async () => {
+    const visibleStation = await fixture.factories.station({ capacity: 5 });
+    const hiddenStation = await fixture.factories.station({ capacity: 5 });
+    const visibleBike = await fixture.factories.bike({ stationId: visibleStation.id, status: "AVAILABLE" });
+    await fixture.factories.bike({ stationId: hiddenStation.id, status: "AVAILABLE" });
+    const token = await createOperatorToken("TECHNICIAN", visibleStation.id);
+
+    const response = await fixture.app.request("http://test/v1/staff/bikes?page=1&pageSize=20", {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    const body = await response.json() as { data: Array<{ id: string }> };
+
+    expect(response.status).toBe(200);
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0]?.id).toBe(visibleBike.id);
+  });
+
+  it("returns 404 when manager requests bike detail outside their station", async () => {
+    const visibleStation = await fixture.factories.station({ capacity: 5 });
+    const hiddenStation = await fixture.factories.station({ capacity: 5 });
+    const hiddenBike = await fixture.factories.bike({ stationId: hiddenStation.id, status: "AVAILABLE" });
+    const token = await createOperatorToken("MANAGER", visibleStation.id);
+
+    const response = await fixture.app.request(`http://test/v1/staff/bikes/${hiddenBike.id}`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/apps/server/src/http/test/e2e/operator-bikes-routing.e2e.int.test.ts
+++ b/apps/server/src/http/test/e2e/operator-bikes-routing.e2e.int.test.ts
@@ -6,12 +6,20 @@ describe("operator bikes routing e2e", () => {
   const fixture = setupHttpE2eFixture({
     buildLayer: async () => {
       const { Layer } = await import("effect");
-      const { BikeDepsLive } = await import("@/http/shared/providers");
+      const {
+        BikeDepsLive,
+        RatingDepsLive,
+        StationDepsLive,
+        SupplierDepsLive,
+      } = await import("@/http/shared/providers");
       const { UserDepsLive } = await import("@/http/shared/features/user.layers");
 
       return Layer.mergeAll(
         UserDepsLive,
         BikeDepsLive,
+        RatingDepsLive,
+        StationDepsLive,
+        SupplierDepsLive,
       );
     },
   });

--- a/apps/server/src/http/test/e2e/operator-stations-routing.e2e.int.test.ts
+++ b/apps/server/src/http/test/e2e/operator-stations-routing.e2e.int.test.ts
@@ -1,0 +1,62 @@
+import type { StationsContracts } from "@mebike/shared";
+
+import { describe, expect, it } from "vitest";
+
+import { setupHttpE2eFixture } from "@/test/http/e2e-fixture";
+
+describe("operator stations routing e2e", () => {
+  const fixture = setupHttpE2eFixture({
+    buildLayer: async () => {
+      const { Layer } = await import("effect");
+      const { StationDepsLive } = await import("@/http/shared/providers");
+      const { UserDepsLive } = await import("@/http/shared/features/user.layers");
+
+      return Layer.mergeAll(
+        UserDepsLive,
+        StationDepsLive,
+      );
+    },
+  });
+
+  async function createOperatorToken(role: "STAFF" | "MANAGER" | "TECHNICIAN", stationId?: string) {
+    const user = await fixture.factories.user({ role });
+
+    if (stationId) {
+      await fixture.factories.userOrgAssignment({ userId: user.id, stationId });
+    }
+
+    return fixture.auth.makeAccessToken({ userId: user.id, role });
+  }
+
+  it("lists only the assigned station for staff", async () => {
+    const currentStation = await fixture.factories.station({ capacity: 5, name: "Current Station" });
+    await fixture.factories.station({ capacity: 5, name: "Hidden Station" });
+    const token = await createOperatorToken("STAFF", currentStation.id);
+
+    const response = await fixture.app.request("http://test/v1/staff/stations?page=1&pageSize=20", {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    const body = await response.json() as StationsContracts.StationListResponse;
+
+    expect(response.status).toBe(200);
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0]?.id).toBe(currentStation.id);
+  });
+
+  it("returns 404 when technician requests a different station detail", async () => {
+    const currentStation = await fixture.factories.station({ capacity: 5 });
+    const hiddenStation = await fixture.factories.station({ capacity: 5 });
+    const token = await createOperatorToken("TECHNICIAN", currentStation.id);
+
+    const response = await fixture.app.request(`http://test/v1/staff/stations/${hiddenStation.id}`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/packages/shared/src/contracts/server/routes/bikes/queries.ts
+++ b/packages/shared/src/contracts/server/routes/bikes/queries.ts
@@ -1,6 +1,7 @@
 import { createRoute } from "@hono/zod-openapi";
 
 import { BikeNotFoundResponseSchema } from "../../bikes";
+import { forbiddenResponse, unauthorizedResponse } from "../helpers";
 import {
   BikeActivityStatsResponseSchema,
   BikeErrorCodeSchema,
@@ -15,6 +16,7 @@ import {
   BikeStatsResponseSchema,
   BikeSummarySchemaOpenApi,
   HighestRevenueBikeResponseSchema,
+  ServerErrorResponseSchema,
 } from "./shared";
 
 export const listBikes = createRoute({
@@ -98,6 +100,68 @@ export const getBike = createRoute({
         "application/json": { schema: BikeNotFoundResponseSchema },
       },
     },
+  },
+});
+
+export const staffListBikes = createRoute({
+  method: "get",
+  path: "/v1/staff/bikes",
+  tags: ["Staff", "Bikes"],
+  security: [{ bearerAuth: [] }],
+  request: {
+    query: BikeListQuerySchema,
+  },
+  responses: {
+    200: {
+      description: "List bikes for staff station scope",
+      content: {
+        "application/json": { schema: BikeListResponseSchema },
+      },
+    },
+    400: {
+      description: "Invalid query",
+      content: {
+        "application/json": {
+          schema: BikeErrorResponseSchema,
+        },
+      },
+    },
+    401: unauthorizedResponse(),
+    403: forbiddenResponse("Staff, Manager, or Technician"),
+  },
+});
+
+export const staffGetBike = createRoute({
+  method: "get",
+  path: "/v1/staff/bikes/{id}",
+  tags: ["Staff", "Bikes"],
+  security: [{ bearerAuth: [] }],
+  request: {
+    params: BikeIdParamSchema,
+  },
+  responses: {
+    200: {
+      description: "Get bike details for staff station scope",
+      content: {
+        "application/json": { schema: BikeSummarySchemaOpenApi },
+      },
+    },
+    400: {
+      description: "Invalid path parameter",
+      content: {
+        "application/json": {
+          schema: ServerErrorResponseSchema,
+        },
+      },
+    },
+    404: {
+      description: "Bike not found",
+      content: {
+        "application/json": { schema: BikeNotFoundResponseSchema },
+      },
+    },
+    401: unauthorizedResponse(),
+    403: forbiddenResponse("Staff, Manager, or Technician"),
   },
 });
 

--- a/packages/shared/src/contracts/server/routes/stations/index.ts
+++ b/packages/shared/src/contracts/server/routes/stations/index.ts
@@ -15,9 +15,11 @@ export {
   getNearbyStations,
   getNearestAvailableBike,
   getStation,
+  staffGetStation,
   getStationAlerts,
   getStationStats,
   listStations,
+  staffListStations,
 } from "./queries";
 
 export const stationsRoutes = {

--- a/packages/shared/src/contracts/server/routes/stations/queries.ts
+++ b/packages/shared/src/contracts/server/routes/stations/queries.ts
@@ -198,6 +198,93 @@ export const getStation = createRoute({
   },
 });
 
+export const staffListStations = createRoute({
+  method: "get",
+  path: "/v1/staff/stations",
+  tags: ["Staff", "Stations"],
+  security: [{ bearerAuth: [] }],
+  request: {
+    query: StationListQuerySchema,
+  },
+  responses: {
+    200: {
+      description: "List current operator station only",
+      content: {
+        "application/json": { schema: StationListResponseSchema },
+      },
+    },
+    400: {
+      description: "Invalid query",
+      content: {
+        "application/json": { schema: StationErrorResponseSchema },
+      },
+    },
+    404: {
+      description: "Assigned station not found",
+      content: {
+        "application/json": {
+          schema: StationErrorResponseSchema,
+        },
+      },
+    },
+    401: unauthorizedResponse(),
+    403: forbiddenResponse("Staff, Manager, or Technician"),
+  },
+});
+
+export const staffGetStation = createRoute({
+  method: "get",
+  path: "/v1/staff/stations/{stationId}",
+  tags: ["Staff", "Stations"],
+  security: [{ bearerAuth: [] }],
+  request: {
+    params: StationIdParamSchema,
+  },
+  responses: {
+    200: {
+      description: "Get station details for current operator station",
+      content: {
+        "application/json": { schema: StationReadSummarySchemaOpenApi },
+      },
+    },
+    400: {
+      description: "Invalid path parameter",
+      content: {
+        "application/json": {
+          schema: ServerErrorResponseSchema,
+          examples: {
+            InvalidStationId: {
+              value: {
+                error: "Invalid request payload",
+                details: {
+                  code: "VALIDATION_ERROR",
+                  issues: [
+                    {
+                      path: "params.stationId",
+                      message: "stationId must be a UUID",
+                      code: "invalid_uuid",
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    404: {
+      description: "Station not found",
+      content: {
+        "application/json": {
+          schema: StationErrorResponseSchema,
+        },
+      },
+    },
+    401: unauthorizedResponse(),
+    403: forbiddenResponse("Staff, Manager, or Technician"),
+  },
+});
+
 export const getStationStats = createRoute({
   method: "get",
   path: "/v1/stations/{stationId}/stats",

--- a/packages/shared/src/contracts/server/routes/stations/shared.ts
+++ b/packages/shared/src/contracts/server/routes/stations/shared.ts
@@ -13,6 +13,7 @@ import {
   StationDateRangeQuerySchema,
   StationErrorCodeSchema,
   StationErrorDetailSchema,
+  StationListQuerySchema,
   StationReadSummarySchema,
   StationRevenueResponseSchema,
   StationStatsResponseSchema,
@@ -26,6 +27,7 @@ export {
   SortDirectionSchema,
   StationDateRangeQuerySchema,
   StationErrorCodeSchema,
+  StationListQuerySchema,
 };
 
 export const StationSortFieldSchema = z.enum(["name", "totalCapacity", "updatedAt"]);
@@ -141,29 +143,6 @@ export const StationIdParamSchema = z
   })
   .openapi("StationIdParam", {
     description: "Path params for station id",
-  });
-
-export const StationListQuerySchema = z
-  .object({
-    name: z.string().optional(),
-    address: z.string().optional(),
-    stationType: StationTypeSchema.optional(),
-    agencyId: z.uuidv7().optional(),
-    latitude: optionalLatitudeQuery(),
-    longitude: optionalLongitudeQuery(),
-    totalCapacity: optionalNumberQuery("totalCapacity", 20),
-    ...paginationQueryFields,
-    sortBy: StationSortFieldSchema.optional().openapi({
-      description: "Sort field",
-      example: "name",
-    }),
-    sortDir: SortDirectionSchema.optional().openapi({
-      description: "Sort direction",
-      example: "asc",
-    }),
-  })
-  .openapi("StationListQuery", {
-    description: "Optional filters for listing stations",
   });
 
 export const CreateStationBodySchema = z.object({

--- a/packages/shared/src/contracts/server/stations/index.ts
+++ b/packages/shared/src/contracts/server/stations/index.ts
@@ -1,6 +1,7 @@
 import type { z } from "../../../zod";
 import { PaginationSchema } from "../schemas";
 import { StationReadSummarySchema } from "./models";
+import { StationListQuerySchema } from "./schemas";
 
 export * from "./errors";
 export * from "./models";
@@ -10,3 +11,5 @@ export type StationListResponse = {
   data: z.infer<typeof StationReadSummarySchema>[];
   pagination: z.infer<typeof PaginationSchema>;
 };
+
+export type StationListQuery = z.infer<typeof StationListQuerySchema>;

--- a/packages/shared/src/contracts/server/stations/schemas.ts
+++ b/packages/shared/src/contracts/server/stations/schemas.ts
@@ -1,4 +1,6 @@
 import { z } from "../../../zod";
+import { paginationQueryFields, SortDirectionSchema } from "../schemas";
+import { StationTypeSchema } from "./models";
 
 export const StationIsoDateTimeStringSchema = z.iso
   .datetime()
@@ -28,3 +30,83 @@ export const StationDateRangeQuerySchema = z
 export type StationDateRangeQuery = z.infer<
   typeof StationDateRangeQuerySchema
 >;
+
+function optionalNumberQuery(field: string, example?: number) {
+  return z
+    .preprocess(
+      value =>
+        value === undefined || value === null
+          ? undefined
+          : typeof value === "string"
+            ? Number(value)
+            : value,
+      z
+        .number()
+        .refine(Number.isFinite, { message: `${field} must be a number` }),
+    )
+    .optional()
+    .openapi({ example });
+}
+
+function optionalLatitudeQuery(example?: number) {
+  return z
+    .preprocess(
+      value =>
+        value === undefined || value === null
+          ? undefined
+          : typeof value === "string"
+            ? Number(value)
+            : value,
+      z
+        .number()
+        .refine(Number.isFinite, { message: "latitude must be a number" })
+        .min(-90, { message: "latitude must be greater than or equal to -90" })
+        .max(90, { message: "latitude must be less than or equal to 90" }),
+    )
+    .optional()
+    .openapi({ example });
+}
+
+function optionalLongitudeQuery(example?: number) {
+  return z
+    .preprocess(
+      value =>
+        value === undefined || value === null
+          ? undefined
+          : typeof value === "string"
+            ? Number(value)
+            : value,
+      z
+        .number()
+        .refine(Number.isFinite, { message: "longitude must be a number" })
+        .min(-180, { message: "longitude must be greater than or equal to -180" })
+        .max(180, { message: "longitude must be less than or equal to 180" }),
+    )
+    .optional()
+    .openapi({ example });
+}
+
+export const StationListQuerySchema = z
+  .object({
+    name: z.string().optional(),
+    address: z.string().optional(),
+    stationType: StationTypeSchema.optional(),
+    agencyId: z.uuidv7().optional(),
+    latitude: optionalLatitudeQuery(),
+    longitude: optionalLongitudeQuery(),
+    totalCapacity: optionalNumberQuery("totalCapacity", 20),
+    ...paginationQueryFields,
+    sortBy: z.enum(["name", "totalCapacity", "updatedAt"]).optional().openapi({
+      description: "Sort field",
+      example: "name",
+    }),
+    sortDir: SortDirectionSchema.optional().openapi({
+      description: "Sort direction",
+      example: "asc",
+    }),
+  })
+  .openapi("StationListQuery", {
+    description: "Optional filters for listing stations",
+  });
+
+export type StationListQuery = z.infer<typeof StationListQuerySchema>;


### PR DESCRIPTION
## Summary
- add `/v1/staff/bikes` and `/v1/staff/stations` list/detail routes scoped by `currentUser.operatorStationId`
- allow shared operator access for `STAFF`, `MANAGER`, and `TECHNICIAN` while keeping public `/v1/bikes` and `/v1/stations` generic
- add focused e2e coverage for operator bike/station route scoping and align shared contracts/docs with the new responses

## Verification
- `pnpm --dir ../../packages/shared build`
- `pnpm prisma generate`
- `pnpm tsc --noEmit`
- focused e2e run remains blocked locally by existing test DB drift: `column \"chip_id\" of relation \"Bike\" does not exist` from `apps/server/src/test/db/seed.ts`