### PR TITLE
feat(server): rename unlimited subscription to ultra

### DIFF
--- a/apps/mobile/constants/subscriptionPackages.ts
+++ b/apps/mobile/constants/subscriptionPackages.ts
@@ -29,11 +29,11 @@ export const SUBSCRIPTION_PACKAGES: Record<SubscriptionPackage, SubscriptionPack
     gradient: ["#9333EA", "#F472B6"],
     description: "Phù hợp cho người dùng thường xuyên cần linh hoạt.",
   },
-  unlimited: {
-    id: "unlimited",
-    title: "Gói Không Giới Hạn",
+  ultra: {
+    id: "ultra",
+    title: "Gói Ultra",
     price: 299000,
-    monthlyLimit: null,
+    monthlyLimit: 90,
     accent: "#16A34A",
     gradient: ["#16A34A", "#4ADE80"],
     description: "Trải nghiệm cao cấp nhất cho người dùng trung thành.",

--- a/apps/mobile/types/subscription-types.ts
+++ b/apps/mobile/types/subscription-types.ts
@@ -1,6 +1,6 @@
 export type SubscriptionStatus = "PENDING" | "ACTIVE" | "EXPIRED" | "CANCELLED";
 
-export type SubscriptionPackage = "basic" | "premium" | "unlimited";
+export type SubscriptionPackage = "basic" | "premium" | "ultra";
 
 export type Subscription = {
   id: string;

--- a/apps/server/generated/kysely/types.ts
+++ b/apps/server/generated/kysely/types.ts
@@ -219,7 +219,7 @@ export type SubscriptionStatus = (typeof SubscriptionStatus)[keyof typeof Subscr
 export const SubscriptionPackage = {
     basic: "basic",
     premium: "premium",
-    unlimited: "unlimited"
+    ultra: "ultra"
 } as const;
 export type SubscriptionPackage = (typeof SubscriptionPackage)[keyof typeof SubscriptionPackage];
 export const SupplierStatus = {

--- a/apps/server/prisma/migrations/20260419112000_rename_unlimited_subscription_to_ultra/migration.sql
+++ b/apps/server/prisma/migrations/20260419112000_rename_unlimited_subscription_to_ultra/migration.sql
@@ -1,0 +1,6 @@
+ALTER TYPE "SubscriptionPackage" RENAME VALUE 'unlimited' TO 'ultra';
+
+UPDATE "Subscription"
+SET "maxUsages" = 90
+WHERE "package_name" = 'ultra'
+  AND "maxUsages" IS NULL;

--- a/apps/server/prisma/models/subscriptions.prisma
+++ b/apps/server/prisma/models/subscriptions.prisma
@@ -8,7 +8,7 @@ enum SubscriptionStatus {
 enum SubscriptionPackage {
   basic
   premium
-  unlimited
+  ultra
 }
 
 model Subscription {

--- a/apps/server/prisma/seed-demo.ts
+++ b/apps/server/prisma/seed-demo.ts
@@ -847,12 +847,12 @@ async function main() {
       id: uuidv7(),
       userId: user.id,
       packageName: idx % 3 === 0
-        ? SubscriptionPackage.unlimited
+        ? SubscriptionPackage.ultra
         : idx % 3 === 1
           ? SubscriptionPackage.premium
           : SubscriptionPackage.basic,
-      maxUsages: idx % 3 === 0 ? null : idx % 3 === 1 ? 60 : 30,
-      usageCount: idx % 3 === 0 ? 0 : idx % 3 === 1 ? 8 : 5,
+      maxUsages: idx % 3 === 0 ? 90 : idx % 3 === 1 ? 60 : 30,
+      usageCount: idx % 3 === 0 ? 12 : idx % 3 === 1 ? 8 : 5,
       status: SubscriptionStatus.ACTIVE,
       activatedAt: toUtcDate(-20 + idx, 9, 0),
       expiresAt: toUtcDate(45 + idx, 23, 0),

--- a/apps/server/src/domain/subscriptions/package-config.ts
+++ b/apps/server/src/domain/subscriptions/package-config.ts
@@ -24,10 +24,10 @@ const PACKAGE_CONFIG: Record<SubscriptionPackage, SubscriptionPackageConfig> = {
     maxUsages: 60,
     currency: "usd",
   },
-  unlimited: {
-    packageName: "unlimited",
+  ultra: {
+    packageName: "ultra",
     price: 2990n,
-    maxUsages: null,
+    maxUsages: 90,
     currency: "usd",
   },
 };

--- a/apps/server/src/domain/subscriptions/repository/test/subscription.repository.int.test.ts
+++ b/apps/server/src/domain/subscriptions/repository/test/subscription.repository.int.test.ts
@@ -50,9 +50,9 @@ describe("subscriptionRepository Integration", () => {
     await Effect.runPromise(
       commandRepo.createPending({
         userId,
-        packageName: "premium",
-        maxUsages: null,
-        price: 2000n,
+        packageName: "ultra",
+        maxUsages: 90,
+        price: 3000n,
       }),
     );
 

--- a/apps/server/src/http/test/e2e/admin-subscriptions-routing.e2e.int.test.ts
+++ b/apps/server/src/http/test/e2e/admin-subscriptions-routing.e2e.int.test.ts
@@ -159,8 +159,8 @@ describe("admin subscriptions routing e2e", () => {
     const subscription = await fixture.prisma.subscription.create({
       data: {
         userId: USER_ONE_ID,
-        packageName: "unlimited",
-        maxUsages: null,
+        packageName: "ultra",
+        maxUsages: 90,
         usageCount: 1,
         status: "ACTIVE",
         activatedAt: new Date("2026-04-10T00:00:00.000Z"),
@@ -179,7 +179,7 @@ describe("admin subscriptions routing e2e", () => {
     expect(body).toMatchObject({
       id: subscription.id,
       userId: USER_ONE_ID,
-      packageName: "unlimited",
+      packageName: "ultra",
       user: {
         id: USER_ONE_ID,
         fullName: "Alice Rider",

--- a/apps/server/src/http/test/e2e/rentals-billing-preview-routing.e2e.int.test.ts
+++ b/apps/server/src/http/test/e2e/rentals-billing-preview-routing.e2e.int.test.ts
@@ -54,7 +54,8 @@ describe("rentals billing preview routing e2e", () => {
     if (options?.withSubscription) {
       const subscription = await fixture.factories.subscription({
         userId: user.id,
-        maxUsages: null,
+        packageName: "ultra",
+        maxUsages: 90,
         status: "ACTIVE",
       });
       subscriptionId = subscription.id;

--- a/apps/server/src/test/factories/subscription.factory.ts
+++ b/apps/server/src/test/factories/subscription.factory.ts
@@ -4,7 +4,7 @@ import type { CreatedSubscription, FactoryContext, SubscriptionOverrides } from 
 
 const defaults = {
   packageName: "basic" as const,
-  maxUsages: null,
+  maxUsages: 30,
   usageCount: 0,
   status: "ACTIVE" as const,
   activatedAt: () => new Date(),

--- a/apps/server/src/test/factories/types.ts
+++ b/apps/server/src/test/factories/types.ts
@@ -82,7 +82,7 @@ export type ReservationOverrides = {
 export type SubscriptionOverrides = {
   id?: string;
   userId?: string;
-  packageName?: "basic" | "premium" | "unlimited";
+  packageName?: "basic" | "premium" | "ultra";
   maxUsages?: number | null;
   usageCount?: number;
   status?: "PENDING" | "ACTIVE" | "EXPIRED" | "CANCELLED";

--- a/packages/shared/src/contracts/server/subscriptions/models.ts
+++ b/packages/shared/src/contracts/server/subscriptions/models.ts
@@ -5,7 +5,7 @@ export const SubscriptionStatusSchema = z
   .openapi("SubscriptionStatus");
 
 export const SubscriptionPackageSchema = z
-  .enum(["basic", "premium", "unlimited"])
+  .enum(["basic", "premium", "ultra"])
   .openapi("SubscriptionPackage");
 
 export const SubscriptionPackageDetailSchema = z.object({


### PR DESCRIPTION
## Summary
- rename the top subscription package from `unlimited` to `ultra` across Prisma, server package config, shared contracts, and mobile subscription types
- cap the top package at 90 usages instead of unlimited and update the demo seed data to create `ultra` subscriptions with that limit
- add a migration to rename existing enum/data values and update focused subscription tests to reflect the new package semantics

## Verification
- pnpm build
- pnpm prisma generate
- pnpm tsc --noEmit
- pnpm exec tsc --noEmit
- TEST_DATABASE_URL=postgresql://mebike:mebike@127.0.0.1:5432/mebike_test_ultra_tmp2 pnpm vitest run --config vitest.int.config.ts --mode test "src/http/test/e2e/admin-subscriptions-routing.e2e.int.test.ts" "src/domain/subscriptions/repository/test/subscription.repository.int.test.ts"