### PR TITLE
feat(server): add scoped manager and agency bike status updates

### DIFF
--- a/apps/server/src/domain/bikes/repository/bike.repository.types.ts
+++ b/apps/server/src/domain/bikes/repository/bike.repository.types.ts
@@ -41,6 +41,19 @@ export type BikeCommandRepo = {
     status: BikeStatus,
     updatedAt: Date,
   ) => Effect.Effect<Option.Option<BikeRow>>;
+  transitionStatusAt: (
+    bikeId: string,
+    from: BikeStatus,
+    to: BikeStatus,
+    updatedAt: Date,
+  ) => Effect.Effect<Option.Option<BikeRow>>;
+  transitionStatusInStationAt: (
+    bikeId: string,
+    stationId: string,
+    from: BikeStatus,
+    to: BikeStatus,
+    updatedAt: Date,
+  ) => Effect.Effect<Option.Option<BikeRow>>;
   updateStatusAndStationAt: (
     bikeId: string,
     status: BikeStatus,

--- a/apps/server/src/domain/bikes/repository/write/bike.write.repository.ts
+++ b/apps/server/src/domain/bikes/repository/write/bike.write.repository.ts
@@ -55,6 +55,20 @@ export function makeBikeWriteRepository(client: BikeDbClient): BikeCommandRepo {
     updateStatusAt: (bikeId, status, updatedAt) =>
       updateAndReloadBike(client, bikeId, buildStatusUpdate(status, updatedAt), "updateStatusAt"),
 
+    transitionStatusAt: (bikeId, from, to, updatedAt) =>
+      transitionAndReloadBike(client, bikeId, from, to, updatedAt, "transitionStatusAt"),
+
+    transitionStatusInStationAt: (bikeId, stationId, from, to, updatedAt) =>
+      transitionAndReloadBikeInStation(
+        client,
+        bikeId,
+        stationId,
+        from,
+        to,
+        updatedAt,
+        "transitionStatusInStationAt",
+      ),
+
     updateStatusAndStationAt: (bikeId, status, stationId, updatedAt) =>
       updateAndReloadBike(
         client,
@@ -249,5 +263,89 @@ function transitionBikeStatus(
         cause,
         message: "Failed to transition bike status",
       }),
+  }).pipe(defectOn(BikeRepositoryError));
+}
+
+function transitionAndReloadBike(
+  client: BikeDbClient,
+  bikeId: string,
+  from: BikeStatus,
+  to: BikeStatus,
+  updatedAt: Date,
+  operation: string,
+) {
+  return Effect.gen(function* () {
+    const transitioned = yield* transitionBikeStatus(client, {
+      bikeId,
+      from,
+      to,
+      updatedAt,
+      operation,
+    });
+
+    if (!transitioned) {
+      return Option.none();
+    }
+
+    const row = yield* Effect.tryPromise({
+      try: () => findBikeById(client, bikeId),
+      catch: cause =>
+        new BikeRepositoryError({
+          operation: `${operation}.findUnique`,
+          cause,
+          message: "Failed to fetch bike after status transition",
+        }),
+    });
+
+    return Option.fromNullable(row);
+  }).pipe(defectOn(BikeRepositoryError));
+}
+
+function transitionAndReloadBikeInStation(
+  client: BikeDbClient,
+  bikeId: string,
+  stationId: string,
+  from: BikeStatus,
+  to: BikeStatus,
+  updatedAt: Date,
+  operation: string,
+) {
+  return Effect.gen(function* () {
+    const transitioned = yield* Effect.tryPromise({
+      try: async () => {
+        const updated = await client.bike.updateMany({
+          where: {
+            id: bikeId,
+            stationId,
+            status: from,
+          },
+          data: buildStatusUpdate(to, updatedAt),
+        });
+
+        return updated.count > 0;
+      },
+      catch: cause =>
+        new BikeRepositoryError({
+          operation,
+          cause,
+          message: "Failed to transition bike status in station scope",
+        }),
+    });
+
+    if (!transitioned) {
+      return Option.none();
+    }
+
+    const row = yield* Effect.tryPromise({
+      try: () => findBikeById(client, bikeId),
+      catch: cause =>
+        new BikeRepositoryError({
+          operation: `${operation}.findUnique`,
+          cause,
+          message: "Failed to fetch bike after station-scoped status transition",
+        }),
+    });
+
+    return Option.fromNullable(row);
   }).pipe(defectOn(BikeRepositoryError));
 }

