### PR TITLE
fix: sync agency request station location uniqueness

### DIFF
--- a/apps/server/src/domain/agency-requests/services/agency-request.service.ts
+++ b/apps/server/src/domain/agency-requests/services/agency-request.service.ts
@@ -5,8 +5,8 @@ import type { PrismaClient } from "generated/prisma/client";
 
 import { makeAgencyAccountProvisionService } from "@/domain/agency-account-provisioning";
 import {
-  StationLocationAlreadyExists,
   makeStationQueryRepository,
+  StationLocationAlreadyExists,
 } from "@/domain/stations";
 import { Prisma } from "@/infrastructure/prisma";
 

--- a/apps/server/src/domain/agency-requests/services/agency-request.service.ts
+++ b/apps/server/src/domain/agency-requests/services/agency-request.service.ts
@@ -4,6 +4,10 @@ import type { PageResult } from "@/domain/shared/pagination";
 import type { PrismaClient } from "generated/prisma/client";
 
 import { makeAgencyAccountProvisionService } from "@/domain/agency-account-provisioning";
+import {
+  StationLocationAlreadyExists,
+  makeStationQueryRepository,
+} from "@/domain/stations";
 import { Prisma } from "@/infrastructure/prisma";
 
 import type {
@@ -58,7 +62,10 @@ export type AgencyRequestService = {
   >;
   submit: (
     input: SubmitAgencyRequestInput,
-  ) => Effect.Effect<AgencyRequestRow, AgencyRequestRepositoryError>;
+  ) => Effect.Effect<
+    AgencyRequestRow,
+    AgencyRequestRepositoryError | StationLocationAlreadyExists
+  >;
   approve: (
     agencyRequestId: string,
     input: ApproveAgencyRequestInput,
@@ -67,6 +74,7 @@ export type AgencyRequestService = {
     | AgencyRequestRepositoryError
     | AgencyRequestNotFound
     | InvalidAgencyRequestStatusTransition
+    | StationLocationAlreadyExists
   >;
   reject: (
     agencyRequestId: string,
@@ -103,6 +111,7 @@ function makeAgencyRequestService(
   client: PrismaClient,
 ): AgencyRequestService {
   const provisionService = makeAgencyAccountProvisionService(client);
+  const stationQueryRepo = makeStationQueryRepository(client);
 
   return {
     getById: id => repo.findById(id),
@@ -118,7 +127,26 @@ function makeAgencyRequestService(
       }),
     list: filter => repo.list(filter),
     listWithOffset: (filter, pageReq) => repo.listWithOffset(filter, pageReq),
-    submit: input => repo.submit(input),
+    submit: input =>
+      Effect.gen(function* () {
+        const stationExists = yield* stationQueryRepo.existsByExactLocation({
+          address: input.stationAddress,
+          latitude: input.stationLatitude,
+          longitude: input.stationLongitude,
+        });
+
+        if (stationExists) {
+          return yield* Effect.fail(
+            new StationLocationAlreadyExists({
+              address: input.stationAddress,
+              latitude: input.stationLatitude,
+              longitude: input.stationLongitude,
+            }),
+          );
+        }
+
+        return yield* repo.submit(input);
+      }),
     approve: (agencyRequestId, input) =>
       Effect.gen(function* () {
         const txAgencyRequestRepo = makeAgencyRequestRepository(client);
@@ -208,13 +236,6 @@ function makeAgencyRequestService(
             }),
           )),
         Effect.catchTag("StationNameAlreadyExists", err =>
-          Effect.fail(
-            new AgencyRequestRepositoryErrorData({
-              operation: "approve.createStation",
-              cause: err,
-            }),
-          )),
-        Effect.catchTag("StationLocationAlreadyExists", err =>
           Effect.fail(
             new AgencyRequestRepositoryErrorData({
               operation: "approve.createStation",

--- a/apps/server/src/domain/stations/repository/read/station.read.repository.ts
+++ b/apps/server/src/domain/stations/repository/read/station.read.repository.ts
@@ -39,6 +39,7 @@ export type StationReadRepo = Pick<
   | "listWithOffset"
   | "getById"
   | "getByAgencyId"
+  | "existsByExactLocation"
   | "findIdNameAddressByIds"
   | "listContextExcludingId"
   | "listNearest"
@@ -232,6 +233,28 @@ export function makeStationReadRepository(
 
         return Option.some(station);
       }).pipe(defectOn(StationRepositoryError));
+    },
+
+    existsByExactLocation({ address, latitude, longitude }) {
+      return Effect.tryPromise({
+        try: () =>
+          client.station.findFirst({
+            where: {
+              address,
+              latitude,
+              longitude,
+            },
+            select: { id: true },
+          }),
+        catch: cause =>
+          new StationRepositoryError({
+            operation: "existsByExactLocation",
+            cause,
+          }),
+      }).pipe(
+        Effect.map(row => row !== null),
+        defectOn(StationRepositoryError),
+      );
     },
 
     findIdNameAddressByIds(ids) {

--- a/apps/server/src/domain/stations/repository/station.repository.types.ts
+++ b/apps/server/src/domain/stations/repository/station.repository.types.ts
@@ -46,6 +46,13 @@ export type StationQueryRepo = {
   getByAgencyId: (
     agencyId: string,
   ) => Effect.Effect<Option.Option<StationRow>>;
+  existsByExactLocation: (
+    args: {
+      readonly address: string;
+      readonly latitude: number;
+      readonly longitude: number;
+    },
+  ) => Effect.Effect<boolean>;
   findIdNameAddressByIds: (
     ids: readonly string[],
   ) => Effect.Effect<readonly { id: string; name: string; address: string }[]>;

--- a/apps/server/src/http/controllers/agency-requests/admin.controller.ts
+++ b/apps/server/src/http/controllers/agency-requests/admin.controller.ts
@@ -125,6 +125,16 @@ const approveAgencyRequest: RouteHandler<AgencyRequestsRoutes["adminApprove"]> =
               nextStatus,
             },
           }, 400)),
+        Match.tag("StationLocationAlreadyExists", ({ address, latitude, longitude }) =>
+          c.json<AgencyRequestErrorResponse, 400>({
+            error: agencyRequestErrorMessages.STATION_LOCATION_ALREADY_EXISTS,
+            details: {
+              code: AgencyRequestErrorCodeSchema.enum.STATION_LOCATION_ALREADY_EXISTS,
+              address,
+              latitude,
+              longitude,
+            },
+          }, 400)),
         Match.orElse(() => {
           throw left;
         }),

--- a/apps/server/src/http/controllers/agency-requests/public.controller.ts
+++ b/apps/server/src/http/controllers/agency-requests/public.controller.ts
@@ -2,14 +2,19 @@ import type { RouteHandler } from "@hono/zod-openapi";
 import type { AgencyRequestsContracts } from "@mebike/shared";
 
 import { serverRoutes } from "@mebike/shared";
-import { Effect } from "effect";
+import { Effect, Match } from "effect";
 
 import { AgencyRequestServiceTag } from "@/domain/agency-requests";
 import { withLoggedCause } from "@/domain/shared";
 import { toAgencyRequest } from "@/http/presenters/agency-requests.presenter";
 import { routeContext } from "@/http/shared/route-context";
 
-import type { AgencyRequestsRoutes } from "./shared";
+import type {
+  AgencyRequestErrorResponse,
+  AgencyRequestsRoutes,
+} from "./shared";
+
+import { AgencyRequestErrorCodeSchema, agencyRequestErrorMessages } from "./shared";
 
 const agencyRequests = serverRoutes.agencyRequests;
 
@@ -39,10 +44,31 @@ const submit: RouteHandler<AgencyRequestsRoutes["submit"]> = async (c) => {
     routeContext(agencyRequests.submit),
   );
 
-  const result = await c.var.runPromise(eff);
-  return c.json<AgencyRequestsContracts.SubmitAgencyRequestResponse, 201>(
-    toAgencyRequest(result),
-    201,
+  const result = await c.var.runPromise(eff.pipe(Effect.either));
+
+  return Match.value(result).pipe(
+    Match.tag("Right", ({ right }) =>
+      c.json<AgencyRequestsContracts.SubmitAgencyRequestResponse, 201>(
+        toAgencyRequest(right),
+        201,
+      )),
+    Match.tag("Left", ({ left }) =>
+      Match.value(left).pipe(
+        Match.tag("StationLocationAlreadyExists", ({ address, latitude, longitude }) =>
+          c.json<AgencyRequestErrorResponse, 400>({
+            error: agencyRequestErrorMessages.STATION_LOCATION_ALREADY_EXISTS,
+            details: {
+              code: AgencyRequestErrorCodeSchema.enum.STATION_LOCATION_ALREADY_EXISTS,
+              address,
+              latitude,
+              longitude,
+            },
+          }, 400)),
+        Match.orElse(() => {
+          throw left;
+        }),
+      )),
+    Match.exhaustive,
   );
 };
 

--- a/apps/server/src/http/test/e2e/agency-requests-routing.e2e.int.test.ts
+++ b/apps/server/src/http/test/e2e/agency-requests-routing.e2e.int.test.ts
@@ -241,6 +241,41 @@ describe("agency requests routing", () => {
     });
   });
 
+  it("rejects submitting an agency request when station exact location already exists", async () => {
+    await fixture.factories.station({
+      name: "Existing Agency Request Location",
+      address: "02 Xa Lo Ha Noi, Thu Duc, TP.HCM",
+      latitude: 10.8486,
+      longitude: 106.7717,
+    });
+
+    const beforeCount = await fixture.prisma.agencyRequest.count();
+
+    const response = await submitAgencyRequest({
+      requesterEmail: "duplicate-submit-location@example.com",
+      agencyName: "Duplicate Submit Location Agency",
+      stationName: "Ga Duplicate Submit Location",
+      stationAddress: "02 Xa Lo Ha Noi, Thu Duc, TP.HCM",
+      stationLatitude: 10.8486,
+      stationLongitude: 106.7717,
+      stationTotalCapacity: 20,
+      stationReturnSlotLimit: 18,
+    });
+    const body = await response.json() as AgencyRequestsContracts.AgencyRequestErrorResponse;
+
+    expect(response.status).toBe(400);
+    expect(body).toEqual({
+      error: "Station address and coordinates already exist",
+      details: {
+        code: "STATION_LOCATION_ALREADY_EXISTS",
+        address: "02 Xa Lo Ha Noi, Thu Duc, TP.HCM",
+        latitude: 10.8486,
+        longitude: 106.7717,
+      },
+    });
+    expect(await fixture.prisma.agencyRequest.count()).toBe(beforeCount);
+  });
+
   it("rejects invalid requester email", async () => {
     const beforeCount = await fixture.prisma.agencyRequest.count();
 
@@ -639,6 +674,126 @@ describe("agency requests routing", () => {
       to: "approved-agency-request@example.com",
       subject: "MeBike phê duyệt tài khoản Agency",
     });
+  });
+
+  it("returns duplicate station location when approving a pending request whose location already exists", async () => {
+    await fixture.factories.station({
+      name: "Existing Legacy Request Location",
+      address: "88 Nguyen Hue, Ben Nghe, District 1, TP.HCM",
+      latitude: 10.775,
+      longitude: 106.699,
+    });
+
+    const agencyRequest = await fixture.prisma.agencyRequest.create({
+      data: {
+        requesterEmail: "legacy-duplicate-location@example.com",
+        agencyName: "Legacy Duplicate Location Agency",
+        agencyAddress: "88 Nguyen Hue, Ben Nghe, District 1, TP.HCM",
+        agencyContactPhone: "0987654321",
+        stationName: "Ga Legacy Duplicate Location",
+        stationAddress: "88 Nguyen Hue, Ben Nghe, District 1, TP.HCM",
+        stationLatitude: 10.775,
+        stationLongitude: 106.699,
+        stationTotalCapacity: 20,
+        stationReturnSlotLimit: 18,
+        status: "PENDING",
+      },
+    });
+
+    const token = fixture.auth.makeAccessToken({ userId: ADMIN_USER_ID, role: "ADMIN" });
+    const response = await approveAgencyRequest(agencyRequest.id, {}, { token });
+    const body = await response.json() as AgencyRequestsContracts.AgencyRequestErrorResponse;
+
+    expect(response.status).toBe(400);
+    expect(body).toEqual({
+      error: "Station address and coordinates already exist",
+      details: {
+        code: "STATION_LOCATION_ALREADY_EXISTS",
+        address: "88 Nguyen Hue, Ben Nghe, District 1, TP.HCM",
+        latitude: 10.775,
+        longitude: 106.699,
+      },
+    });
+
+    const savedRequest = await fixture.prisma.agencyRequest.findUnique({
+      where: { id: agencyRequest.id },
+      select: {
+        status: true,
+        reviewedByUserId: true,
+        approvedAgencyId: true,
+        createdAgencyUserId: true,
+      },
+    });
+
+    expect(savedRequest).toEqual({
+      status: "PENDING",
+      reviewedByUserId: null,
+      approvedAgencyId: null,
+      createdAgencyUserId: null,
+    });
+    expect(await fixture.prisma.agency.findFirst({
+      where: { name: "Legacy Duplicate Location Agency" },
+    })).toBeNull();
+  });
+
+  it("returns duplicate station location when a station is created after request submit but before approve", async () => {
+    const submitResponse = await submitAgencyRequest({
+      requesterEmail: "race-duplicate-location@example.com",
+      agencyName: "Race Duplicate Location Agency",
+      agencyAddress: "77 Race Street, Thu Duc, TP.HCM",
+      agencyContactPhone: "0987654321",
+      stationName: "Ga Race Duplicate Location",
+      stationAddress: "77 Race Street, Thu Duc, TP.HCM",
+      stationLatitude: 10.8421,
+      stationLongitude: 106.8284,
+      stationTotalCapacity: 20,
+      stationReturnSlotLimit: 18,
+    });
+    const submitted = await submitResponse.json() as AgencyRequestsContracts.SubmitAgencyRequestResponse;
+
+    expect(submitResponse.status).toBe(201);
+
+    await fixture.factories.station({
+      name: "Station Created After Agency Request Submit",
+      address: "77 Race Street, Thu Duc, TP.HCM",
+      latitude: 10.8421,
+      longitude: 106.8284,
+    });
+
+    const token = fixture.auth.makeAccessToken({ userId: ADMIN_USER_ID, role: "ADMIN" });
+    const response = await approveAgencyRequest(submitted.id, {}, { token });
+    const body = await response.json() as AgencyRequestsContracts.AgencyRequestErrorResponse;
+
+    expect(response.status).toBe(400);
+    expect(body).toEqual({
+      error: "Station address and coordinates already exist",
+      details: {
+        code: "STATION_LOCATION_ALREADY_EXISTS",
+        address: "77 Race Street, Thu Duc, TP.HCM",
+        latitude: 10.8421,
+        longitude: 106.8284,
+      },
+    });
+
+    const savedRequest = await fixture.prisma.agencyRequest.findUnique({
+      where: { id: submitted.id },
+      select: {
+        status: true,
+        reviewedByUserId: true,
+        approvedAgencyId: true,
+        createdAgencyUserId: true,
+      },
+    });
+
+    expect(savedRequest).toEqual({
+      status: "PENDING",
+      reviewedByUserId: null,
+      approvedAgencyId: null,
+      createdAgencyUserId: null,
+    });
+    expect(await fixture.prisma.agency.findFirst({
+      where: { name: "Race Duplicate Location Agency" },
+    })).toBeNull();
   });
 
   it("returns 404 when admin approves an unknown agency request", async () => {

--- a/docs/agency/agency-station-scalar-pgadmin-checklist.md
+++ b/docs/agency/agency-station-scalar-pgadmin-checklist.md
@@ -1184,8 +1184,7 @@ Body:
   "stationLatitude": 10.8495,
   "stationLongitude": 106.7712,
   "stationTotalCapacity": 20,
-  "stationPickupSlotLimit": 10,
-  "stationReturnSlotLimit": 10,
+  "stationReturnSlotLimit": 18,
   "description": "New agency request for VINCOM Thu Duc"
 }
 ```
@@ -1195,6 +1194,7 @@ Ky vong:
 - `201`
 - `status = "PENDING"`
 - response co day du `requesterEmail`, `agencyName`, `stationName`, `stationAddress`
+- chua tao `Agency`, `Station`, hay account `AGENCY`
 
 Kiem tra DB:
 
@@ -1208,7 +1208,6 @@ SELECT
   station_latitude,
   station_longitude,
   station_total_capacity,
-  station_pickup_slot_limit,
   station_return_slot_limit,
   status
 FROM "AgencyRequest"
@@ -1216,6 +1215,12 @@ ORDER BY created_at DESC;
 ```
 
 Lay `agencyRequestId` vua tao.
+
+Luu y exact station location uniqueness:
+
+- submit se bi chan som neu da co `Station` cung exact `address + latitude + longitude`
+- loi tra ve HTTP `400` voi `details.code = "STATION_LOCATION_ALREADY_EXISTS"`
+- rule nay khong lien quan `pickupSlotLimit`; agency request chi dung `stationReturnSlotLimit`
 
 ## 21. Admin approve agency request va auto-create station
 
@@ -1273,6 +1278,361 @@ Ky vong:
 
 - agency moi da co station moi
 - station moi co `station_type = 'AGENCY'`
+- station moi dung `return_slot_limit` tu `stationReturnSlotLimit`
+
+Luu y duplicate location khi approve:
+
+- approve van phai handle `STATION_LOCATION_ALREADY_EXISTS` du submit da pre-check
+- ly do: pending request cu co the da ton tai truoc rule moi, hoac race condition xay ra giua submit va approve
+- neu approve fail vi duplicate location thi transaction rollback, request van `PENDING`, khong tao `Agency`, `Station`, hay account `AGENCY`
+
+## 21A. Verify exact station location uniqueness cho agency request
+
+Section nay verify phan moi sua: agency request submit va agency request approve
+dong bo duplicate exact station location voi station/admin agency provisioning flow.
+
+Rule duplicate location la exact match tren:
+
+```text
+Station.address + Station.latitude + Station.longitude
+```
+
+Response duplicate ky vong:
+
+```json
+{
+  "error": "Station address and coordinates already exist",
+  "details": {
+    "code": "STATION_LOCATION_ALREADY_EXISTS",
+    "address": "20 Demo Duplicate Submit Street, Thu Duc, TP.HCM",
+    "latitude": 10.848601,
+    "longitude": 106.771701
+  }
+}
+```
+
+### 21A.1. Submit agency request bi reject neu station exact location da ton tai
+
+Tao station truoc bang Scalar:
+
+```text
+POST /v1/stations
+```
+
+Body:
+
+```json
+{
+  "name": "Demo Existing Exact Location 01",
+  "address": "20 Demo Duplicate Submit Street, Thu Duc, TP.HCM",
+  "stationType": "INTERNAL",
+  "totalCapacity": 20,
+  "returnSlotLimit": 20,
+  "latitude": 10.848601,
+  "longitude": 106.771701
+}
+```
+
+Ky vong: HTTP `201`.
+
+Submit agency request cung exact location:
+
+```text
+POST /v1/agency-requests
+```
+
+Body:
+
+```json
+{
+  "requesterEmail": "demo-submit-dup-01@example.com",
+  "agencyName": "Demo Submit Duplicate Agency 01",
+  "stationName": "Ga Demo Submit Duplicate 01",
+  "stationAddress": "20 Demo Duplicate Submit Street, Thu Duc, TP.HCM",
+  "stationLatitude": 10.848601,
+  "stationLongitude": 106.771701,
+  "stationTotalCapacity": 20,
+  "stationReturnSlotLimit": 18
+}
+```
+
+Ky vong:
+
+- HTTP `400`
+- `details.code = "STATION_LOCATION_ALREADY_EXISTS"`
+- response co `address`, `latitude`, `longitude`
+
+Kiem tra DB:
+
+```sql
+SELECT id, status, requester_email, agency_name
+FROM "AgencyRequest"
+WHERE requester_email = 'demo-submit-dup-01@example.com';
+```
+
+Ky vong: `0 rows`.
+
+### 21A.2. Exact match phai trung ca address + latitude + longitude
+
+Cung address nhung khac toa do van duoc submit:
+
+```json
+{
+  "requesterEmail": "demo-same-address-diff-coord-01@example.com",
+  "agencyName": "Demo Same Address Diff Coord Agency 01",
+  "stationName": "Ga Same Address Diff Coord 01",
+  "stationAddress": "20 Demo Duplicate Submit Street, Thu Duc, TP.HCM",
+  "stationLatitude": 10.848602,
+  "stationLongitude": 106.771702,
+  "stationTotalCapacity": 20,
+  "stationReturnSlotLimit": 18
+}
+```
+
+Khac address nhung cung toa do van duoc submit:
+
+```json
+{
+  "requesterEmail": "demo-diff-address-same-coord-01@example.com",
+  "agencyName": "Demo Diff Address Same Coord Agency 01",
+  "stationName": "Ga Diff Address Same Coord 01",
+  "stationAddress": "21 Demo Different Address Street, Thu Duc, TP.HCM",
+  "stationLatitude": 10.848601,
+  "stationLongitude": 106.771701,
+  "stationTotalCapacity": 20,
+  "stationReturnSlotLimit": 18
+}
+```
+
+Ky vong: ca 2 request deu HTTP `201`, `status = "PENDING"`.
+
+Kiem tra DB:
+
+```sql
+SELECT requester_email, status, station_address, station_latitude, station_longitude
+FROM "AgencyRequest"
+WHERE requester_email IN (
+  'demo-same-address-diff-coord-01@example.com',
+  'demo-diff-address-same-coord-01@example.com'
+)
+ORDER BY requester_email;
+```
+
+Ky vong: 2 rows `PENDING`.
+
+### 21A.3. Approve pending request cu bi reject neu location da co station
+
+Case nay mo phong pending request cu, vi public submit hien da chan duplicate
+truoc khi tao request.
+
+Tao station truoc bang Scalar:
+
+```text
+POST /v1/stations
+```
+
+Body:
+
+```json
+{
+  "name": "Demo Existing Legacy Approve Location 01",
+  "address": "30 Demo Legacy Duplicate Street, Thu Duc, TP.HCM",
+  "stationType": "INTERNAL",
+  "totalCapacity": 20,
+  "returnSlotLimit": 20,
+  "latitude": 10.775001,
+  "longitude": 106.699001
+}
+```
+
+Tao legacy pending request bang pgAdmin. Luu y phai set `id` thu cong vi
+`@default(uuid(7))` la Prisma-side default, insert truc tiep SQL se khong tu
+sinh id.
+
+```sql
+DELETE FROM "AgencyRequest"
+WHERE id = '019b17bd-d130-7e7d-be69-91ceef7d1001'::uuid
+   OR requester_email = 'demo-legacy-approve-dup-01@example.com';
+
+INSERT INTO "AgencyRequest" (
+  id,
+  requester_email,
+  requester_phone,
+  agency_name,
+  agency_address,
+  agency_contact_phone,
+  station_name,
+  station_address,
+  station_latitude,
+  station_longitude,
+  station_total_capacity,
+  station_return_slot_limit,
+  status,
+  description,
+  updated_at
+)
+VALUES (
+  '019b17bd-d130-7e7d-be69-91ceef7d1001'::uuid,
+  'demo-legacy-approve-dup-01@example.com',
+  '0912345678',
+  'Demo Legacy Approve Duplicate Agency 01',
+  '30 Demo Legacy Duplicate Street, Thu Duc, TP.HCM',
+  '0987654321',
+  'Ga Demo Legacy Approve Duplicate 01',
+  '30 Demo Legacy Duplicate Street, Thu Duc, TP.HCM',
+  10.775001,
+  106.699001,
+  20,
+  18,
+  'PENDING',
+  'Legacy pending request for duplicate approve demo',
+  now()
+)
+RETURNING id;
+```
+
+Approve bang Scalar:
+
+```text
+POST /v1/admin/agency-requests/019b17bd-d130-7e7d-be69-91ceef7d1001/approve
+```
+
+Body:
+
+```json
+{}
+```
+
+Ky vong:
+
+- HTTP `400`
+- `details.code = "STATION_LOCATION_ALREADY_EXISTS"`
+- request van `PENDING`
+- khong tao `Agency`, `Station`, hay account `AGENCY` moi
+
+Kiem tra DB:
+
+```sql
+SELECT id, status, reviewed_by_user_id, reviewed_at,
+       approved_agency_id, created_agency_user_id
+FROM "AgencyRequest"
+WHERE id = '019b17bd-d130-7e7d-be69-91ceef7d1001'::uuid;
+```
+
+Ky vong: `status = 'PENDING'`, cac cot review/approve/user la `NULL`.
+
+```sql
+SELECT id, name
+FROM "Agency"
+WHERE name = 'Demo Legacy Approve Duplicate Agency 01';
+```
+
+Ky vong: `0 rows`.
+
+### 21A.4. Race condition: request tao truoc, station trung tao sau
+
+Submit request truoc khi location co station:
+
+```text
+POST /v1/agency-requests
+```
+
+Body:
+
+```json
+{
+  "requesterEmail": "demo-race-approve-dup-01@example.com",
+  "requesterPhone": "0912345678",
+  "agencyName": "Demo Race Approve Duplicate Agency 01",
+  "agencyAddress": "40 Demo Race Duplicate Street, Thu Duc, TP.HCM",
+  "agencyContactPhone": "0987654321",
+  "stationName": "Ga Demo Race Approve Duplicate 01",
+  "stationAddress": "40 Demo Race Duplicate Street, Thu Duc, TP.HCM",
+  "stationLatitude": 10.842201,
+  "stationLongitude": 106.828501,
+  "stationTotalCapacity": 20,
+  "stationReturnSlotLimit": 18
+}
+```
+
+Ky vong: HTTP `201`, copy `id`.
+
+Tao station trung exact location:
+
+```text
+POST /v1/stations
+```
+
+Body:
+
+```json
+{
+  "name": "Demo Station Created During Race 01",
+  "address": "40 Demo Race Duplicate Street, Thu Duc, TP.HCM",
+  "stationType": "INTERNAL",
+  "totalCapacity": 20,
+  "returnSlotLimit": 20,
+  "latitude": 10.842201,
+  "longitude": 106.828501
+}
+```
+
+Approve request vua tao:
+
+```text
+POST /v1/admin/agency-requests/{id}/approve
+```
+
+Body:
+
+```json
+{}
+```
+
+Ky vong: HTTP `400`, `details.code = "STATION_LOCATION_ALREADY_EXISTS"`.
+
+Kiem tra DB:
+
+```sql
+SELECT id, status, reviewed_by_user_id, reviewed_at,
+       approved_agency_id, created_agency_user_id
+FROM "AgencyRequest"
+WHERE requester_email = 'demo-race-approve-dup-01@example.com';
+```
+
+Ky vong: request van `PENDING`, cac cot review/approve/user la `NULL`.
+
+```sql
+SELECT id, name, address, station_type, agency_id, latitude, longitude
+FROM "Station"
+WHERE address = '40 Demo Race Duplicate Street, Thu Duc, TP.HCM'
+  AND latitude = 10.842201
+  AND longitude = 106.828501;
+```
+
+Ky vong: chi co station tao de mo phong race; khong co agency station moi tu
+approve.
+
+### 21A.5. Kiem tra DB unique constraint
+
+```sql
+SELECT indexname, indexdef
+FROM pg_indexes
+WHERE tablename = 'Station'
+  AND indexname = 'uq_station_exact_location';
+```
+
+Ky vong: co index `uq_station_exact_location` tren `address`, `latitude`,
+`longitude`.
+
+```sql
+SELECT address, latitude, longitude, COUNT(*) AS total
+FROM "Station"
+GROUP BY address, latitude, longitude
+HAVING COUNT(*) > 1;
+```
+
+Ky vong: `0 rows`.
 
 ## 22. Verify agency API khong con dung address o root
 
@@ -1391,12 +1751,17 @@ Thu tu khuyen nghi:
 13. test incident bi chan o agency station
 14. test submit agency request
 15. test approve agency request va auto-create station
+16. test submit agency request duplicate exact station location
+17. test approve agency request duplicate exact station location va race condition
 
 ## 25. Ghi chu khi test
 
 - Khong hardcode UUID tu lan seed truoc. Moi lan reset DB nen lay lai ID bang SQL baseline.
 - Neu da approve bike swap request roi thi muon test reject phai reset lai DB hoac tao request pending moi.
 - `POST /v1/agency-requests` bat buoc co `requesterEmail`.
+- `POST /v1/agency-requests` se reject neu da co `Station` cung exact `address + latitude + longitude`.
+- `POST /v1/admin/agency-requests/{id}/approve` van phai handle duplicate exact station location de chong pending request cu va race condition.
+- Loi duplicate station location phai la HTTP `400` voi `details.code = "STATION_LOCATION_ALREADY_EXISTS"`.
 - `PUT /v1/rentals/{rentalId}/end` hien tai chi hop le cho `STAFF` hoac `AGENCY`, khong con `ADMIN`.
 - `incident` khong con ho tro `AGENCY` role va khong duoc tao o station `AGENCY`.
 - `bike swap` da duoc gop thanh operator routes chung `/v1/operators/bike-swap-requests...`; quyen duoc resolve theo role dang dang nhap va owner cua station.

--- a/packages/shared/src/contracts/server/routes/agency-requests/mutations.ts
+++ b/packages/shared/src/contracts/server/routes/agency-requests/mutations.ts
@@ -3,7 +3,6 @@ import { createRoute, z } from "@hono/zod-openapi";
 import {
   OptionalPhoneNumberNullableSchema,
   OptionalTrimmedNullableStringSchema,
-  ServerErrorResponseSchema,
 } from "../../schemas";
 import { AgencyRequestSchema } from "../../agency-requests/models";
 import { forbiddenResponse, unauthorizedResponse } from "../helpers";
@@ -111,10 +110,23 @@ export const submitAgencyRequestRoute = createRoute({
       },
     },
     400: {
-      description: "Invalid request payload",
+      description: "Invalid request payload or duplicate station location",
       content: {
         "application/json": {
-          schema: ServerErrorResponseSchema,
+          schema: AgencyRequestErrorResponseSchema,
+          examples: {
+            DuplicateLocation: {
+              value: {
+                error: agencyRequestErrorMessages.STATION_LOCATION_ALREADY_EXISTS,
+                details: {
+                  code: AgencyRequestErrorCodeSchema.enum.STATION_LOCATION_ALREADY_EXISTS,
+                  address: "371 Doan Ket, Binh Tho, Thu Duc, TP.HCM",
+                  latitude: 10.762622,
+                  longitude: 106.660172,
+                },
+              },
+            },
+          },
         },
       },
     },
@@ -237,6 +249,17 @@ export const approveAgencyRequestRoute = createRoute({
                   agencyRequestId: "0195e4f7-f7d3-7b7a-8fd8-5f2df87fd301",
                   currentStatus: "APPROVED",
                   nextStatus: "APPROVED",
+                },
+              },
+            },
+            DuplicateLocation: {
+              value: {
+                error: agencyRequestErrorMessages.STATION_LOCATION_ALREADY_EXISTS,
+                details: {
+                  code: AgencyRequestErrorCodeSchema.enum.STATION_LOCATION_ALREADY_EXISTS,
+                  address: "371 Doan Ket, Binh Tho, Thu Duc, TP.HCM",
+                  latitude: 10.762622,
+                  longitude: 106.660172,
                 },
               },
             },

--- a/packages/shared/src/contracts/server/routes/agency-requests/shared.ts
+++ b/packages/shared/src/contracts/server/routes/agency-requests/shared.ts
@@ -69,6 +69,7 @@ export const AgencyRequestErrorCodeSchema = z.enum([
   "AGENCY_REQUEST_NOT_FOUND",
   "AGENCY_REQUEST_NOT_OWNED",
   "INVALID_AGENCY_REQUEST_STATUS_TRANSITION",
+  "STATION_LOCATION_ALREADY_EXISTS",
 ]).openapi("AgencyRequestErrorCode");
 
 export const AgencyRequestErrorDetailSchema = z
@@ -78,6 +79,9 @@ export const AgencyRequestErrorDetailSchema = z
     userId: z.uuidv7().optional(),
     currentStatus: AgencyRequestStatusSchema.optional(),
     nextStatus: AgencyRequestStatusSchema.optional(),
+    address: z.string().optional(),
+    latitude: z.number().optional(),
+    longitude: z.number().optional(),
   })
   .openapi("AgencyRequestErrorDetail");
 
@@ -92,6 +96,7 @@ export const agencyRequestErrorMessages = {
   AGENCY_REQUEST_NOT_FOUND: "Agency request not found",
   AGENCY_REQUEST_NOT_OWNED: "Agency request does not belong to user",
   INVALID_AGENCY_REQUEST_STATUS_TRANSITION: "Invalid agency request status transition",
+  STATION_LOCATION_ALREADY_EXISTS: "Station address and coordinates already exist",
 } as const;
 
 export {


### PR DESCRIPTION
Reject agency request submits with duplicate exact station locations, surface duplicate location errors during approval, update shared contracts, add e2e coverage, and document Scalar/pgAdmin verification flows.