### PR TITLE
refactor(server): remove bike chip ID from API contracts

### DIFF
--- a/apps/mobile/presenters/rentals/rental-error-presenter.ts
+++ b/apps/mobile/presenters/rentals/rental-error-presenter.ts
@@ -9,7 +9,7 @@ const rentalErrorMessages = {
   bikeMissingStation: "Xe này đang thiếu thông tin trạm, vui lòng thử lại sau.",
   bikeNotAvailableForRental: "Xe hiện chưa sẵn sàng để bắt đầu chuyến đi.",
   bikeNotFound: "Không tìm thấy xe phù hợp.",
-  bikeNotFoundForChip: "Không tìm thấy xe tương ứng với chip được quét.",
+  bikeNotFoundForBikeId: "Không tìm thấy xe tương ứng với mã xe được gửi lên.",
   bikeNotFoundInStation: "Không tìm thấy xe này tại trạm đã chọn.",
   bikeSwapRequestAlreadyPending: "Yêu cầu đổi xe cho chuyến đi này đang chờ xử lý.",
   cannotApproveSwapThisRentalWithStatus: "Không thể duyệt đổi xe ở trạng thái chuyến đi hiện tại.",
@@ -85,8 +85,8 @@ function presentRentalApiError(error: Extract<RentalError, { _tag: "ApiError" }>
       return rentalErrorMessages.bikeNotAvailableForRental;
     case "BIKE_NOT_FOUND":
       return rentalErrorMessages.bikeNotFound;
-    case "BIKE_NOT_FOUND_FOR_CHIP":
-      return rentalErrorMessages.bikeNotFoundForChip;
+    case "BIKE_NOT_FOUND_FOR_BIKE_ID":
+      return rentalErrorMessages.bikeNotFoundForBikeId;
     case "BIKE_NOT_FOUND_IN_STATION":
       return rentalErrorMessages.bikeNotFoundInStation;
     case "BIKE_SWAP_REQUEST_ALREADY_PENDING":

--- a/apps/mobile/screen/staff/rental-detail/components/staff-party-card.tsx
+++ b/apps/mobile/screen/staff/rental-detail/components/staff-party-card.tsx
@@ -86,7 +86,6 @@ export function StaffPartyCard({ booking }: StaffPartyCardProps) {
         iconName="bike"
         label="Xe đạp"
         primary={getBikeDisplayLabel(booking.bike)}
-        secondary={booking.bike.chipId}
       />
 
       <YStack borderTopColor="$borderSubtle" borderTopWidth={borderWidths.subtle}>

--- a/apps/mobile/screen/technician/incidents/technician-incident-detail-screen.tsx
+++ b/apps/mobile/screen/technician/incidents/technician-incident-detail-screen.tsx
@@ -336,7 +336,7 @@ export default function TechnicianIncidentDetailScreen() {
           </SectionCard>
 
           <SectionCard accentTone="success" icon="bike" title="Thông tin xe & Vị trí">
-            <DetailRow label="Mã xe" value={incident.bike.chipId} />
+            <DetailRow label="Mã xe" value={incident.bike.bikeNumber} />
             <DetailRow label="Khóa xe đang bật" value={incident.bikeLocked ? "Có" : "Không"} valueTone={incident.bikeLocked ? "danger" : "success"} />
             <DetailRow emptyLabel="Không gắn với trạm" label="Trạm liên quan" value={incident.station?.name ?? ""} />
             <DetailRow

--- a/apps/mobile/screen/technician/incidents/technician-incident-list-screen.tsx
+++ b/apps/mobile/screen/technician/incidents/technician-incident-list-screen.tsx
@@ -163,7 +163,7 @@ function IncidentRow({
               Xe:
               {" "}
               <AppText tone="default" variant="bodyStrong">
-                {incident.bike.chipId}
+                {incident.bike.bikeNumber}
               </AppText>
             </AppText>
             <AppText tone="muted" variant="bodySmall">

--- a/apps/server/generated/kysely/types.ts
+++ b/apps/server/generated/kysely/types.ts
@@ -323,7 +323,6 @@ export type AuthEvent = {
 export type Bike = {
     id: string;
     bike_number: string;
-    chip_id: string;
     stationId: string | null;
     supplierId: string | null;
     status: BikeStatus;

--- a/apps/server/prisma/migrations/20260418100000_remove_bike_chip_id/migration.sql
+++ b/apps/server/prisma/migrations/20260418100000_remove_bike_chip_id/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "Bike" DROP COLUMN "chip_id";

--- a/apps/server/prisma/models/bikes.prisma
+++ b/apps/server/prisma/models/bikes.prisma
@@ -10,7 +10,6 @@ enum BikeStatus {
 model Bike {
   id         String     @id @default(uuid(7)) @db.Uuid
   bikeNumber String     @unique @map("bike_number")
-  chipId     String     @unique @map("chip_id")
   stationId  String?    @db.Uuid
   supplierId String?    @db.Uuid
   status     BikeStatus

--- a/apps/server/prisma/seed-bikes.ts
+++ b/apps/server/prisma/seed-bikes.ts
@@ -154,7 +154,6 @@ async function main() {
         data: {
           id: uuidv7(),
           bikeNumber: formatBikeNumber(bikeIndex + 1),
-          chipId: bike.chip_id,
           stationId,
           supplierId: supplier.id,
           status,
@@ -179,7 +178,7 @@ async function main() {
       },
       orderBy: [
         { stationId: "asc" },
-        { chipId: "asc" },
+        { bikeNumber: "asc" },
       ],
     });
 

--- a/apps/server/prisma/seed-demo.ts
+++ b/apps/server/prisma/seed-demo.ts
@@ -25,7 +25,6 @@ import {
   UserVerifyStatus,
   WalletStatus,
 } from "../generated/prisma/client";
-import { formatBikeNumber } from "../src/domain/bikes/bike-number";
 import { setBikeNumberSequence } from "../src/domain/bikes/repository/bike.repository.shared";
 import { toPrismaDecimal } from "../src/domain/shared/decimal";
 import logger from "../src/lib/logger";
@@ -650,7 +649,7 @@ async function main() {
 
     await prisma.bike.deleteMany({
       where: {
-        chipId: {
+        bikeNumber: {
           startsWith: "DEMO-",
         },
       },
@@ -833,8 +832,7 @@ async function main() {
 
     const bikesToCreate = Array.from({ length: 40 }, (_, idx) => ({
       id: uuidv7(),
-      bikeNumber: formatBikeNumber(idx + 1),
-      chipId: `DEMO-CHIP-${String(idx + 1).padStart(3, "0")}`,
+      bikeNumber: `DEMO-${String(idx + 1).padStart(3, "0")}`,
       stationId: pick(stationIds, idx),
       supplierId: suppliers[idx % suppliers.length]!.id,
       status: BikeStatus.AVAILABLE,

--- a/apps/server/prisma/seed/rated-rental-scenarios.ts
+++ b/apps/server/prisma/seed/rated-rental-scenarios.ts
@@ -9,7 +9,7 @@ export type RatedRentalScenario = {
     readonly phoneNumber: string;
   };
   readonly bike: {
-    readonly chipId: string;
+    readonly bikeNumber: string;
   };
   readonly rental: {
     readonly id: string;
@@ -39,7 +39,7 @@ export async function seedRatedRentalScenario(
 ) {
   const user = await upsertSeedUser(prisma, scenario.user);
   const bike = await upsertSeedBike(prisma, {
-    chipId: scenario.bike.chipId,
+    bikeNumber: scenario.bike.bikeNumber,
     stationId: context.stationId,
     supplierId: context.supplierId,
   });

--- a/apps/server/prisma/seed/sample-completed-ratings.ts
+++ b/apps/server/prisma/seed/sample-completed-ratings.ts
@@ -9,7 +9,7 @@ const SEEDED_SUPPLIER_ID = "11111111-1111-4111-8111-111111111112";
 
 const seededRatings = [
   {
-    bike: { chipId: "SEED-RATE-001" },
+    bike: { bikeNumber: "MB-900001" },
     rating: { bikeScore: 5, stationScore: 4, comment: "Trai nghiem tot, xe van hanh on dinh." },
     rental: {
       id: "11111111-1111-4111-8111-111111111201",
@@ -23,7 +23,7 @@ const seededRatings = [
     },
   },
   {
-    bike: { chipId: "SEED-RATE-002" },
+    bike: { bikeNumber: "MB-900002" },
     rating: { bikeScore: 3, stationScore: 5, comment: "Xe di duoc nhung phanh hoi yeu." },
     rental: {
       id: "11111111-1111-4111-8111-111111111202",
@@ -37,7 +37,7 @@ const seededRatings = [
     },
   },
   {
-    bike: { chipId: "SEED-RATE-003" },
+    bike: { bikeNumber: "MB-900003" },
     rating: { bikeScore: 4, stationScore: 5, comment: "Tram de tim va tra xe nhanh." },
     rental: {
       id: "11111111-1111-4111-8111-111111111203",

--- a/apps/server/prisma/seed/seed-factories.ts
+++ b/apps/server/prisma/seed/seed-factories.ts
@@ -29,7 +29,7 @@ export type SeedSupplierInput = {
 };
 
 export type SeedBikeInput = {
-  readonly chipId: string;
+  readonly bikeNumber: string;
   readonly stationId: string;
   readonly supplierId?: string | null;
   readonly status?: BikeStatus;
@@ -112,13 +112,13 @@ export async function upsertSeedSupplier(prisma: PrismaClient, input: SeedSuppli
 
 export async function upsertSeedBike(prisma: PrismaClient, input: SeedBikeInput) {
   const existing = await prisma.bike.findUnique({
-    where: { chipId: input.chipId },
+    where: { bikeNumber: input.bikeNumber },
     select: { id: true },
   });
 
   if (existing) {
     return prisma.bike.update({
-      where: { chipId: input.chipId },
+      where: { bikeNumber: input.bikeNumber },
       data: {
         stationId: input.stationId,
         status: input.status ?? BikeStatus.AVAILABLE,
@@ -140,8 +140,7 @@ export async function upsertSeedBike(prisma: PrismaClient, input: SeedBikeInput)
   return prisma.bike.create({
     data: {
       id: uuidv7(),
-      bikeNumber: formatBikeNumber(Number(counter.value)),
-      chipId: input.chipId,
+      bikeNumber: input.bikeNumber || formatBikeNumber(Number(counter.value)),
       stationId: input.stationId,
       status: input.status ?? BikeStatus.AVAILABLE,
       supplierId: input.supplierId ?? null,

--- a/apps/server/src/domain/bikes/domain-errors.ts
+++ b/apps/server/src/domain/bikes/domain-errors.ts
@@ -10,10 +10,6 @@ export class BikeNotFound extends Data.TaggedError("BikeNotFound")<{
   readonly id: string;
 }> {}
 
-export class DuplicateChipId extends Data.TaggedError("DuplicateChipId")<{
-  readonly chipId: string;
-}> {}
-
 export class BikeStationNotFound extends Data.TaggedError("BikeStationNotFound")<{
   readonly stationId: string;
 }> {}

--- a/apps/server/src/domain/bikes/models.ts
+++ b/apps/server/src/domain/bikes/models.ts
@@ -3,7 +3,6 @@ import type { BikeStatus } from "generated/prisma/enums";
 export type BikeRow = {
   id: string;
   bikeNumber: string;
-  chipId: string;
   stationId: string | null;
   supplierId: string | null;
   status: BikeStatus;
@@ -91,7 +90,7 @@ export type BikeStats = {
 
 export type HighestRevenueBike = {
   bikeId: string;
-  bikeChipId: string;
+  bikeNumber: string;
   totalRevenue: number;
   rentalCount: number;
   station: {

--- a/apps/server/src/domain/bikes/repository/bike-stats.repository.ts
+++ b/apps/server/src/domain/bikes/repository/bike-stats.repository.ts
@@ -135,7 +135,7 @@ export function makeBikeStatsRepository(db: Kysely<DB>): BikeStatsRepo {
           .leftJoin("Station", "Station.id", "Bike.stationId")
           .select([
             "Bike.id as bike_id",
-            "Bike.chip_id as chip_id",
+            "Bike.bike_number as bike_number",
             "Station.id as station_id",
             "Station.name as station_name",
             sql<number>`sum("Rental"."total_price"::numeric)`.as("total_revenue"),
@@ -145,7 +145,7 @@ export function makeBikeStatsRepository(db: Kysely<DB>): BikeStatsRepo {
           .where("Rental.total_price", "is not", null)
           .groupBy([
             "Bike.id",
-            "Bike.chip_id",
+            "Bike.bike_number",
             "Station.id",
             "Station.name",
           ])
@@ -159,7 +159,7 @@ export function makeBikeStatsRepository(db: Kysely<DB>): BikeStatsRepo {
 
         return {
           bikeId: row.bike_id,
-          bikeChipId: row.chip_id,
+          bikeNumber: row.bike_number,
           totalRevenue: Number(row.total_revenue ?? 0),
           rentalCount: Number(row.rental_count ?? 0),
           station: row.station_id

--- a/apps/server/src/domain/bikes/repository/bike.repository.shared.ts
+++ b/apps/server/src/domain/bikes/repository/bike.repository.shared.ts
@@ -10,7 +10,6 @@ export type BikeDbClient = PrismaClient | PrismaTypes.TransactionClient;
 export const bikeSelect = {
   id: true,
   bikeNumber: true,
-  chipId: true,
   stationId: true,
   supplierId: true,
   status: true,

--- a/apps/server/src/domain/bikes/repository/bike.repository.types.ts
+++ b/apps/server/src/domain/bikes/repository/bike.repository.types.ts
@@ -3,18 +3,15 @@ import type { Effect, Option } from "effect";
 import type { PageRequest, PageResult } from "@/domain/shared/pagination";
 import type { BikeStatus } from "generated/prisma/client";
 
-import type { DuplicateChipId } from "../domain-errors";
 import type { BikeFilter, BikeRow, BikeSortField } from "../models";
 
 export type BikeCreateInput = {
-  chipId: string;
   stationId: string;
   supplierId: string;
   status: BikeStatus;
 };
 
 export type BikeUpdatePatch = Partial<{
-  chipId: string;
   stationId: string;
   status: BikeStatus;
   supplierId: string | null;
@@ -34,7 +31,7 @@ export type BikeQueryRepo = {
 };
 
 export type BikeCommandRepo = {
-  create: (input: BikeCreateInput) => Effect.Effect<BikeRow, DuplicateChipId>;
+  create: (input: BikeCreateInput) => Effect.Effect<BikeRow>;
   updateStatus: (
     bikeId: string,
     status: BikeStatus,
@@ -85,7 +82,7 @@ export type BikeCommandRepo = {
   updateById: (
     bikeId: string,
     patch: BikeUpdatePatch,
-  ) => Effect.Effect<Option.Option<BikeRow>, DuplicateChipId>;
+  ) => Effect.Effect<Option.Option<BikeRow>>;
 };
 
 export type BikeRepo = BikeQueryRepo & BikeCommandRepo;

--- a/apps/server/src/domain/bikes/repository/test/bike.repository.int.test.ts
+++ b/apps/server/src/domain/bikes/repository/test/bike.repository.int.test.ts
@@ -3,8 +3,8 @@ import { uuidv7 } from "uuidv7";
 import { beforeAll, describe, expect, it } from "vitest";
 
 import { makeUnreachablePrisma } from "@/test/db/unreachable-prisma";
-import { expectDefect, expectLeftTag } from "@/test/effect/assertions";
-import { runEffect, runEffectEither } from "@/test/effect/run";
+import { expectDefect } from "@/test/effect/assertions";
+import { runEffect } from "@/test/effect/run";
 import { setupPrismaIntFixture } from "@/test/prisma/prisma-int-fixture";
 
 import { BikeRepositoryError } from "../../domain-errors";
@@ -36,7 +36,6 @@ describe("bikeRepository Integration", () => {
 
     const created = await runEffect(
       repo.create({
-        chipId: `chip-${uuidv7()}`,
         stationId: station.id,
         supplierId: supplier.id,
         status: "AVAILABLE",
@@ -54,7 +53,6 @@ describe("bikeRepository Integration", () => {
 
     const first = await runEffect(
       repo.create({
-        chipId: `chip-${uuidv7()}`,
         stationId: station.id,
         supplierId: supplier.id,
         status: "AVAILABLE",
@@ -63,7 +61,6 @@ describe("bikeRepository Integration", () => {
 
     const second = await runEffect(
       repo.create({
-        chipId: `chip-${uuidv7()}`,
         stationId: station.id,
         supplierId: supplier.id,
         status: "AVAILABLE",
@@ -73,32 +70,6 @@ describe("bikeRepository Integration", () => {
     expect(first.bikeNumber).toMatch(/^MB-\d{6}$/);
     expect(second.bikeNumber).toMatch(/^MB-\d{6}$/);
     expect(first.bikeNumber).not.toBe(second.bikeNumber);
-  });
-
-  it("create rejects duplicate chipId", async () => {
-    const station = await fixture.factories.station();
-    const supplier = await fixture.factories.supplier();
-    const chipId = `chip-${uuidv7()}`;
-
-    await runEffect(
-      repo.create({
-        chipId,
-        stationId: station.id,
-        supplierId: supplier.id,
-        status: "AVAILABLE",
-      }),
-    );
-
-    const result = await runEffectEither(
-      repo.create({
-        chipId,
-        stationId: station.id,
-        supplierId: supplier.id,
-        status: "AVAILABLE",
-      }),
-    );
-
-    expectLeftTag(result, "DuplicateChipId");
   });
 
   it("getById returns Option.none for missing bike", async () => {

--- a/apps/server/src/domain/bikes/repository/write/bike.write.repository.ts
+++ b/apps/server/src/domain/bikes/repository/write/bike.write.repository.ts
@@ -4,12 +4,12 @@ import type { BikeStatus } from "generated/prisma/client";
 
 import { defectOn } from "@/domain/shared";
 import { pickDefined } from "@/domain/shared/pick-defined";
-import { isPrismaRecordNotFound, isPrismaUniqueViolation } from "@/infrastructure/prisma-errors";
+import { isPrismaRecordNotFound } from "@/infrastructure/prisma-errors";
 
 import type { BikeDbClient } from "../bike.repository.shared";
-import type { BikeCommandRepo, BikeCreateInput, BikeUpdatePatch } from "../bike.repository.types";
+import type { BikeCommandRepo, BikeCreateInput } from "../bike.repository.types";
 
-import { BikeRepositoryError, DuplicateChipId } from "../../domain-errors";
+import { BikeRepositoryError } from "../../domain-errors";
 import { bikeSelect, buildStatusUpdate, findBikeById, getNextBikeNumber } from "../bike.repository.shared";
 
 export function makeBikeWriteRepository(client: BikeDbClient): BikeCommandRepo {
@@ -46,7 +46,7 @@ export function makeBikeWriteRepository(client: BikeDbClient): BikeCommandRepo {
     create: input =>
       Effect.tryPromise({
         try: () => createBike(client, input),
-        catch: cause => handleCreateError(cause, input.chipId),
+        catch: cause => handleCreateError(cause),
       }).pipe(defectOn(BikeRepositoryError)),
 
     updateStatus: (bikeId, status) =>
@@ -125,7 +125,6 @@ export function makeBikeWriteRepository(client: BikeDbClient): BikeCommandRepo {
             where: { id: bikeId },
             data: {
               ...pickDefined({
-                chipId: patch.chipId,
                 stationId: patch.stationId,
                 status: patch.status,
                 supplierId: patch.supplierId,
@@ -136,7 +135,7 @@ export function makeBikeWriteRepository(client: BikeDbClient): BikeCommandRepo {
           }),
         catch: err => err as unknown,
       }).pipe(
-        Effect.catchAll(cause => handleUpdateError(cause, patch)),
+        Effect.catchAll(cause => handleUpdateError(cause)),
         Effect.map(row => Option.fromNullable(row)),
         defectOn(BikeRepositoryError),
       ),
@@ -150,7 +149,6 @@ async function createBike(client: BikeDbClient, input: BikeCreateInput) {
     return tx.bike.create({
       data: {
         bikeNumber,
-        chipId: input.chipId,
         stationId: input.stationId,
         supplierId: input.supplierId,
         status: input.status,
@@ -165,11 +163,7 @@ async function createBike(client: BikeDbClient, input: BikeCreateInput) {
     : createWithClient(client);
 }
 
-function handleCreateError(cause: unknown, chipId: string) {
-  if (isPrismaUniqueViolation(cause)) {
-    return new DuplicateChipId({ chipId });
-  }
-
+function handleCreateError(cause: unknown) {
   return new BikeRepositoryError({
     operation: "create",
     cause,
@@ -179,14 +173,9 @@ function handleCreateError(cause: unknown, chipId: string) {
 
 function handleUpdateError(
   cause: unknown,
-  patch: BikeUpdatePatch,
-): Effect.Effect<null, BikeRepositoryError | DuplicateChipId> {
+): Effect.Effect<null, BikeRepositoryError> {
   if (isPrismaRecordNotFound(cause)) {
     return Effect.succeed(null);
-  }
-
-  if (isPrismaUniqueViolation(cause) && patch.chipId) {
-    return Effect.fail(new DuplicateChipId({ chipId: patch.chipId }));
   }
 
   return Effect.fail(new BikeRepositoryError({

--- a/apps/server/src/domain/bikes/services/bike.service.ts
+++ b/apps/server/src/domain/bikes/services/bike.service.ts
@@ -42,7 +42,6 @@ function makeBikeService(
         }
 
         return yield* repo.create({
-          chipId: input.chipId,
           stationId: input.stationId,
           supplierId: input.supplierId,
           status: input.status ?? "AVAILABLE",

--- a/apps/server/src/domain/bikes/services/bike.service.types.ts
+++ b/apps/server/src/domain/bikes/services/bike.service.types.ts
@@ -9,7 +9,6 @@ import type {
   BikeNotFound,
   BikeStationNotFound,
   BikeSupplierNotFound,
-  DuplicateChipId,
 } from "../domain-errors";
 import type { BikeFilter, BikeRow, BikeSortField } from "../models";
 import type { BikeUpdatePatch } from "../repository/bike.repository.types";
@@ -17,14 +16,13 @@ import type { BikeUpdatePatch } from "../repository/bike.repository.types";
 export type BikeService = {
   createBike: (
     input: {
-      chipId: string;
       stationId: string;
       supplierId: string;
       status?: BikeStatus;
     },
   ) => Effect.Effect<
     BikeRow,
-    DuplicateChipId | BikeStationNotFound | BikeSupplierNotFound
+    BikeStationNotFound | BikeSupplierNotFound
   >;
 
   listBikes: (
@@ -44,7 +42,6 @@ export type BikeService = {
     | BikeCurrentlyRented
     | BikeCurrentlyReserved
     | BikeNotFound
-    | DuplicateChipId
     | BikeStationNotFound
     | BikeSupplierNotFound
   >;

--- a/apps/server/src/domain/bikes/services/test/bike-test-kit.ts
+++ b/apps/server/src/domain/bikes/services/test/bike-test-kit.ts
@@ -28,7 +28,6 @@ export function makeBikeTestLayer(client: PrismaClient) {
 export function makeBikeRunners(layer: Layer.Layer<BikeDeps>) {
   return {
     createBike(input: {
-      chipId: string;
       stationId: string;
       supplierId: string;
       status: "AVAILABLE";
@@ -39,7 +38,6 @@ export function makeBikeRunners(layer: Layer.Layer<BikeDeps>) {
       );
     },
     createBikeEither(input: {
-      chipId: string;
       stationId: string;
       supplierId: string;
       status: "AVAILABLE";
@@ -52,7 +50,6 @@ export function makeBikeRunners(layer: Layer.Layer<BikeDeps>) {
     adminUpdateBike(bikeId: string, input: {
       stationId?: string;
       supplierId?: string;
-      chipId?: string;
     }) {
       return runEffectWithLayer(
         Effect.flatMap(BikeServiceTag, service => service.adminUpdateBike(bikeId, input)),
@@ -62,7 +59,6 @@ export function makeBikeRunners(layer: Layer.Layer<BikeDeps>) {
     adminUpdateBikeEither(bikeId: string, input: {
       stationId?: string;
       supplierId?: string;
-      chipId?: string;
     }) {
       return runEffectEitherWithLayer(
         Effect.flatMap(BikeServiceTag, service => service.adminUpdateBike(bikeId, input)),

--- a/apps/server/src/domain/bikes/services/test/bike.service.int.test.ts
+++ b/apps/server/src/domain/bikes/services/test/bike.service.int.test.ts
@@ -21,11 +21,10 @@ describe("bikeService Integration", () => {
     runAdminUpdateBikeEither = runners.adminUpdateBikeEither;
   });
 
-  const createBike = (args: { stationId: string; supplierId: string; chipId?: string }) =>
+  const createBike = (args: { stationId: string; supplierId: string }) =>
     fixture.factories.bike({
       stationId: args.stationId,
       supplierId: args.supplierId,
-      chipId: args.chipId,
       status: "AVAILABLE",
     });
 
@@ -33,7 +32,6 @@ describe("bikeService Integration", () => {
     const supplier = await fixture.factories.supplier();
 
     const result = await runCreateBikeEither({
-      chipId: `chip-${uuidv7()}`,
       stationId: uuidv7(),
       supplierId: supplier.id,
       status: "AVAILABLE",
@@ -46,7 +44,6 @@ describe("bikeService Integration", () => {
     const station = await fixture.factories.station();
 
     const result = await runCreateBikeEither({
-      chipId: `chip-${uuidv7()}`,
       stationId: station.id,
       supplierId: uuidv7(),
       status: "AVAILABLE",
@@ -60,7 +57,6 @@ describe("bikeService Integration", () => {
     const supplier = await fixture.factories.supplier();
 
     const created = await runCreateBike({
-      chipId: `chip-${uuidv7()}`,
       stationId: station.id,
       supplierId: supplier.id,
       status: "AVAILABLE",
@@ -93,19 +89,6 @@ describe("bikeService Integration", () => {
     });
 
     expectLeftTag(result, "BikeSupplierNotFound");
-  });
-
-  it("update fails with DuplicateChipId when chipId already exists", async () => {
-    const station = await fixture.factories.station();
-    const supplier = await fixture.factories.supplier();
-    const primaryBike = await createBike({ stationId: station.id, supplierId: supplier.id });
-    const existingBike = await createBike({ stationId: station.id, supplierId: supplier.id });
-
-    const result = await runAdminUpdateBikeEither(primaryBike.id, {
-      chipId: existingBike.chipId,
-    });
-
-    expectLeftTag(result, "DuplicateChipId");
   });
 
   it("update succeeds when changing to another valid station and supplier", async () => {

--- a/apps/server/src/domain/incidents/models.ts
+++ b/apps/server/src/domain/incidents/models.ts
@@ -42,7 +42,7 @@ export type IncidentDetail = {
   } | null;
   bike: {
     id: string;
-    chipId: string;
+    bikeNumber: string;
   };
   station: {
     id: string;

--- a/apps/server/src/domain/incidents/repository/incident.repository.query.ts
+++ b/apps/server/src/domain/incidents/repository/incident.repository.query.ts
@@ -19,7 +19,7 @@ export const incidentDetailSelect = {
   bike: {
     select: {
       id: true,
-      chipId: true,
+      bikeNumber: true,
     },
   },
   station: {

--- a/apps/server/src/domain/ratings/models.ts
+++ b/apps/server/src/domain/ratings/models.ts
@@ -34,7 +34,7 @@ export type AdminRatingUserRow = {
 
 export type AdminRatingBikeRow = {
   readonly id: string;
-  readonly chipId: string;
+  readonly bikeNumber: string;
 };
 
 export type AdminRatingStationRow = {

--- a/apps/server/src/domain/ratings/repository/read/rating.read.repository.ts
+++ b/apps/server/src/domain/ratings/repository/read/rating.read.repository.ts
@@ -119,7 +119,7 @@ export function makeRatingReadRepository(
         ? Promise.resolve([])
         : client.bike.findMany({
             where: { id: { in: bikeIds } },
-            select: { id: true, chipId: true },
+            select: { id: true, bikeNumber: true },
           }),
       stationIds.length === 0
         ? Promise.resolve([])
@@ -130,7 +130,7 @@ export function makeRatingReadRepository(
     ]);
 
     return {
-      bikeMap: new Map(bikes.map(bike => [bike.id, { id: bike.id, chipId: bike.chipId }])),
+      bikeMap: new Map(bikes.map(bike => [bike.id, { id: bike.id, bikeNumber: bike.bikeNumber }])),
       stationMap: new Map(stations.map(station => [
         station.id,
         { id: station.id, name: station.name, address: station.address },

--- a/apps/server/src/domain/redistribution/models.ts
+++ b/apps/server/src/domain/redistribution/models.ts
@@ -41,7 +41,7 @@ export type StationDetail = {
 
 export type BikeDetail = {
   id: string;
-  chipId: string;
+  bikeNumber: string;
   status: BikeStatus;
   supplierId: string | null;
   updatedAt: Date;

--- a/apps/server/src/domain/redistribution/repository/redistribution.repository.query.ts
+++ b/apps/server/src/domain/redistribution/repository/redistribution.repository.query.ts
@@ -84,7 +84,7 @@ export const redistributionRequestItemSelect = {
   bike: {
     select: {
       id: true,
-      chipId: true,
+      bikeNumber: true,
       status: true,
       supplierId: true,
       updatedAt: true,

--- a/apps/server/src/domain/rentals/models.ts
+++ b/apps/server/src/domain/rentals/models.ts
@@ -107,7 +107,6 @@ export type AdminRentalDetail = {
   bike: {
     id: string;
     bikeNumber: string;
-    chipId: string;
     status: BikeStatus;
     supplierId: string | null;
     updatedAt: Date;
@@ -271,7 +270,6 @@ export type StaffBikeSwapRequestRow = {
   oldBike: {
     id: string;
     bikeNumber: string;
-    chipId: string;
     station: {
       id: string;
       name: string;
@@ -285,7 +283,6 @@ export type StaffBikeSwapRequestRow = {
   newBike: {
     id: string;
     bikeNumber: string;
-    chipId: string;
     station: {
       id: string;
       name: string;

--- a/apps/server/src/domain/rentals/repository/rental.repository.admin.query.ts
+++ b/apps/server/src/domain/rentals/repository/rental.repository.admin.query.ts
@@ -89,7 +89,6 @@ export const adminRentalDetailSelect = {
     select: {
       id: true,
       bikeNumber: true,
-      chipId: true,
       status: true,
       supplierId: true,
       updatedAt: true,
@@ -161,7 +160,6 @@ export function mapToAdminRentalDetail(raw: AdminRentalDetailSelectRow): AdminRe
     bike: {
       id: raw.bike.id,
       bikeNumber: raw.bike.bikeNumber,
-      chipId: raw.bike.chipId,
       status: raw.bike.status,
       supplierId: raw.bike.supplierId,
       updatedAt: raw.bike.updatedAt,

--- a/apps/server/src/domain/rentals/repository/rental.repository.query.ts
+++ b/apps/server/src/domain/rentals/repository/rental.repository.query.ts
@@ -227,7 +227,6 @@ export const staffBikeSwapRequestSelect = {
     select: {
       id: true,
       bikeNumber: true,
-      chipId: true,
       station: {
         select: {
           id: true,
@@ -247,7 +246,6 @@ export const staffBikeSwapRequestSelect = {
     select: {
       id: true,
       bikeNumber: true,
-      chipId: true,
       station: {
         select: {
           id: true,
@@ -286,7 +284,6 @@ function mapBikeInfo(bike: any) {
   return {
     id: bike.id,
     bikeNumber: bike.bikeNumber,
-    chipId: bike.chipId,
     station: {
       id: bike.station?.id,
       name: bike.station?.name,

--- a/apps/server/src/domain/reservations/models.ts
+++ b/apps/server/src/domain/reservations/models.ts
@@ -40,7 +40,6 @@ export type ReservationDetailUserRow = {
 export type ReservationDetailBikeRow = {
   readonly id: string;
   readonly bikeNumber: string;
-  readonly chipId: string;
   readonly status: BikeStatus;
 };
 

--- a/apps/server/src/domain/reservations/repository/reservation.mappers.ts
+++ b/apps/server/src/domain/reservations/repository/reservation.mappers.ts
@@ -43,7 +43,6 @@ export const selectReservationExpandedDetailRow = {
     select: {
       id: true,
       bikeNumber: true,
-      chipId: true,
       status: true,
     },
   },
@@ -155,7 +154,6 @@ export function toReservationExpandedDetailRow(row: {
   bike: {
     id: string;
     bikeNumber: string;
-    chipId: string;
     status: string;
   } | null;
   station: {
@@ -181,7 +179,6 @@ export function toReservationExpandedDetailRow(row: {
       ? {
           id: row.bike.id,
           bikeNumber: row.bike.bikeNumber,
-          chipId: row.bike.chipId,
           status: row.bike.status as NonNullable<ReservationExpandedDetailRow["bike"]>["status"],
         }
       : null,

--- a/apps/server/src/http/controllers/bikes/admin.controller.ts
+++ b/apps/server/src/http/controllers/bikes/admin.controller.ts
@@ -25,7 +25,6 @@ const createBike: RouteHandler<BikesRoutes["createBike"]> = async (c) => {
     Effect.gen(function* () {
       const service = yield* BikeServiceTag;
       const bike = yield* service.createBike({
-        chipId: body.chipId,
         stationId: body.stationId,
         supplierId: body.supplierId,
         status: body.status,
@@ -41,11 +40,6 @@ const createBike: RouteHandler<BikesRoutes["createBike"]> = async (c) => {
     Match.tag("Right", ({ right }) =>
       c.json<BikeSummary, 201>(right, 201)),
     Match.tag("Left", ({ left }) => Match.value(left).pipe(
-      Match.tag("DuplicateChipId", () =>
-        c.json<BikeUpdateConflictResponse, 400>({
-          error: bikeErrorMessages.DUPLICATE_CHIP_ID,
-          details: { code: BikeErrorCodeSchema.enum.DUPLICATE_CHIP_ID },
-        }, 400)),
       Match.tag("BikeStationNotFound", ({ stationId }) =>
         c.json<BikeUpdateConflictResponse, 400>({
           error: bikeErrorMessages.BIKE_STATION_NOT_FOUND,
@@ -111,11 +105,6 @@ const updateBike: RouteHandler<BikesRoutes["updateBike"]> = async (c) => {
           error: bikeErrorMessages.BIKE_NOT_FOUND,
           details: { code: BikeErrorCodeSchema.enum.BIKE_NOT_FOUND },
         }, 404)),
-      Match.tag("DuplicateChipId", () =>
-        c.json<BikeUpdateConflictResponse, 400>({
-          error: bikeErrorMessages.DUPLICATE_CHIP_ID,
-          details: { code: BikeErrorCodeSchema.enum.DUPLICATE_CHIP_ID },
-        }, 400)),
       Match.tag("BikeStationNotFound", ({ stationId }) =>
         c.json<BikeUpdateConflictResponse, 400>({
           error: bikeErrorMessages.BIKE_STATION_NOT_FOUND,

--- a/apps/server/src/http/presenters/bikes.presenter.ts
+++ b/apps/server/src/http/presenters/bikes.presenter.ts
@@ -28,7 +28,6 @@ export function toBikeSummary(
   return {
     id: row.id,
     bikeNumber: row.bikeNumber,
-    chipId: row.chipId,
     stationId: row.stationId,
     station,
     supplier,
@@ -78,7 +77,7 @@ export function toHighestRevenueBike(
 ): BikesContracts.HighestRevenueBike {
   return {
     bikeId: row.bikeId,
-    bikeChipId: row.bikeChipId,
+    bikeNumber: row.bikeNumber,
     totalRevenue: row.totalRevenue,
     rentalCount: row.rentalCount,
     station: row.station

--- a/apps/server/src/http/presenters/ratings.presenter.ts
+++ b/apps/server/src/http/presenters/ratings.presenter.ts
@@ -52,7 +52,7 @@ export function toAdminRatingListItem(
     bike: row.bike
       ? {
           id: row.bike.id,
-          chipId: row.bike.chipId,
+          bikeNumber: row.bike.bikeNumber,
         }
       : null,
     station: row.station

--- a/apps/server/src/http/presenters/redistribution.presenter.ts
+++ b/apps/server/src/http/presenters/redistribution.presenter.ts
@@ -61,7 +61,7 @@ function mapBikeDetail(bike: any) {
     return null;
   return {
     id: bike.id,
-    chipId: bike.chipId,
+    bikeNumber: bike.bikeNumber,
     status: bike.status,
     supplierId: bike.supplierId,
     updatedAt: bike.updatedAt.toISOString(),

--- a/apps/server/src/http/presenters/rentals.presenter.ts
+++ b/apps/server/src/http/presenters/rentals.presenter.ts
@@ -123,7 +123,6 @@ export function toContractAdminRentalDetail(
     bike: {
       id: detail.bike.id,
       bikeNumber: detail.bike.bikeNumber,
-      chipId: detail.bike.chipId,
       status: detail.bike.status,
       supplierId: detail.bike.supplierId ?? undefined,
       updatedAt: detail.bike.updatedAt.toISOString(),
@@ -200,7 +199,6 @@ export function toContractBikeSwapRequestDetail(
     oldBike: {
       id: row.oldBike.id,
       bikeNumber: row.oldBike.bikeNumber,
-      chipId: row.oldBike.chipId,
       station: {
         id: row.oldBike.station.id,
         name: row.oldBike.station.name,
@@ -215,7 +213,6 @@ export function toContractBikeSwapRequestDetail(
       ? {
           id: row.newBike.id,
           bikeNumber: row.newBike.bikeNumber,
-          chipId: row.newBike.chipId,
           station: {
             id: row.newBike.station.id,
             name: row.newBike.station.name,

--- a/apps/server/src/http/presenters/reservations.presenter.ts
+++ b/apps/server/src/http/presenters/reservations.presenter.ts
@@ -42,7 +42,6 @@ export function toContractReservationExpanded(
       ? {
           id: row.bike.id,
           bikeNumber: row.bike.bikeNumber,
-          chipId: row.bike.chipId,
           status: row.bike.status,
         }
       : null,

--- a/apps/server/src/http/test/e2e/ratings-routing.e2e.int.test.ts
+++ b/apps/server/src/http/test/e2e/ratings-routing.e2e.int.test.ts
@@ -122,7 +122,7 @@ describe("ratings routing e2e", () => {
       name: "Tram Nguyen Hue, Quan 1",
     });
     const bike = await fixture.factories.bike({
-      chipId: "MB-8821",
+      bikeNumber: "MB-8821",
       stationId: station.id,
     });
     const rental = await fixture.factories.rental({
@@ -177,7 +177,7 @@ describe("ratings routing e2e", () => {
     expect(body.data).toHaveLength(1);
     expect(body.data[0]).toMatchObject({
       bike: {
-        chipId: "MB-8821",
+        bikeNumber: "MB-8821",
       },
       bikeScore: 4,
       comment: "Xe on nhung khoa hoi cham",
@@ -210,7 +210,7 @@ describe("ratings routing e2e", () => {
       name: "Tram Le Loi",
     });
     const bike = await fixture.factories.bike({
-      chipId: "MB-3342",
+      bikeNumber: "MB-3342",
       stationId: station.id,
     });
     const rental = await fixture.factories.rental({
@@ -263,7 +263,7 @@ describe("ratings routing e2e", () => {
     expect(response.status).toBe(200);
     expect(body).toMatchObject({
       bike: {
-        chipId: "MB-3342",
+        bikeNumber: "MB-3342",
       },
       bikeScore: 5,
       comment: "Rat hai long",

--- a/apps/server/src/test/factories/bike.factory.ts
+++ b/apps/server/src/test/factories/bike.factory.ts
@@ -11,19 +11,14 @@ const defaults = {
 };
 
 export function createBikeFactory(ctx: FactoryContext) {
-  let counter = 0;
-
   return async (overrides: BikeOverrides = {}): Promise<CreatedBike> => {
-    counter++;
     const id = overrides.id ?? uuidv7();
     const bikeNumber = overrides.bikeNumber ?? await getNextBikeNumber(ctx.prisma);
-    const chipId = overrides.chipId ?? `CHIP-${counter}-${id.slice(0, 8)}`;
 
     await ctx.prisma.bike.create({
       data: {
         id,
         bikeNumber,
-        chipId,
         stationId: overrides.stationId ?? defaults.stationId,
         supplierId: overrides.supplierId ?? defaults.supplierId,
         status: overrides.status ?? defaults.status,
@@ -31,7 +26,7 @@ export function createBikeFactory(ctx: FactoryContext) {
       },
     });
 
-    return { id, bikeNumber, chipId };
+    return { id, bikeNumber };
   };
 }
 

--- a/apps/server/src/test/factories/types.ts
+++ b/apps/server/src/test/factories/types.ts
@@ -34,7 +34,6 @@ export type StationOverrides = {
 export type BikeOverrides = {
   id?: string;
   bikeNumber?: string;
-  chipId?: string;
   stationId?: string | null;
   supplierId?: string | null;
   status?: "AVAILABLE" | "BOOKED" | "BROKEN" | "RESERVED" | "MAINTAINED" | "UNAVAILABLE";
@@ -151,7 +150,6 @@ export type CreatedStation = {
 export type CreatedBike = {
   id: string;
   bikeNumber: string;
-  chipId: string;
 };
 
 export type CreatedSupplier = {

--- a/apps/server/src/test/fixtures/users-stats.seed.ts
+++ b/apps/server/src/test/fixtures/users-stats.seed.ts
@@ -99,7 +99,6 @@ export const bikes: BikeSeed[] = [
   {
     id: BIKE_ONE_ID,
     bike_number: "MB-000001",
-    chip_id: "TEST-BIKE-001",
     stationId: STATION_ID,
     supplierId: null,
     status: "AVAILABLE",
@@ -108,7 +107,6 @@ export const bikes: BikeSeed[] = [
   {
     id: BIKE_TWO_ID,
     bike_number: "MB-000002",
-    chip_id: "TEST-BIKE-002",
     stationId: STATION_ID,
     supplierId: null,
     status: "AVAILABLE",

--- a/apps/server/src/worker/test/reservation-hold-worker.int.test.ts
+++ b/apps/server/src/worker/test/reservation-hold-worker.int.test.ts
@@ -62,7 +62,6 @@ describe("reservation hold worker integration", () => {
       longitude: 106.699018,
     });
     const bike = await fixture.factories.bike({
-      chipId: "bike-near-expiry",
       stationId: station.id,
       status: "RESERVED",
     });
@@ -118,7 +117,6 @@ describe("reservation hold worker integration", () => {
       longitude: 106.700424,
     });
     const bike = await fixture.factories.bike({
-      chipId: "bike-expired-hold",
       stationId: station.id,
       status: "RESERVED",
     });

--- a/packages/shared/src/contracts/server/bikes/errors.ts
+++ b/packages/shared/src/contracts/server/bikes/errors.ts
@@ -3,7 +3,6 @@ import { ServerErrorDetailSchema, ServerErrorResponseSchema } from "../schemas";
 
 export const bikeErrorCodes = [
   "BIKE_NOT_FOUND",
-  "DUPLICATE_CHIP_ID",
   "BIKE_STATION_NOT_FOUND",
   "BIKE_SUPPLIER_NOT_FOUND",
   "INVALID_BIKE_STATUS",
@@ -18,7 +17,6 @@ export const BikeErrorCodeSchema = z.enum(bikeErrorCodes);
 export const BikeErrorDetailSchema = ServerErrorDetailSchema.extend({
   code: BikeErrorCodeSchema,
   bikeId: z.uuidv7().optional(),
-  chipId: z.string().optional(),
   stationId: z.uuidv7().optional(),
   supplierId: z.uuidv7().optional(),
   status: z.string().optional(),
@@ -35,7 +33,6 @@ export const BikeNotFoundCodeSchema = z.enum(["BIKE_NOT_FOUND"]);
 export const BikeUpdateConflictCodeSchema = z.enum([
   "BIKE_CURRENTLY_RENTED",
   "BIKE_CURRENTLY_RESERVED",
-  "DUPLICATE_CHIP_ID",
   "BIKE_STATION_NOT_FOUND",
   "BIKE_SUPPLIER_NOT_FOUND",
   "INVALID_BIKE_STATUS",
@@ -100,7 +97,6 @@ export type BikeReportForbiddenResponse = z.infer<typeof BikeReportForbiddenResp
 
 export const bikeErrorMessages: Record<BikeErrorCode, string> = {
   BIKE_NOT_FOUND: "Bike not found",
-  DUPLICATE_CHIP_ID: "Chip ID already exists",
   BIKE_STATION_NOT_FOUND: "Station not found",
   BIKE_SUPPLIER_NOT_FOUND: "Supplier not found",
   INVALID_BIKE_STATUS: "Invalid bike status transition",

--- a/packages/shared/src/contracts/server/bikes/models.ts
+++ b/packages/shared/src/contracts/server/bikes/models.ts
@@ -20,7 +20,6 @@ export const BikeRatingSchema = z.object({
 export const BikeSummarySchema = z.object({
   id: z.uuidv7(),
   bikeNumber: z.string(),
-  chipId: z.string(),
   stationId: z.uuidv7().nullable(),
   station: BikeStationSchema.nullable(),
   supplier: BikeSupplierSchema.nullable(),
@@ -92,7 +91,7 @@ export const BikeStatsSchema = z.object({
 
 export const HighestRevenueBikeSchema = z.object({
   bikeId: z.uuidv7(),
-  bikeChipId: z.string(),
+  bikeNumber: z.string(),
   totalRevenue: z.number(),
   rentalCount: z.number(),
   station: z.object({

--- a/packages/shared/src/contracts/server/incidents/models.ts
+++ b/packages/shared/src/contracts/server/incidents/models.ts
@@ -42,7 +42,7 @@ export const IncidentDetailSchema = z.object({
     .nullable(),
   bike: z.object({
     id: z.uuidv7(),
-    chipId: z.string(),
+    bikeNumber: z.string(),
   }),
   station: z
     .object({

--- a/packages/shared/src/contracts/server/ratings/models.ts
+++ b/packages/shared/src/contracts/server/ratings/models.ts
@@ -23,7 +23,7 @@ export const AdminRatingUserSchema = z.object({
 
 export const AdminRatingBikeSchema = z.object({
   id: z.uuidv7(),
-  chipId: z.string(),
+  bikeNumber: z.string(),
 }).nullable();
 
 export const AdminRatingStationSchema = z.object({

--- a/packages/shared/src/contracts/server/redistribution/models.ts
+++ b/packages/shared/src/contracts/server/redistribution/models.ts
@@ -1,7 +1,7 @@
 import { z } from "../../../zod";
 import { BikeStatusSchema } from "../bikes";
-import { UserRoleSchema, VerifyStatusSchema } from "../users";
 import { PaginationSchema } from "../schemas";
+import { UserRoleSchema, VerifyStatusSchema } from "../users";
 
 export const RedistributionStatusSchema = z.enum([
   "PENDING_APPROVAL",
@@ -82,7 +82,7 @@ export const RedistributionStationSummarySchema = z.object({
 // Bike info for redistribution
 export const RedistributionBikeSchema = z.object({
   id: z.uuidv7(),
-  chipId: z.string(),
+  bikeNumber: z.string(),
   status: BikeStatusSchema,
   supplierId: z.uuidv7().optional(),
   updatedAt: z.iso.datetime(),
@@ -108,8 +108,8 @@ export const RedistributionRequestDetailBaseSchema = z.object({
   updatedAt: z.iso.datetime(),
 });
 
-export const RedistributionRequestDetailSchema =
-  RedistributionRequestDetailBaseSchema.extend({
+export const RedistributionRequestDetailSchema
+  = RedistributionRequestDetailBaseSchema.extend({
     requestedByUser: RedistributionUserDetailSchema,
     approvedByUser: RedistributionUserDetailSchema.nullable(),
     sourceStation: RedistributionStationSchema,
@@ -118,8 +118,8 @@ export const RedistributionRequestDetailSchema =
   });
 
 // Redistribution list item (for paginated lists)
-export const RedistributionRequestListItemSchema =
-  RedistributionRequestDetailBaseSchema.extend({
+export const RedistributionRequestListItemSchema
+  = RedistributionRequestDetailBaseSchema.extend({
     requestedByUser: RedistributionUserSummarySchema,
     approvedByUser: RedistributionUserSummarySchema.nullable(),
     sourceStation: RedistributionStationSummarySchema,

--- a/packages/shared/src/contracts/server/rentals/errors.ts
+++ b/packages/shared/src/contracts/server/rentals/errors.ts
@@ -95,7 +95,7 @@ export const RentalErrorDetailSchema = ServerErrorDetailSchema.extend({
   subscriptionId: z.uuidv7().optional(),
   sosId: z.uuidv7().optional(),
   cardUid: z.string().optional(),
-  chipId: z.string().optional(),
+  bikeIdLookup: z.uuidv7().optional(),
   from: z.string().optional(),
   to: z.string().optional(),
   endTime: z.string().optional(),

--- a/packages/shared/src/contracts/server/rentals/errors.ts
+++ b/packages/shared/src/contracts/server/rentals/errors.ts
@@ -70,7 +70,7 @@ export const rentalErrorCodes = [
 
   // Card Tap Specific Errors
   "USER_NOT_FOUND_FOR_CARD",
-  "BIKE_NOT_FOUND_FOR_CHIP",
+  "BIKE_NOT_FOUND_FOR_BIKE_ID",
   "BIKE_MISSING_STATION",
   "BIKE_NOT_AVAILABLE_FOR_RENTAL",
   "BIKE_SWAP_REQUEST_ALREADY_PENDING",
@@ -226,7 +226,7 @@ export const rentalErrorMessages: Record<RentalErrorCode, string> = {
   BIKE_UPDATE_FAILED: "Bike update failed",
 
   USER_NOT_FOUND_FOR_CARD: "User not found for the provided card",
-  BIKE_NOT_FOUND_FOR_CHIP: "Bike not found for the provided chip",
+  BIKE_NOT_FOUND_FOR_BIKE_ID: "Bike not found for the provided bike ID",
   BIKE_MISSING_STATION: "Bike is missing station information",
   BIKE_NOT_AVAILABLE_FOR_RENTAL: "Bike is not available for rental",
   BIKE_SWAP_REQUEST_ALREADY_PENDING: "A bike swap request is already pending for this rental",

--- a/packages/shared/src/contracts/server/rentals/errors.ts
+++ b/packages/shared/src/contracts/server/rentals/errors.ts
@@ -95,7 +95,6 @@ export const RentalErrorDetailSchema = ServerErrorDetailSchema.extend({
   subscriptionId: z.uuidv7().optional(),
   sosId: z.uuidv7().optional(),
   cardUid: z.string().optional(),
-  bikeIdLookup: z.uuidv7().optional(),
   from: z.string().optional(),
   to: z.string().optional(),
   endTime: z.string().optional(),

--- a/packages/shared/src/contracts/server/rentals/models.ts
+++ b/packages/shared/src/contracts/server/rentals/models.ts
@@ -80,7 +80,6 @@ export const RentalUserDetailSchema = z.object({
 export const RentalBikeSchema = z.object({
   id: z.uuidv7(),
   bikeNumber: z.string(),
-  chipId: z.string(),
   status: BikeStatusSchema,
   supplierId: z.uuidv7().optional(),
   updatedAt: z.iso.datetime(),
@@ -263,7 +262,7 @@ export const StaffCreateRentalRequestSchema = CreateRentalRequestSchema.extend({
 });
 
 export const CardTapRentalRequestSchema = z.object({
-  chipId: z.string(),
+  bikeId: z.uuidv7(),
   cardUid: z.string(),
 });
 
@@ -328,7 +327,6 @@ export const BikeSwapSupplierSchema = z.object({
 export const BikeSwapBikeSchema = z.object({
   id: z.uuidv7(),
   bikeNumber: z.string(),
-  chipId: z.string(),
   station: BikeSwapStationSchema,
   supplier: BikeSwapSupplierSchema,
 });

--- a/packages/shared/src/contracts/server/reservations/models.ts
+++ b/packages/shared/src/contracts/server/reservations/models.ts
@@ -40,7 +40,6 @@ export const ReservationDetailUserSchema = z.object({
 export const ReservationDetailBikeSchema = z.object({
   id: z.uuidv7(),
   bikeNumber: z.string(),
-  chipId: z.string(),
   status: BikeStatusSchema,
 }).openapi("ReservationDetailBike");
 

--- a/packages/shared/src/contracts/server/routes/bikes/mutations.ts
+++ b/packages/shared/src/contracts/server/routes/bikes/mutations.ts
@@ -34,20 +34,10 @@ export const createBike = createRoute({
       },
     },
     400: {
-      description: "Invalid input or duplicate chip ID",
+      description: "Invalid input",
       content: {
         "application/json": {
           schema: BikeUpdateConflictResponseSchema,
-          examples: {
-            DuplicateChipId: {
-              value: {
-                error: "Duplicate Chip ID",
-                details: {
-                  code: BikeErrorCodeSchema.enum.DUPLICATE_CHIP_ID,
-                },
-              },
-            },
-          },
         },
       },
     },

--- a/packages/shared/src/contracts/server/routes/bikes/shared.ts
+++ b/packages/shared/src/contracts/server/routes/bikes/shared.ts
@@ -84,14 +84,12 @@ export const BikeRentalHistoryQuerySchema = z
   });
 
 export const CreateBikeBodySchema = z.object({
-  chipId: z.string().min(1),
   stationId: z.uuidv7(),
   supplierId: z.uuidv7(),
   status: BikeStatusSchema.optional(),
 }).openapi("CreateBikeBody");
 
 export const UpdateBikeBodySchema = z.object({
-  chipId: z.string().optional(),
   stationId: z.uuidv7().optional(),
   supplierId: z.uuidv7().optional(),
   status: BikeStatusSchema.optional(),

--- a/packages/shared/src/contracts/server/routes/ratings/queries.ts
+++ b/packages/shared/src/contracts/server/routes/ratings/queries.ts
@@ -200,7 +200,7 @@ export const adminListRatingsRoute = createRoute({
                     },
                     bike: {
                       id: "0195f9d8-7f4a-7b21-b12a-8c3b5a5d0004",
-                      chipId: "MB-8821",
+                      bikeNumber: "MB-8821",
                     },
                     station: {
                       id: "0195f9d8-7f4a-7b21-b12a-8c3b5a5d0005",
@@ -266,7 +266,7 @@ export const adminGetRatingRoute = createRoute({
                 },
                 bike: {
                   id: "0195f9d8-7f4a-7b21-b12a-8c3b5a5d0004",
-                  chipId: "MB-3342",
+                  bikeNumber: "MB-3342",
                 },
                 station: {
                   id: "0195f9d8-7f4a-7b21-b12a-8c3b5a5d0005",

--- a/packages/shared/src/contracts/server/routes/rentals/mutations.ts
+++ b/packages/shared/src/contracts/server/routes/rentals/mutations.ts
@@ -466,7 +466,7 @@ export const processCardTapRental = createRoute({
               value: {
                 error: "Bike not found or unavailable",
                 details: {
-                  code: RentalErrorCodeSchema.enum.BIKE_NOT_FOUND_FOR_CHIP,
+                  code: RentalErrorCodeSchema.enum.BIKE_NOT_FOUND_FOR_BIKE_ID,
                   bikeId: "019b17bd-d130-7e7d-be69-91ceef7b6888",
                 },
               },

--- a/packages/shared/src/contracts/server/routes/rentals/mutations.ts
+++ b/packages/shared/src/contracts/server/routes/rentals/mutations.ts
@@ -18,7 +18,6 @@ import {
 import { unauthorizedResponse } from "../helpers";
 import {
   BikeSwapRequestDetailSchemaOpenApi,
-  BikeSwapRequestIdParamSchema,
   BikeSwapRequestSchemaOpenApi,
   createSuccessResponse,
   RentalDetailSchemaOpenApi,
@@ -331,10 +330,10 @@ export const confirmRentalReturnByOperator = createRoute({
       },
     },
   },
-    responses: {
-      200: {
-        description: "Rental return confirmed by staff or agency operator",
-        content: {
+  responses: {
+    200: {
+      description: "Rental return confirmed by staff or agency operator",
+      content: {
         "application/json": {
           schema: RentalDetailSchemaOpenApi,
         },
@@ -465,10 +464,10 @@ export const processCardTapRental = createRoute({
             },
             BikeNotFound: {
               value: {
-                error: "Bike with chipId not found or unavailable",
+                error: "Bike not found or unavailable",
                 details: {
                   code: RentalErrorCodeSchema.enum.BIKE_NOT_FOUND_FOR_CHIP,
-                  chipId: "CHIP123456",
+                  bikeId: "019b17bd-d130-7e7d-be69-91ceef7b6888",
                 },
               },
             },

--- a/packages/shared/src/contracts/server/routes/rentals/queries.ts
+++ b/packages/shared/src/contracts/server/routes/rentals/queries.ts
@@ -519,7 +519,7 @@ export const adminGetRental = createRoute({
                 },
                 bike: {
                   id: "019b17bd-d130-7e7d-be69-91ceef7b6888",
-                  chipId: "CHIP-001",
+                  bikeNumber: "MB-000001",
                   status: "AVAILABLE",
                   supplierId: "019b17bd-d130-7e7d-be69-91ceef7b6777",
                   updatedAt: "2026-03-10T09:05:00.000Z",
@@ -602,7 +602,7 @@ export const staffGetRental = createRoute({
                 },
                 bike: {
                   id: "019b17bd-d130-7e7d-be69-91ceef7b6888",
-                  chipId: "CHIP-001",
+                  bikeNumber: "MB-000001",
                   status: "AVAILABLE",
                   supplierId: "019b17bd-d130-7e7d-be69-91ceef7b6777",
                   updatedAt: "2026-03-10T09:05:00.000Z",

--- a/packages/shared/src/contracts/server/stations/models.ts
+++ b/packages/shared/src/contracts/server/stations/models.ts
@@ -142,7 +142,7 @@ export const StationRevenueResponseSchema = z.object({
 
 export const BikeRevenueItemSchema = z.object({
   _id: z.uuidv7(),
-  chipId: z.string(),
+  bikeNumber: z.string(),
   totalRevenue: z.number(),
   totalRevenueFormatted: z.string(),
   totalRentals: z.number(),
@@ -202,7 +202,7 @@ export const NearbyStationSchema = StationReadSummarySchema.extend({
 
 export const NearestAvailableBikeSchema = z.object({
   bikeId: z.uuidv7(),
-  chipId: z.string(),
+  bikeNumber: z.string(),
   status: z.string(),
   stationId: z.uuidv7(),
   stationName: z.string(),


### PR DESCRIPTION
## Summary
- remove `chipId` from bike-related server models, presenters, shared contracts, and seeds/migrations
- rename card-rental and bike-related contract fields to use `bikeId` or `bikeNumber` instead of `chipId`
- update mobile rental and technician incident screens plus rental error presenter to stop depending on `chipId`

## API Changes
- `POST /v1/bikes`: request body removed `chipId`; response bike summary removed `chipId`; duplicate chip-id error removed
- `PATCH /v1/bikes/{id}`: request body removed `chipId`; response bike summary removed `chipId`; duplicate chip-id error removed
- `GET /v1/bikes`: bike summaries no longer include `chipId`
- `GET /v1/bikes/{id}`: bike detail no longer includes `chipId`
- `GET /v1/staff/bikes`: bike summaries no longer include `chipId`
- `GET /v1/staff/bikes/{id}`: bike detail no longer includes `chipId`
- `POST /v1/bikes/{id}/report-broken`: returned bike summary no longer includes `chipId`
- `GET /v1/bikes/stats/highest-revenue`: `bikeChipId` renamed to `bikeNumber`
- `GET /v1/incidents`: nested `bike` changed from `{ id, chipId }` to `{ id, bikeNumber }`
- `GET /v1/incidents/{incidentId}`: nested `bike` changed from `{ id, chipId }` to `{ id, bikeNumber }`
- `PUT /v1/incidents/{incidentId}`: nested `bike` changed from `{ id, chipId }` to `{ id, bikeNumber }`
- `PATCH /v1/incidents/{incidentId}/start`: nested `bike` changed from `{ id, chipId }` to `{ id, bikeNumber }`
- `PATCH /v1/incidents/{incidentId}/resolve`: nested `bike` changed from `{ id, chipId }` to `{ id, bikeNumber }`
- `GET /v1/admin/ratings`: nested `bike` changed from `{ id, chipId }` to `{ id, bikeNumber }`
- `GET /v1/admin/ratings/{ratingId}`: nested `bike` changed from `{ id, chipId }` to `{ id, bikeNumber }`
- `PUT /v1/rentals/{rentalId}/end`: nested rental `bike` no longer includes `chipId`
- `GET /v1/admin/rentals/{rentalId}`: nested rental `bike` no longer includes `chipId`
- `GET /v1/staff/rentals/{rentalId}`: nested rental `bike` no longer includes `chipId`
- `POST /v1/rentals/card-rental` (shared contract): request changed from `{ chipId, cardUid }` to `{ bikeId, cardUid }`; stale chip-based error code/message removed in favor of bike-id wording
- bike-swap detail contracts used by operator/admin/user rental bike-swap routes dropped `chipId` from `oldBike` and `newBike`
- `GET /v1/reservations/me/{reservationId}`: nested reservation `bike` no longer includes `chipId`
- `GET /v1/admin/reservations/{reservationId}`: nested reservation `bike` no longer includes `chipId`
- `GET /v1/staff/reservations/{reservationId}`: nested reservation `bike` no longer includes `chipId`
- redistribution detail and mutation response contracts now expose `bikeNumber` instead of `chipId` for nested bikes
- `GET /v1/stations/bike-revenue` (shared contract): bike revenue items use `bikeNumber` instead of `chipId`
- `GET /v1/stations/nearest-available-bike` (shared contract): response uses `bikeNumber` instead of `chipId`

## Verification
- `pnpm --dir packages/shared build`
- `pnpm prisma generate && pnpm exec tsc --noEmit` in `apps/server`
- `pnpm exec tsc --noEmit` in `apps/mobile`