--- a/apps/server/src/domain/bikes/services/bike.service.ts
+++ b/apps/server/src/domain/bikes/services/bike.service.ts
@@ -1,9 +1,11 @@
 import { Effect, Layer, Option } from "effect";
 
+import type { BikeStatus } from "generated/prisma/client";
+
 import { Prisma } from "@/infrastructure/prisma";
 
 import type { BikeRepo } from "../repository/bike.repository";
-import type { BikeService } from "./bike.service.types";
+import type { BikeManageableStatus, BikeService } from "./bike.service.types";
 
 import {
   BikeCurrentlyRented,
@@ -11,8 +13,21 @@ import {
   BikeNotFound,
   BikeStationNotFound,
   BikeSupplierNotFound,
+  InvalidBikeStatus,
 } from "../domain-errors";
 import { BikeRepository } from "../repository/bike.repository";
+
+function getScopedStatusTransitions(currentStatus: BikeStatus): readonly BikeManageableStatus[] {
+  if (currentStatus === "AVAILABLE") {
+    return ["BROKEN"] as const;
+  }
+
+  if (currentStatus === "BROKEN") {
+    return ["AVAILABLE"] as const;
+  }
+
+  return [] as const;
+}
 
 function makeBikeService(
   repo: BikeRepo,
@@ -117,6 +132,45 @@ function makeBikeService(
         }
 
         return updated;
+      }),
+
+    updateBikeStatusInStationScope: (bikeId, input) =>
+      Effect.gen(function* () {
+        const current = yield* repo.getById(bikeId);
+
+        if (Option.isNone(current) || current.value.stationId !== input.stationId) {
+          return yield* Effect.fail(new BikeNotFound({ id: bikeId }));
+        }
+
+        const allowed = getScopedStatusTransitions(current.value.status);
+        if (!allowed.includes(input.status)) {
+          return yield* Effect.fail(new InvalidBikeStatus({
+            status: input.status,
+            allowed,
+          }));
+        }
+
+        const updated = yield* repo.transitionStatusInStationAt(
+          bikeId,
+          input.stationId,
+          current.value.status,
+          input.status,
+          new Date(),
+        );
+
+        if (Option.isSome(updated)) {
+          return updated.value;
+        }
+
+        const latest = yield* repo.getById(bikeId);
+        if (Option.isNone(latest) || latest.value.stationId !== input.stationId) {
+          return yield* Effect.fail(new BikeNotFound({ id: bikeId }));
+        }
+
+        return yield* Effect.fail(new InvalidBikeStatus({
+          status: input.status,
+          allowed: getScopedStatusTransitions(latest.value.status),
+        }));
       }),
 
   };

--- a/apps/server/src/domain/bikes/services/bike.service.types.ts
+++ b/apps/server/src/domain/bikes/services/bike.service.types.ts
@@ -9,9 +9,12 @@ import type {
   BikeNotFound,
   BikeStationNotFound,
   BikeSupplierNotFound,
+  InvalidBikeStatus,
 } from "../domain-errors";
 import type { BikeFilter, BikeRow, BikeSortField } from "../models";
 import type { BikeUpdatePatch } from "../repository/bike.repository.types";
+
+export type BikeManageableStatus = Extract<BikeStatus, "AVAILABLE" | "BROKEN">;
 
 export type BikeService = {
   createBike: (
@@ -44,5 +47,17 @@ export type BikeService = {
     | BikeNotFound
     | BikeStationNotFound
     | BikeSupplierNotFound
+  >;
+
+  updateBikeStatusInStationScope: (
+    bikeId: string,
+    input: {
+      stationId: string;
+      status: BikeManageableStatus;
+    },
+  ) => Effect.Effect<
+    BikeRow,
+    | BikeNotFound
+    | InvalidBikeStatus
   >;
 };

--- a/apps/server/src/http/controllers/bikes/index.ts
+++ b/apps/server/src/http/controllers/bikes/index.ts
@@ -1,4 +1,5 @@
 export * from "./admin.controller";
+export * from "./management.controller";
 export * from "./public.controller";
 export * from "./shared";
 export * from "./staff.controller";

--- a/apps/server/src/http/controllers/bikes/management.controller.ts
+++ b/apps/server/src/http/controllers/bikes/management.controller.ts
@@ -1,0 +1,119 @@
+import type { RouteHandler } from "@hono/zod-openapi";
+
+import { Effect, Match } from "effect";
+
+import { BikeServiceTag } from "@/domain/bikes";
+import { withLoggedCause } from "@/domain/shared";
+
+import type { BikeNotFoundResponse, BikesRoutes, BikeSummary, BikeUpdateConflictResponse } from "./shared";
+
+import {
+  BikeErrorCodeSchema,
+  bikeErrorMessages,
+  loadBikeSummary,
+} from "./shared";
+
+function notFoundResponse(bikeId: string): BikeNotFoundResponse {
+  return {
+    error: bikeErrorMessages.BIKE_NOT_FOUND,
+    details: {
+      code: BikeErrorCodeSchema.enum.BIKE_NOT_FOUND,
+      bikeId,
+    },
+  };
+}
+
+function invalidStatusResponse(status: string): BikeUpdateConflictResponse {
+  return {
+    error: bikeErrorMessages.INVALID_BIKE_STATUS,
+    details: {
+      code: BikeErrorCodeSchema.enum.INVALID_BIKE_STATUS,
+      status,
+    },
+  };
+}
+
+const managerUpdateBikeStatus: RouteHandler<BikesRoutes["managerUpdateBikeStatus"]> = async (c) => {
+  const { id } = c.req.valid("param");
+  const body = c.req.valid("json");
+  const stationId = c.var.currentUser?.operatorStationId;
+
+  if (!stationId) {
+    return c.json<BikeNotFoundResponse, 404>(notFoundResponse(id), 404);
+  }
+
+  const eff = withLoggedCause(
+    Effect.gen(function* () {
+      const service = yield* BikeServiceTag;
+      const bike = yield* service.updateBikeStatusInStationScope(id, {
+        stationId,
+        status: body.status,
+      });
+
+      return yield* loadBikeSummary(bike);
+    }),
+    "PATCH /v1/manager/bikes/{id}/status",
+  );
+
+  const result = await c.var.runPromise(eff.pipe(Effect.either));
+  return Match.value(result).pipe(
+    Match.tag("Right", ({ right }) =>
+      c.json<BikeSummary, 200>(right, 200)),
+    Match.tag("Left", ({ left }) =>
+      Match.value(left).pipe(
+        Match.tag("BikeNotFound", ({ id: bikeId }) =>
+          c.json<BikeNotFoundResponse, 404>(notFoundResponse(bikeId), 404)),
+        Match.tag("InvalidBikeStatus", ({ status }) =>
+          c.json<BikeUpdateConflictResponse, 400>(invalidStatusResponse(status), 400)),
+        Match.orElse((err) => {
+          throw err;
+        }),
+      )),
+    Match.exhaustive,
+  );
+};
+
+const agencyUpdateBikeStatus: RouteHandler<BikesRoutes["agencyUpdateBikeStatus"]> = async (c) => {
+  const { id } = c.req.valid("param");
+  const body = c.req.valid("json");
+  const stationId = c.var.currentUser?.operatorStationId;
+
+  if (!stationId) {
+    return c.json<BikeNotFoundResponse, 404>(notFoundResponse(id), 404);
+  }
+
+  const eff = withLoggedCause(
+    Effect.gen(function* () {
+      const service = yield* BikeServiceTag;
+      const bike = yield* service.updateBikeStatusInStationScope(id, {
+        stationId,
+        status: body.status,
+      });
+
+      return yield* loadBikeSummary(bike);
+    }),
+    "PATCH /v1/agency/bikes/{id}/status",
+  );
+
+  const result = await c.var.runPromise(eff.pipe(Effect.either));
+  return Match.value(result).pipe(
+    Match.tag("Right", ({ right }) =>
+      c.json<BikeSummary, 200>(right, 200)),
+    Match.tag("Left", ({ left }) =>
+      Match.value(left).pipe(
+        Match.tag("BikeNotFound", ({ id: bikeId }) =>
+          c.json<BikeNotFoundResponse, 404>(notFoundResponse(bikeId), 404)),
+        Match.tag("InvalidBikeStatus", ({ status }) =>
+          c.json<BikeUpdateConflictResponse, 400>(invalidStatusResponse(status), 400)),
+        Match.orElse((err) => {
+          throw err;
+        }),
+      )),
+    Match.exhaustive,
+  );
+};
+
+export const BikeManagementController = {
+  managerUpdateBikeStatus,
+  agencyUpdateBikeStatus,
+} as const;

--- a/apps/server/src/http/routes/bikes.ts
+++ b/apps/server/src/http/routes/bikes.ts
@@ -4,13 +4,16 @@ import { serverRoutes } from "@mebike/shared";
 
 import {
   BikeAdminController,
+  BikeManagementController,
   BikePublicController,
   BikeStaffController,
   BikeStatsController,
 } from "@/http/controllers/bikes";
 import {
   requireAdminMiddleware,
+  requireAgencyMiddleware,
   requireBackofficeMiddleware,
+  requireManagerMiddleware,
   requireStationScopedOperatorMiddleware,
 } from "@/http/middlewares/auth";
 
@@ -33,6 +36,20 @@ export function registerBikeRoutes(app: import("@hono/zod-openapi").OpenAPIHono)
   app.openapi(staffListBikesRoute, BikeStaffController.staffListBikes);
 
   app.openapi(bikes.updateBike, BikeAdminController.updateBike);
+
+  const managerUpdateBikeStatusRoute = {
+    ...bikes.managerUpdateBikeStatus,
+    middleware: [requireManagerMiddleware] as const,
+  } satisfies RouteConfig;
+
+  app.openapi(managerUpdateBikeStatusRoute, BikeManagementController.managerUpdateBikeStatus);
+
+  const agencyUpdateBikeStatusRoute = {
+    ...bikes.agencyUpdateBikeStatus,
+    middleware: [requireAgencyMiddleware] as const,
+  } satisfies RouteConfig;
+
+  app.openapi(agencyUpdateBikeStatusRoute, BikeManagementController.agencyUpdateBikeStatus);
 
   app.openapi(bikes.reportBrokenBike, BikePublicController.reportBrokenBike);
 

--- a/apps/server/src/http/test/e2e/operator-bikes-routing.e2e.int.test.ts
+++ b/apps/server/src/http/test/e2e/operator-bikes-routing.e2e.int.test.ts
@@ -34,6 +34,25 @@ describe("operator bikes routing e2e", () => {
     return fixture.auth.makeAccessToken({ userId: user.id, role });
   }
 
+  async function createAgencyContext() {
+    const agencyUser = await fixture.factories.user({ role: "AGENCY" });
+    const agency = await fixture.prisma.agency.create({
+      data: {
+        name: `Agency ${agencyUser.id}`,
+        contactPhone: "0281234567",
+        status: "ACTIVE",
+      },
+    });
+
+    await fixture.factories.userOrgAssignment({ userId: agencyUser.id, agencyId: agency.id });
+
+    return {
+      agency,
+      agencyUser,
+      token: fixture.auth.makeAccessToken({ userId: agencyUser.id, role: "AGENCY" }),
+    };
+  }
+
   it("lists only bikes from the assigned station for technician", async () => {
     const visibleStation = await fixture.factories.station({ capacity: 5 });
     const hiddenStation = await fixture.factories.station({ capacity: 5 });
@@ -67,5 +86,160 @@ describe("operator bikes routing e2e", () => {
     });
 
     expect(response.status).toBe(404);
+  });
+
+  it("allows manager to toggle an in-scope bike from available to broken", async () => {
+    const station = await fixture.factories.station({ capacity: 5 });
+    const bike = await fixture.factories.bike({ stationId: station.id, status: "AVAILABLE" });
+    const token = await createOperatorToken("MANAGER", station.id);
+
+    const response = await fixture.app.request(`http://test/v1/manager/bikes/${bike.id}/status`, {
+      method: "PATCH",
+      headers: {
+        "Authorization": `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ status: "BROKEN" }),
+    });
+
+    const body = await response.json() as { status: string };
+
+    expect(response.status).toBe(200);
+    expect(body.status).toBe("BROKEN");
+  });
+
+  it("returns 400 when manager requests an invalid status transition", async () => {
+    const station = await fixture.factories.station({ capacity: 5 });
+    const bike = await fixture.factories.bike({ stationId: station.id, status: "AVAILABLE" });
+    const token = await createOperatorToken("MANAGER", station.id);
+
+    const response = await fixture.app.request(`http://test/v1/manager/bikes/${bike.id}/status`, {
+      method: "PATCH",
+      headers: {
+        "Authorization": `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ status: "AVAILABLE" }),
+    });
+
+    const body = await response.json() as { details?: { code?: string } };
+
+    expect(response.status).toBe(400);
+    expect(body.details?.code).toBe("INVALID_BIKE_STATUS");
+  });
+
+  it("returns 400 when manager sends a status outside the contract", async () => {
+    const station = await fixture.factories.station({ capacity: 5 });
+    const bike = await fixture.factories.bike({ stationId: station.id, status: "AVAILABLE" });
+    const token = await createOperatorToken("MANAGER", station.id);
+
+    const response = await fixture.app.request(`http://test/v1/manager/bikes/${bike.id}/status`, {
+      method: "PATCH",
+      headers: {
+        "Authorization": `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ status: "BOOKED" }),
+    });
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 404 when manager updates a rented bike outside station scope", async () => {
+    const station = await fixture.factories.station({ capacity: 5 });
+    const bike = await fixture.factories.bike({ stationId: null, status: "BOOKED" });
+    const token = await createOperatorToken("MANAGER", station.id);
+
+    const response = await fixture.app.request(`http://test/v1/manager/bikes/${bike.id}/status`, {
+      method: "PATCH",
+      headers: {
+        "Authorization": `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ status: "BROKEN" }),
+    });
+
+    expect(response.status).toBe(404);
+  });
+
+  it("allows agency to toggle a bike in its assigned station", async () => {
+    const { agency, token } = await createAgencyContext();
+    const station = await fixture.factories.station({
+      stationType: "AGENCY",
+      capacity: 5,
+      agencyId: agency.id,
+    });
+    const bike = await fixture.factories.bike({ stationId: station.id, status: "BROKEN" });
+
+    const response = await fixture.app.request(`http://test/v1/agency/bikes/${bike.id}/status`, {
+      method: "PATCH",
+      headers: {
+        "Authorization": `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ status: "AVAILABLE" }),
+    });
+
+    const body = await response.json() as { status: string };
+
+    expect(response.status).toBe(200);
+    expect(body.status).toBe("AVAILABLE");
+  });
+
+  it("returns 404 when agency updates a bike outside its station scope", async () => {
+    const { agency, token } = await createAgencyContext();
+    await fixture.factories.station({
+      stationType: "AGENCY",
+      capacity: 5,
+      agencyId: agency.id,
+    });
+    const otherAgency = await fixture.prisma.agency.create({
+      data: {
+        name: `Other Agency ${agency.id}`,
+        contactPhone: "0287654321",
+        status: "ACTIVE",
+      },
+    });
+    const otherStation = await fixture.factories.station({
+      stationType: "AGENCY",
+      capacity: 5,
+      agencyId: otherAgency.id,
+    });
+    const bike = await fixture.factories.bike({ stationId: otherStation.id, status: "AVAILABLE" });
+
+    const response = await fixture.app.request(`http://test/v1/agency/bikes/${bike.id}/status`, {
+      method: "PATCH",
+      headers: {
+        "Authorization": `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ status: "BROKEN" }),
+    });
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 400 when agency requests an invalid status transition", async () => {
+    const { agency, token } = await createAgencyContext();
+    const station = await fixture.factories.station({
+      stationType: "AGENCY",
+      capacity: 5,
+      agencyId: agency.id,
+    });
+    const bike = await fixture.factories.bike({ stationId: station.id, status: "BROKEN" });
+
+    const response = await fixture.app.request(`http://test/v1/agency/bikes/${bike.id}/status`, {
+      method: "PATCH",
+      headers: {
+        "Authorization": `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ status: "BROKEN" }),
+    });
+
+    const body = await response.json() as { details?: { code?: string } };
+
+    expect(response.status).toBe(400);
+    expect(body.details?.code).toBe("INVALID_BIKE_STATUS");
   });
 });

--- a/packages/shared/src/contracts/server/routes/bikes/mutations.ts
+++ b/packages/shared/src/contracts/server/routes/bikes/mutations.ts
@@ -7,8 +7,10 @@ import {
   BikeReportForbiddenResponseSchema,
   BikeUpdateConflictResponseSchema,
 } from "../../bikes";
+import { forbiddenResponse, unauthorizedResponse } from "../helpers";
 import {
   BikeIdParamSchema,
+  BikeStatusUpdateBodySchema,
   BikeSummarySchemaOpenApi,
   CreateBikeBodySchema,
   UpdateBikeBodySchema,
@@ -122,6 +124,106 @@ export const deleteBike = createRoute({
         "application/json": { schema: BikeNotFoundResponseSchema },
       },
     },
+  },
+});
+
+export const managerUpdateBikeStatus = createRoute({
+  method: "patch",
+  path: "/v1/manager/bikes/{id}/status",
+  tags: ["Manager", "Bikes"],
+  security: [{ bearerAuth: [] }],
+  request: {
+    params: BikeIdParamSchema,
+    body: {
+      content: {
+        "application/json": { schema: BikeStatusUpdateBodySchema },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "Bike status updated successfully",
+      content: {
+        "application/json": { schema: BikeSummarySchemaOpenApi },
+      },
+    },
+    400: {
+      description: "Invalid bike status transition",
+      content: {
+        "application/json": {
+          schema: BikeUpdateConflictResponseSchema,
+          examples: {
+            InvalidTransition: {
+              value: {
+                error: "Invalid bike status transition",
+                details: {
+                  code: BikeErrorCodeSchema.enum.INVALID_BIKE_STATUS,
+                  status: "AVAILABLE",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    404: {
+      description: "Bike not found in manager scope",
+      content: {
+        "application/json": { schema: BikeNotFoundResponseSchema },
+      },
+    },
+    401: unauthorizedResponse(),
+    403: forbiddenResponse("Manager"),
+  },
+});
+
+export const agencyUpdateBikeStatus = createRoute({
+  method: "patch",
+  path: "/v1/agency/bikes/{id}/status",
+  tags: ["Agency", "Bikes"],
+  security: [{ bearerAuth: [] }],
+  request: {
+    params: BikeIdParamSchema,
+    body: {
+      content: {
+        "application/json": { schema: BikeStatusUpdateBodySchema },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "Bike status updated successfully",
+      content: {
+        "application/json": { schema: BikeSummarySchemaOpenApi },
+      },
+    },
+    400: {
+      description: "Invalid bike status transition",
+      content: {
+        "application/json": {
+          schema: BikeUpdateConflictResponseSchema,
+          examples: {
+            InvalidTransition: {
+              value: {
+                error: "Invalid bike status transition",
+                details: {
+                  code: BikeErrorCodeSchema.enum.INVALID_BIKE_STATUS,
+                  status: "BROKEN",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    404: {
+      description: "Bike not found in agency scope",
+      content: {
+        "application/json": { schema: BikeNotFoundResponseSchema },
+      },
+    },
+    401: unauthorizedResponse(),
+    403: forbiddenResponse("Agency"),
   },
 });
 

--- a/packages/shared/src/contracts/server/routes/bikes/shared.ts
+++ b/packages/shared/src/contracts/server/routes/bikes/shared.ts
@@ -95,6 +95,12 @@ export const UpdateBikeBodySchema = z.object({
   status: BikeStatusSchema.optional(),
 }).openapi("UpdateBikeBody");
 
+export const BikeManageableStatusSchema = z.enum(["AVAILABLE", "BROKEN"]).openapi("BikeManageableStatus");
+
+export const BikeStatusUpdateBodySchema = z.object({
+  status: BikeManageableStatusSchema,
+}).openapi("BikeStatusUpdateBody");
+
 export const BikeSummarySchemaOpenApi = BikeSummarySchema.openapi("BikeSummary", {
   description: "Bike summary details",
 });


### PR DESCRIPTION
## Summary
- add dedicated manager and agency bike status endpoints with station-scoped authorization instead of reusing the broad admin bike update boundary
- restrict the contract and runtime rules to `AVAILABLE <-> BROKEN`, and enforce station scope in the write predicate to avoid cross-station races
- add focused operator bike e2e coverage for manager and agency success, invalid transitions, raw contract rejection, and out-of-scope cases

## Verification
- pnpm build
- pnpm tsc --noEmit
- pnpm vitest run --config vitest.int.config.ts --mode test src/http/test/e2e/operator-bikes-routing.e2e.int.test.ts