### PR TITLE
feat(ai): expand customer assistant return-slot and station flows

### DIFF
--- a/apps/mobile/components/IconSymbol.tsx
+++ b/apps/mobile/components/IconSymbol.tsx
@@ -2,7 +2,6 @@
 
 import type { ColorValue, StyleProp, ViewStyle } from "react-native";
 
-import { iconSizes } from "@theme/metrics";
 import {
   ArrowDown,
   ArrowLeft,
@@ -56,6 +55,8 @@ import {
   X,
 } from "lucide-react-native";
 import React from "react";
+
+import { iconSizes } from "@theme/metrics";
 
 type LucideIconComponent = typeof ArrowLeft;
 

--- a/apps/mobile/hooks/ai/use-ai-assistant-chat.ts
+++ b/apps/mobile/hooks/ai/use-ai-assistant-chat.ts
@@ -1,9 +1,12 @@
-import type { AiAssistantChatContext, AiAssistantMessage } from "@services/ai";
 import type { ChatRequestOptions, ChatStatus } from "ai";
 
 import { useChat } from "@ai-sdk/react";
-import { createAiAssistantChatTransport } from "@services/ai";
 import { useCallback, useEffect, useMemo, useRef } from "react";
+
+import type { AiAssistantChatContext, AiAssistantMessage } from "@services/ai";
+
+import { useCurrentLocation } from "@providers/location-provider";
+import { createAiAssistantChatTransport } from "@services/ai";
 
 export type UseAiAssistantChatOptions = {
   chatId?: string;
@@ -23,11 +26,22 @@ export function useAiAssistantChat({
   onError,
 }: UseAiAssistantChatOptions = {}) {
   const stableChatId = useRef(chatId ?? createChatId());
-  const contextRef = useRef(context);
+  const { location, status: locationStatus } = useCurrentLocation();
+  const mergedContext = useMemo(() => {
+    if (locationStatus !== "ready" || !location) {
+      return context ?? null;
+    }
+
+    return {
+      ...(context ?? {}),
+      location,
+    };
+  }, [context, location, locationStatus]);
+  const contextRef = useRef(mergedContext);
 
   useEffect(() => {
-    contextRef.current = context;
-  }, [context]);
+    contextRef.current = mergedContext;
+  }, [mergedContext]);
 
   const transport = useMemo(() => {
     return createAiAssistantChatTransport({

--- a/apps/mobile/hooks/ai/use-ai-assistant-chat.ts
+++ b/apps/mobile/hooks/ai/use-ai-assistant-chat.ts
@@ -1,6 +1,7 @@
 import type { ChatRequestOptions, ChatStatus } from "ai";
 
 import { useChat } from "@ai-sdk/react";
+import { lastAssistantMessageIsCompleteWithApprovalResponses } from "ai";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 
 import type { AiAssistantChatContext, AiAssistantMessage } from "@services/ai";
@@ -50,6 +51,7 @@ export function useAiAssistantChat({
   }, []);
 
   const {
+    addToolApprovalResponse,
     error,
     id,
     messages,
@@ -60,6 +62,7 @@ export function useAiAssistantChat({
   } = useChat<AiAssistantMessage>({
     id: stableChatId.current,
     messages: initialMessages ?? [],
+    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
     transport,
     onError,
   });
@@ -83,7 +86,15 @@ export function useAiAssistantChat({
     void stop();
   }, [stop]);
 
+  const respondToToolApproval = useCallback((id: string, approved: boolean) => {
+    addToolApprovalResponse({
+      approved,
+      id,
+    });
+  }, [addToolApprovalResponse]);
+
   return {
+    addToolApprovalResponse: respondToToolApproval,
     error,
     id,
     isBusy: status === "submitted" || status === "streaming",

--- a/apps/mobile/navigation/main-tab-navigator.tsx
+++ b/apps/mobile/navigation/main-tab-navigator.tsx
@@ -1,5 +1,4 @@
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
-import { useNavigation } from "@react-navigation/native";
 import React from "react";
 
 import { LoadingScreen } from "@components/LoadingScreen";
@@ -15,23 +14,19 @@ import {
   StaffDashboardScreen,
   TechnicianDashboardScreen,
 } from "../screen";
+import StationSelectScreen from "../styles/StationSelect";
 import { BottomTabBar } from "./bottom-tab-bar";
 
 const Tab = createBottomTabNavigator<RootStackParamList>();
 
-function StationTabRedirectScreen() {
-  const navigation = useNavigation();
-
-  React.useEffect(() => {
-    navigation.getParent()?.navigate("StationSelectFlow");
-  }, [navigation]);
-
-  return null;
-}
-
 function MainTabNavigator() {
   const { status, isAuthenticated, isTechnician, user } = useAuthNext();
   const canUseStaffTools = user?.role === "STAFF" || user?.role === "AGENCY";
+  const initialRouteName = canUseStaffTools || isTechnician
+    ? "Công cụ"
+    : isAuthenticated
+      ? "Booking"
+      : "Trạm";
 
   if (status === "loading") {
     return <LoadingScreen />;
@@ -39,6 +34,7 @@ function MainTabNavigator() {
 
   return (
     <Tab.Navigator
+      initialRouteName={initialRouteName}
       screenOptions={{
         headerShown: false,
         tabBarHideOnKeyboard: true,
@@ -57,19 +53,19 @@ function MainTabNavigator() {
           )
         : (
             <>
+              {isAuthenticated
+                ? (
+                    <Tab.Screen
+                      name="Booking"
+                      component={BookingHistoryScreen}
+                      options={{ tabBarLabel: "Chuyến đi" }}
+                    />
+                  )
+                : null}
               <Tab.Screen
                 name="Trạm"
-                component={StationTabRedirectScreen}
-                listeners={({ navigation }) => ({
-                  tabPress: (event) => {
-                    event.preventDefault();
-                    navigation.getParent()?.navigate("StationSelectFlow");
-                  },
-                })}
+                component={StationSelectScreen}
               />
-              {isAuthenticated
-                ? <Tab.Screen name="Booking" component={BookingHistoryScreen} />
-                : null}
               {isAuthenticated
                 ? (
                     <Tab.Screen

--- a/apps/mobile/navigation/root-navigator.tsx
+++ b/apps/mobile/navigation/root-navigator.tsx
@@ -1,6 +1,9 @@
 import { createStackNavigator } from "@react-navigation/stack";
 import React from "react";
 
+import { LoadingScreen } from "@components/LoadingScreen";
+import { useAuthNext } from "@providers/auth-provider-next";
+
 import type { RootStackParamList } from "../types/navigation";
 
 import {
@@ -42,8 +45,71 @@ import MainTabNavigator from "./main-tab-navigator";
 const Stack = createStackNavigator<RootStackParamList>();
 
 function RootNavigator() {
+  const { status, isAuthenticated } = useAuthNext();
+
+  if (status === "loading") {
+    return <LoadingScreen />;
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <Stack.Navigator initialRouteName="StationSelectFlow" key="unauthenticated">
+        <Stack.Screen
+          name="StationSelectFlow"
+          component={StationSelectScreen}
+          options={{ headerShown: false, gestureEnabled: false }}
+        />
+        <Stack.Screen
+          name="StationDetail"
+          component={StationDetailScreen}
+          options={{ headerShown: false, gestureEnabled: false }}
+        />
+        <Stack.Screen
+          name="BikeDetail"
+          component={BikeDetailScreen}
+          options={{ headerShown: false, gestureEnabled: false }}
+        />
+        <Stack.Screen
+          name="Login"
+          component={LoginScreen}
+          options={{ headerShown: false, gestureEnabled: false }}
+        />
+        <Stack.Screen
+          name="Intro"
+          component={IntroScreen}
+          options={{ headerShown: false, gestureEnabled: false }}
+        />
+        <Stack.Screen
+          name="Register"
+          component={RegisterScreen}
+          options={{ headerShown: false, gestureEnabled: false }}
+        />
+        <Stack.Screen
+          name="EmailVerification"
+          component={EmailVerificationScreen}
+          options={{ headerShown: false, gestureEnabled: false }}
+        />
+        <Stack.Screen
+          name="ForgotPassword"
+          component={ForgotPasswordScreen}
+          options={{ headerShown: false, gestureEnabled: false }}
+        />
+        <Stack.Screen
+          name="ResetPasswordOTP"
+          component={ResetPasswordOTPScreen}
+          options={{ headerShown: false, gestureEnabled: false }}
+        />
+        <Stack.Screen
+          name="ResetPasswordForm"
+          component={ResetPasswordFormScreen}
+          options={{ headerShown: false, gestureEnabled: false }}
+        />
+      </Stack.Navigator>
+    );
+  }
+
   return (
-    <Stack.Navigator initialRouteName="Main">
+    <Stack.Navigator initialRouteName="Main" key="authenticated">
       <Stack.Screen
         name="Main"
         component={MainTabNavigator}

--- a/apps/mobile/screen/account/profile/hooks/use-profile.ts
+++ b/apps/mobile/screen/account/profile/hooks/use-profile.ts
@@ -1,14 +1,14 @@
-import type { UserDetail } from "@services/users/user-service";
-
-import { useMyRentalCountsQuery } from "@hooks/query/rentals/use-my-rental-counts-query";
-import { invalidateMyRentalCountsQuery } from "@hooks/rentals/rental-cache";
-import { useAuthNext } from "@providers/auth-provider-next";
 import { useNavigation } from "@react-navigation/native";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useMemo, useState } from "react";
 import { Alert } from "react-native";
 
+import type { UserDetail } from "@services/users/user-service";
+
 import { authQueryKeys } from "@/hooks/query/auth-next/auth-query-keys";
+import { useMyRentalCountsQuery } from "@hooks/query/rentals/use-my-rental-counts-query";
+import { invalidateMyRentalCountsQuery } from "@hooks/rentals/rental-cache";
+import { useAuthNext } from "@providers/auth-provider-next";
 
 import { useProfileEmailVerification } from "./use-profile-email-verification";
 
@@ -89,7 +89,6 @@ export function useProfile() {
         text: "Đăng xuất",
         onPress: async () => {
           await logout();
-          navigation.navigate("Login" as never);
         },
       },
     ]);

--- a/apps/mobile/screen/ai-assistant/action-tool-card.tsx
+++ b/apps/mobile/screen/ai-assistant/action-tool-card.tsx
@@ -1,0 +1,274 @@
+import { Check, ShieldAlert, TriangleAlert, XCircle } from "lucide-react-native";
+import { useTheme, XStack, YStack } from "tamagui";
+
+import type { AiAssistantActionCard } from "@services/ai";
+
+import { borderWidths, iconSizes, radii } from "@theme/metrics";
+import { AppButton } from "@ui/primitives/app-button";
+import { AppCard } from "@ui/primitives/app-card";
+import { AppText } from "@ui/primitives/app-text";
+
+const ACTION_CARD_MAX_WIDTH = 360;
+
+function getActionCardAccent(state: AiAssistantActionCard["state"]) {
+  switch (state) {
+    case "success":
+      return {
+        borderColor: "$borderSubtle" as const,
+        iconBackgroundColor: "$statusSuccessSoft" as const,
+        iconColorKey: "statusSuccess" as const,
+        subtitleTone: "subtle" as const,
+        titleTone: "default" as const,
+      };
+    case "failure":
+    case "denied":
+      return {
+        borderColor: "$borderSubtle" as const,
+        iconBackgroundColor: "$statusDangerSoft" as const,
+        iconColorKey: "statusDanger" as const,
+        subtitleTone: "subtle" as const,
+        titleTone: "danger" as const,
+      };
+    default:
+      return {
+        borderColor: "$borderFocus" as const,
+        iconBackgroundColor: "$surfaceAccent" as const,
+        iconColorKey: "actionPrimary" as const,
+        subtitleTone: "subtle" as const,
+        titleTone: "default" as const,
+      };
+  }
+}
+
+function getActionCardStateLabel(state: AiAssistantActionCard["state"]) {
+  switch (state) {
+    case "approval":
+      return "Yêu cầu xác nhận";
+    case "success":
+      return "Thực hiện thành công";
+    case "failure":
+      return "Không thể thực hiện";
+    case "denied":
+      return "Đã từ chối";
+    default:
+      return "Trạng thái thao tác";
+  }
+}
+
+function getActionCardStateSubtitle(state: AiAssistantActionCard["state"]) {
+  switch (state) {
+    case "approval":
+      return "Quyền thực thi hệ thống";
+    case "success":
+      return "Hệ thống đã cập nhật";
+    case "failure":
+      return "Hệ thống chưa thực hiện được";
+    case "denied":
+      return "Không có thay đổi nào được thực hiện";
+    default:
+      return "Trạng thái thao tác";
+  }
+}
+
+function ActionCardIcon({ state }: { state: AiAssistantActionCard["state"] }) {
+  const theme = useTheme();
+  const accent = getActionCardAccent(state);
+  const color = theme[accent.iconColorKey].val;
+
+  if (state === "success") {
+    return <Check color={color} size={iconSizes.md} />;
+  }
+
+  if (state === "failure") {
+    return <TriangleAlert color={color} size={iconSizes.md} />;
+  }
+
+  if (state === "denied") {
+    return <XCircle color={color} size={iconSizes.md} />;
+  }
+
+  return <ShieldAlert color={color} size={iconSizes.md} />;
+}
+
+function ActionCardSummary({ items }: { items: AiAssistantActionCard["summaryItems"] }) {
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <YStack
+      backgroundColor="$surfaceSubtle"
+      borderColor="$borderSubtle"
+      borderRadius={radii.lg}
+      borderWidth={borderWidths.subtle}
+      gap="$3"
+      padding="$4"
+      width="100%"
+    >
+      {items.map(item => (
+        <XStack alignItems="center" gap="$4" justifyContent="space-between" key={`${item.label}:${item.value}`}>
+          <AppText flexShrink={0} minWidth={84} tone="subtle" variant="bodySmall">
+            {item.label}
+          </AppText>
+          <AppText align="right" flex={1} minWidth={0} variant="bodyStrong">
+            {item.value}
+          </AppText>
+        </XStack>
+      ))}
+    </YStack>
+  );
+}
+
+function ActionCardHeader({ card }: { card: AiAssistantActionCard }) {
+  const accent = getActionCardAccent(card.state);
+
+  return (
+    <XStack alignItems="center" gap="$3">
+      <XStack
+        alignItems="center"
+        backgroundColor={accent.iconBackgroundColor}
+        borderRadius="$round"
+        height={iconSizes.display}
+        justifyContent="center"
+        width={iconSizes.display}
+      >
+        <ActionCardIcon state={card.state} />
+      </XStack>
+
+      <YStack flex={1} gap="$1" minWidth={0}>
+        <AppText tone={accent.titleTone} variant="sectionTitle">
+          {getActionCardStateLabel(card.state)}
+        </AppText>
+        <AppText tone={accent.subtitleTone} variant="bodySmall">
+          {getActionCardStateSubtitle(card.state)}
+        </AppText>
+      </YStack>
+    </XStack>
+  );
+}
+
+function ApprovalActionToolCard({
+  approvalBusy,
+  card,
+  onApprove,
+  onDeny,
+}: {
+  approvalBusy: boolean;
+  card: AiAssistantActionCard;
+  onApprove: (approvalId: string) => void;
+  onDeny: (approvalId: string) => void;
+}) {
+  const accent = getActionCardAccent(card.state);
+
+  if (!card.approvalId) {
+    return null;
+  }
+
+  return (
+    <AppCard
+      alignSelf="flex-start"
+      backgroundColor="$surfaceDefault"
+      borderColor={accent.borderColor}
+      borderRadius={radii.xxl}
+      borderTopLeftRadius={radii.sm}
+      borderWidth={borderWidths.subtle}
+      chrome="flat"
+      gap="$4"
+      maxWidth={ACTION_CARD_MAX_WIDTH}
+      padding="$4"
+      width="100%"
+    >
+      <ActionCardHeader card={card} />
+
+      <ActionCardSummary items={card.summaryItems} />
+
+      <XStack gap="$3">
+        <AppButton
+          backgroundColor="$surfaceSubtle"
+          borderColor="$surfaceSubtle"
+          buttonSize="large"
+          disabled={approvalBusy}
+          flex={1}
+          onPress={() => onDeny(card.approvalId!)}
+          shadowOpacity={0}
+          tone="ghost"
+        >
+          <AppText tone="muted" variant="bodyStrong">
+            Hủy bỏ
+          </AppText>
+        </AppButton>
+
+        <AppButton
+          buttonSize="large"
+          disabled={approvalBusy}
+          flex={1}
+          onPress={() => onApprove(card.approvalId!)}
+          tone="primary"
+        >
+          <XStack alignItems="center" gap="$2">
+            <Check color="white" size={iconSizes.sm} />
+            <AppText tone="inverted" variant="bodyStrong">
+              Xác nhận
+            </AppText>
+          </XStack>
+        </AppButton>
+      </XStack>
+    </AppCard>
+  );
+}
+
+function ActionResultCard({ card }: { card: AiAssistantActionCard }) {
+  const accent = getActionCardAccent(card.state);
+
+  return (
+    <AppCard
+      alignSelf="flex-start"
+      backgroundColor="$surfaceDefault"
+      borderColor={accent.borderColor}
+      borderRadius={radii.xxl}
+      borderTopLeftRadius={radii.sm}
+      borderWidth={borderWidths.subtle}
+      chrome="flat"
+      gap="$4"
+      maxWidth={ACTION_CARD_MAX_WIDTH}
+      padding="$4"
+      width="100%"
+    >
+      <ActionCardHeader card={card} />
+
+      <YStack gap="$2">
+        <AppText variant="sectionTitle">{card.title}</AppText>
+        {card.description
+          ? <AppText variant="bodySmall">{card.description}</AppText>
+          : null}
+      </YStack>
+
+      <ActionCardSummary items={card.summaryItems} />
+    </AppCard>
+  );
+}
+
+export function ActionToolCard({
+  approvalBusy,
+  card,
+  onApprove,
+  onDeny,
+}: {
+  approvalBusy: boolean;
+  card: AiAssistantActionCard;
+  onApprove: (approvalId: string) => void;
+  onDeny: (approvalId: string) => void;
+}) {
+  if (card.state === "approval") {
+    return (
+      <ApprovalActionToolCard
+        approvalBusy={approvalBusy}
+        card={card}
+        onApprove={onApprove}
+        onDeny={onDeny}
+      />
+    );
+  }
+
+  return <ActionResultCard card={card} />;
+}

--- a/apps/mobile/screen/ai-assistant/components.tsx
+++ b/apps/mobile/screen/ai-assistant/components.tsx
@@ -5,6 +5,7 @@ import { useMarkdown } from "react-native-marked";
 import { useTheme, XStack, YStack } from "tamagui";
 
 import type {
+  AiAssistantActionCard,
   AiAssistantFeedMessage,
   AiAssistantToolActivity,
   AiAssistantToolActivityState,
@@ -13,6 +14,7 @@ import type {
 import { IconSymbol } from "@components/IconSymbol";
 import { borderWidths, spaceScale } from "@theme/metrics";
 import { fontFaces, fontSizes, lineHeights } from "@theme/typography";
+import { AppButton } from "@ui/primitives/app-button";
 import { AppCard } from "@ui/primitives/app-card";
 import { AppText } from "@ui/primitives/app-text";
 
@@ -188,6 +190,207 @@ export function ToolActivityRow({ activity }: { activity: AiAssistantToolActivit
   );
 }
 
+export function ToolApprovalActions({
+  activity,
+  disabled,
+  onApprove,
+  onDeny,
+}: {
+  activity: AiAssistantToolActivity;
+  disabled: boolean;
+  onApprove: (approvalId: string) => void;
+  onDeny: (approvalId: string) => void;
+}) {
+  if (activity.rawState !== "approval-requested" || !activity.approvalId) {
+    return null;
+  }
+
+  return (
+    <XStack gap="$2">
+      <AppButton
+        buttonSize="compact"
+        disabled={disabled}
+        onPress={() => onApprove(activity.approvalId!)}
+        tone="primary"
+      >
+        Xác nhận
+      </AppButton>
+      <AppButton
+        buttonSize="compact"
+        disabled={disabled}
+        onPress={() => onDeny(activity.approvalId!)}
+        tone="outline"
+      >
+        Từ chối
+      </AppButton>
+    </XStack>
+  );
+}
+
+function getActionCardAccent(state: AiAssistantActionCard["state"]) {
+  switch (state) {
+    case "success":
+      return {
+        iconColorKey: "statusSuccess" as const,
+        titleTone: "default" as const,
+      };
+    case "failure":
+    case "denied":
+      return {
+        iconColorKey: "statusDanger" as const,
+        titleTone: "danger" as const,
+      };
+    default:
+      return {
+        iconColorKey: "actionPrimary" as const,
+        titleTone: "default" as const,
+      };
+  }
+}
+
+function getActionCardStateLabel(state: AiAssistantActionCard["state"]) {
+  switch (state) {
+    case "approval":
+      return "Yêu cầu xác nhận";
+    case "success":
+      return "Thực hiện thành công";
+    case "failure":
+      return "Không thể thực hiện";
+    case "denied":
+      return "Đã từ chối";
+    default:
+      return "Trạng thái thao tác";
+  }
+}
+
+function ActionCardIcon({ state }: { state: AiAssistantActionCard["state"] }) {
+  const theme = useTheme();
+  const accent = getActionCardAccent(state);
+  const color = theme[accent.iconColorKey].val;
+
+  if (state === "success") {
+    return <Check color={color} size={18} />;
+  }
+
+  if (state === "failure" || state === "denied") {
+    return <TriangleAlert color={color} size={18} />;
+  }
+
+  return <Sparkles color={color} size={18} />;
+}
+
+function ActionCardSummary({ items }: { items: AiAssistantActionCard["summaryItems"] }) {
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <YStack
+      backgroundColor="$surfaceSubtle"
+      borderColor="$borderSubtle"
+      borderRadius="$4"
+      borderWidth={borderWidths.subtle}
+      gap="$3"
+      padding="$4"
+      width="100%"
+    >
+      {items.map(item => (
+        <YStack key={`${item.label}:${item.value}`} gap="$1">
+          <AppText tone="subtle" variant="bodySmall">
+            {item.label}
+          </AppText>
+          <AppText variant="bodyStrong">
+            {item.value}
+          </AppText>
+        </YStack>
+      ))}
+    </YStack>
+  );
+}
+
+export function ActionToolCard({
+  approvalBusy,
+  card,
+  onApprove,
+  onDeny,
+}: {
+  approvalBusy: boolean;
+  card: AiAssistantActionCard;
+  onApprove: (approvalId: string) => void;
+  onDeny: (approvalId: string) => void;
+}) {
+  const accent = getActionCardAccent(card.state);
+
+  return (
+    <AppCard
+      alignSelf="flex-start"
+      backgroundColor="$surfaceDefault"
+      borderColor="$borderSubtle"
+      borderTopLeftRadius="$2"
+      borderWidth={borderWidths.subtle}
+      chrome="flat"
+      gap="$4"
+      maxWidth="92%"
+      padding="$4"
+      size="default"
+    >
+      <XStack alignItems="center" gap="$3">
+        <XStack
+          alignItems="center"
+          backgroundColor="$surfaceSubtle"
+          borderRadius="$round"
+          height={44}
+          justifyContent="center"
+          width={44}
+        >
+          <ActionCardIcon state={card.state} />
+        </XStack>
+
+        <YStack flex={1} gap="$1">
+          <AppText tone={accent.titleTone} variant="bodyStrong">
+            {getActionCardStateLabel(card.state)}
+          </AppText>
+          <AppText variant="label">{card.title}</AppText>
+        </YStack>
+      </XStack>
+
+      {card.description
+        ? (
+            <AppText variant="bodySmall">{card.description}</AppText>
+          )
+        : null}
+
+      <ActionCardSummary items={card.summaryItems} />
+
+      {card.state === "approval" && card.approvalId
+        ? (
+            <XStack gap="$2">
+              <AppButton
+                buttonSize="compact"
+                disabled={approvalBusy}
+                flex={1}
+                onPress={() => onDeny(card.approvalId!)}
+                tone="outline"
+              >
+                Từ chối
+              </AppButton>
+              <AppButton
+                buttonSize="compact"
+                disabled={approvalBusy}
+                flex={1}
+                onPress={() => onApprove(card.approvalId!)}
+                tone="primary"
+              >
+                Xác nhận
+              </AppButton>
+            </XStack>
+          )
+        : null}
+
+    </AppCard>
+  );
+}
+
 export function AssistantBubble({ markdown }: { markdown: string }) {
   return (
     <AppCard
@@ -207,16 +410,49 @@ export function AssistantBubble({ markdown }: { markdown: string }) {
   );
 }
 
-export function AssistantMessageBlock({ message }: { message: AiAssistantFeedMessage }) {
+export function AssistantMessageBlock({
+  approvalBusy,
+  message,
+  onApproveTool,
+  onDenyTool,
+}: {
+  approvalBusy: boolean;
+  message: AiAssistantFeedMessage;
+  onApproveTool: (approvalId: string) => void;
+  onDenyTool: (approvalId: string) => void;
+}) {
   return (
     <YStack alignItems="flex-start" gap="$2">
-      {message.toolActivities.map((activity, index) => (
-        <YStack key={activity.key} marginTop={index > 0 ? -spaceScale[1] : 0}>
-          <ToolActivityRow activity={activity} />
-        </YStack>
-      ))}
-
-      {message.hasTextContent ? <AssistantBubble markdown={message.markdown} /> : null}
+      {message.contentBlocks.map((block, index) => {
+        switch (block.kind) {
+          case "action-card":
+            return (
+              <ActionToolCard
+                approvalBusy={approvalBusy}
+                card={block.card}
+                key={block.key}
+                onApprove={onApproveTool}
+                onDeny={onDenyTool}
+              />
+            );
+          case "tool-activity":
+            return (
+              <YStack gap="$2" key={block.key} marginTop={index > 0 ? -spaceScale[1] : 0}>
+                <ToolActivityRow activity={block.activity} />
+                <ToolApprovalActions
+                  activity={block.activity}
+                  disabled={approvalBusy}
+                  onApprove={onApproveTool}
+                  onDeny={onDenyTool}
+                />
+              </YStack>
+            );
+          case "text":
+            return <AssistantBubble key={block.key} markdown={block.markdown} />;
+          default:
+            return null;
+        }
+      })}
     </YStack>
   );
 }

--- a/apps/mobile/screen/ai-assistant/components.tsx
+++ b/apps/mobile/screen/ai-assistant/components.tsx
@@ -5,7 +5,6 @@ import { useMarkdown } from "react-native-marked";
 import { useTheme, XStack, YStack } from "tamagui";
 
 import type {
-  AiAssistantActionCard,
   AiAssistantFeedMessage,
   AiAssistantToolActivity,
   AiAssistantToolActivityState,
@@ -17,6 +16,8 @@ import { fontFaces, fontSizes, lineHeights } from "@theme/typography";
 import { AppButton } from "@ui/primitives/app-button";
 import { AppCard } from "@ui/primitives/app-card";
 import { AppText } from "@ui/primitives/app-text";
+
+import { ActionToolCard } from "./action-tool-card";
 
 function getToolColors(state: AiAssistantToolActivityState) {
   switch (state) {
@@ -224,170 +225,6 @@ export function ToolApprovalActions({
         Từ chối
       </AppButton>
     </XStack>
-  );
-}
-
-function getActionCardAccent(state: AiAssistantActionCard["state"]) {
-  switch (state) {
-    case "success":
-      return {
-        iconColorKey: "statusSuccess" as const,
-        titleTone: "default" as const,
-      };
-    case "failure":
-    case "denied":
-      return {
-        iconColorKey: "statusDanger" as const,
-        titleTone: "danger" as const,
-      };
-    default:
-      return {
-        iconColorKey: "actionPrimary" as const,
-        titleTone: "default" as const,
-      };
-  }
-}
-
-function getActionCardStateLabel(state: AiAssistantActionCard["state"]) {
-  switch (state) {
-    case "approval":
-      return "Yêu cầu xác nhận";
-    case "success":
-      return "Thực hiện thành công";
-    case "failure":
-      return "Không thể thực hiện";
-    case "denied":
-      return "Đã từ chối";
-    default:
-      return "Trạng thái thao tác";
-  }
-}
-
-function ActionCardIcon({ state }: { state: AiAssistantActionCard["state"] }) {
-  const theme = useTheme();
-  const accent = getActionCardAccent(state);
-  const color = theme[accent.iconColorKey].val;
-
-  if (state === "success") {
-    return <Check color={color} size={18} />;
-  }
-
-  if (state === "failure" || state === "denied") {
-    return <TriangleAlert color={color} size={18} />;
-  }
-
-  return <Sparkles color={color} size={18} />;
-}
-
-function ActionCardSummary({ items }: { items: AiAssistantActionCard["summaryItems"] }) {
-  if (items.length === 0) {
-    return null;
-  }
-
-  return (
-    <YStack
-      backgroundColor="$surfaceSubtle"
-      borderColor="$borderSubtle"
-      borderRadius="$4"
-      borderWidth={borderWidths.subtle}
-      gap="$3"
-      padding="$4"
-      width="100%"
-    >
-      {items.map(item => (
-        <YStack key={`${item.label}:${item.value}`} gap="$1">
-          <AppText tone="subtle" variant="bodySmall">
-            {item.label}
-          </AppText>
-          <AppText variant="bodyStrong">
-            {item.value}
-          </AppText>
-        </YStack>
-      ))}
-    </YStack>
-  );
-}
-
-export function ActionToolCard({
-  approvalBusy,
-  card,
-  onApprove,
-  onDeny,
-}: {
-  approvalBusy: boolean;
-  card: AiAssistantActionCard;
-  onApprove: (approvalId: string) => void;
-  onDeny: (approvalId: string) => void;
-}) {
-  const accent = getActionCardAccent(card.state);
-
-  return (
-    <AppCard
-      alignSelf="flex-start"
-      backgroundColor="$surfaceDefault"
-      borderColor="$borderSubtle"
-      borderTopLeftRadius="$2"
-      borderWidth={borderWidths.subtle}
-      chrome="flat"
-      gap="$4"
-      maxWidth="92%"
-      padding="$4"
-      size="default"
-    >
-      <XStack alignItems="center" gap="$3">
-        <XStack
-          alignItems="center"
-          backgroundColor="$surfaceSubtle"
-          borderRadius="$round"
-          height={44}
-          justifyContent="center"
-          width={44}
-        >
-          <ActionCardIcon state={card.state} />
-        </XStack>
-
-        <YStack flex={1} gap="$1">
-          <AppText tone={accent.titleTone} variant="bodyStrong">
-            {getActionCardStateLabel(card.state)}
-          </AppText>
-          <AppText variant="label">{card.title}</AppText>
-        </YStack>
-      </XStack>
-
-      {card.description
-        ? (
-            <AppText variant="bodySmall">{card.description}</AppText>
-          )
-        : null}
-
-      <ActionCardSummary items={card.summaryItems} />
-
-      {card.state === "approval" && card.approvalId
-        ? (
-            <XStack gap="$2">
-              <AppButton
-                buttonSize="compact"
-                disabled={approvalBusy}
-                flex={1}
-                onPress={() => onDeny(card.approvalId!)}
-                tone="outline"
-              >
-                Từ chối
-              </AppButton>
-              <AppButton
-                buttonSize="compact"
-                disabled={approvalBusy}
-                flex={1}
-                onPress={() => onApprove(card.approvalId!)}
-                tone="primary"
-              >
-                Xác nhận
-              </AppButton>
-            </XStack>
-          )
-        : null}
-
-    </AppCard>
   );
 }
 

--- a/apps/mobile/screen/ai-assistant/components.tsx
+++ b/apps/mobile/screen/ai-assistant/components.tsx
@@ -1,3 +1,9 @@
+import { Check, SendHorizontal, Sparkles, TriangleAlert } from "lucide-react-native";
+import { Fragment } from "react";
+import { ActivityIndicator, Pressable, useColorScheme } from "react-native";
+import { useMarkdown } from "react-native-marked";
+import { useTheme, XStack, YStack } from "tamagui";
+
 import type {
   AiAssistantFeedMessage,
   AiAssistantToolActivity,
@@ -6,14 +12,9 @@ import type {
 
 import { IconSymbol } from "@components/IconSymbol";
 import { borderWidths, spaceScale } from "@theme/metrics";
-import { fontFaces, fontSizes, fontWeights, lineHeights } from "@theme/typography";
+import { fontFaces, fontSizes, lineHeights } from "@theme/typography";
 import { AppCard } from "@ui/primitives/app-card";
 import { AppText } from "@ui/primitives/app-text";
-import { Check, SendHorizontal, Sparkles, TriangleAlert } from "lucide-react-native";
-import { Fragment } from "react";
-import { ActivityIndicator, Pressable, useColorScheme } from "react-native";
-import { useMarkdown } from "react-native-marked";
-import { useTheme, XStack, YStack } from "tamagui";
 
 function getToolColors(state: AiAssistantToolActivityState) {
   switch (state) {
@@ -88,58 +89,53 @@ export function AssistantMarkdown({ markdown }: { markdown: string }) {
       text: {
         color: theme.textPrimary.val,
         fontFamily: fontFaces.regular,
-        fontSize: fontSizes.base,
-        fontWeight: fontWeights.regular,
-        lineHeight: lineHeights.base,
+        fontSize: fontSizes.md,
+        lineHeight: lineHeights.md,
       },
       paragraph: {
-        marginBottom: spaceScale[1],
+        marginBottom: spaceScale[2],
+        paddingVertical: 0,
       },
       strong: {
         color: theme.textPrimary.val,
         fontFamily: fontFaces.semibold,
-        fontWeight: fontWeights.semibold,
       },
       em: {
         color: theme.textPrimary.val,
         fontFamily: fontFaces.medium,
-        fontWeight: fontWeights.medium,
       },
       link: {
         color: theme.textBrand.val,
         fontFamily: fontFaces.medium,
-        fontWeight: fontWeights.medium,
       },
       h1: {
         color: theme.textPrimary.val,
         fontFamily: fontFaces.bold,
         fontSize: fontSizes.xxl,
-        fontWeight: fontWeights.bold,
         lineHeight: lineHeights.xxl,
       },
       h2: {
         color: theme.textPrimary.val,
         fontFamily: fontFaces.bold,
         fontSize: fontSizes.xl,
-        fontWeight: fontWeights.bold,
         lineHeight: lineHeights.xl,
       },
       h3: {
         color: theme.textPrimary.val,
         fontFamily: fontFaces.semibold,
         fontSize: fontSizes.lg,
-        fontWeight: fontWeights.semibold,
         lineHeight: lineHeights.lg,
       },
       li: {
         color: theme.textPrimary.val,
         fontFamily: fontFaces.regular,
-        fontSize: fontSizes.base,
-        fontWeight: fontWeights.regular,
-        lineHeight: lineHeights.base,
+        flexShrink: 1,
+        fontSize: fontSizes.md,
+        lineHeight: lineHeights.md,
+        marginBottom: spaceScale[2],
       },
       list: {
-        marginBottom: spaceScale[2],
+        marginBottom: 0,
       },
       blockquote: {
         borderLeftColor: theme.borderFocus.val,
@@ -151,7 +147,6 @@ export function AssistantMarkdown({ markdown }: { markdown: string }) {
         color: theme.textPrimary.val,
         fontFamily: fontFaces.medium,
         fontSize: fontSizes.sm,
-        fontWeight: fontWeights.medium,
       },
     },
   });

--- a/apps/mobile/screen/ai-assistant/index.tsx
+++ b/apps/mobile/screen/ai-assistant/index.tsx
@@ -36,6 +36,7 @@ export default function AiAssistantScreen() {
   const [isSending, setIsSending] = useState(false);
   const routeContext = route.params?.context ?? null;
   const {
+    addToolApprovalResponse,
     error,
     isBusy,
     messages,
@@ -47,7 +48,7 @@ export default function AiAssistantScreen() {
 
   const feedMessages = useMemo(() => mapAiAssistantMessagesToFeed(messages), [messages]);
   const hasRunningToolActivity = useMemo(() => {
-    return feedMessages.some(message => message.toolActivities.some(activity => activity.state === "running"));
+    return feedMessages.some(message => message.toolActivities.some(activity => activity.state === "running" && activity.rawState !== "approval-requested"));
   }, [feedMessages]);
   const hasConversation = feedMessages.length > 0;
   const canSend = composerText.trim().length > 0;
@@ -98,6 +99,14 @@ export default function AiAssistantScreen() {
     void handleSend(composerText);
   }, [composerText, handleSend, isBusy, stop]);
 
+  const handleApproveTool = useCallback((approvalId: string) => {
+    addToolApprovalResponse(approvalId, true);
+  }, [addToolApprovalResponse]);
+
+  const handleDenyTool = useCallback((approvalId: string) => {
+    addToolApprovalResponse(approvalId, false);
+  }, [addToolApprovalResponse]);
+
   return (
     <Screen tone="subtle">
       <StatusBar barStyle="light-content" />
@@ -139,7 +148,14 @@ export default function AiAssistantScreen() {
                 <YStack key={message.id}>
                   {message.role === "user"
                     ? <UserMessageBlock message={message} />
-                    : <AssistantMessageBlock message={message} />}
+                    : (
+                        <AssistantMessageBlock
+                          approvalBusy={isAssistantWorking}
+                          message={message}
+                          onApproveTool={handleApproveTool}
+                          onDenyTool={handleDenyTool}
+                        />
+                      )}
                 </YStack>
               ))}
 

--- a/apps/mobile/screen/ai-assistant/index.tsx
+++ b/apps/mobile/screen/ai-assistant/index.tsx
@@ -1,15 +1,19 @@
 import type { ScrollView as ScrollViewType } from "react-native";
 
-import { useAiAssistantChat } from "@hooks/ai/use-ai-assistant-chat";
-import { mapAiAssistantMessagesToFeed } from "@services/ai";
-import { borderWidths, radii, spaceScale, spacingRules } from "@theme/metrics";
-import { AppComposerInput } from "@ui/primitives/app-composer-input";
-import { AppText } from "@ui/primitives/app-text";
-import { Screen } from "@ui/primitives/screen";
+import { useRoute } from "@react-navigation/native";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { KeyboardAvoidingView, Platform, ScrollView, StatusBar } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { XStack, YStack } from "tamagui";
+
+import type { AiAssistantRouteProp } from "@/types/navigation";
+
+import { useAiAssistantChat } from "@hooks/ai/use-ai-assistant-chat";
+import { mapAiAssistantMessagesToFeed } from "@services/ai";
+import { borderWidths, radii, spacingRules } from "@theme/metrics";
+import { AppComposerInput } from "@ui/primitives/app-composer-input";
+import { AppText } from "@ui/primitives/app-text";
+import { Screen } from "@ui/primitives/screen";
 
 import {
   AssistantBubble,
@@ -25,17 +29,21 @@ import { INTRO_MARKDOWN, SUGGESTED_PROMPTS } from "./constants";
 import { getAiAssistantErrorMessage } from "./helpers";
 
 export default function AiAssistantScreen() {
+  const route = useRoute<AiAssistantRouteProp>();
   const insets = useSafeAreaInsets();
   const scrollRef = useRef<ScrollViewType | null>(null);
   const [composerText, setComposerText] = useState("");
   const [isSending, setIsSending] = useState(false);
+  const routeContext = route.params?.context ?? null;
   const {
     error,
     isBusy,
     messages,
     sendTextMessage,
     stop,
-  } = useAiAssistantChat();
+  } = useAiAssistantChat({
+    context: routeContext,
+  });
 
   const feedMessages = useMemo(() => mapAiAssistantMessagesToFeed(messages), [messages]);
   const hasRunningToolActivity = useMemo(() => {
@@ -75,7 +83,8 @@ export default function AiAssistantScreen() {
 
     try {
       await sendTextMessage(trimmedText);
-    } finally {
+    }
+    finally {
       setIsSending(false);
     }
   }, [sendTextMessage]);

--- a/apps/mobile/screen/auth/login/components/login-header.tsx
+++ b/apps/mobile/screen/auth/login/components/login-header.tsx
@@ -3,15 +3,16 @@ import { AuthHeader } from "@ui/patterns/auth-header";
 import BackendStatusIndicator from "./backend-status";
 
 type LoginHeaderProps = {
-  onBack: () => void;
+  canGoBack?: boolean;
+  onBack?: () => void;
   backendStatus: "checking" | "online" | "offline";
 };
 
-function LoginHeader({ onBack, backendStatus }: LoginHeaderProps) {
+function LoginHeader({ canGoBack = false, onBack, backendStatus }: LoginHeaderProps) {
   return (
     <AuthHeader
       accessory={__DEV__ ? <BackendStatusIndicator backendStatus={backendStatus} /> : undefined}
-      onBack={onBack}
+      onBack={canGoBack ? onBack : undefined}
       subtitle="Chào mừng bạn trở lại"
       title="Đăng nhập"
     />

--- a/apps/mobile/screen/auth/login/hooks/use-login.ts
+++ b/apps/mobile/screen/auth/login/hooks/use-login.ts
@@ -20,6 +20,7 @@ export type BackendStatus = "checking" | "online" | "offline";
 
 export function useLogin() {
   const navigation = useNavigation<LoginScreenNavigationProp>();
+  const canGoBack = navigation.canGoBack();
   const [showPassword, setShowPassword] = useState(false);
   const [backendStatus, setBackendStatus] = useState<BackendStatus>("checking");
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -79,7 +80,6 @@ export function useLogin() {
         Alert.alert("Đăng nhập thất bại", message);
         return;
       }
-      navigation.navigate("Main");
     }
     catch {
       rotateAnim.stopAnimation();
@@ -110,6 +110,7 @@ export function useLogin() {
     showPassword,
     toggleShowPassword,
     backendStatus,
+    canGoBack,
     rotateAnim,
     submit,
     isSubmitting,

--- a/apps/mobile/screen/auth/login/index.tsx
+++ b/apps/mobile/screen/auth/login/index.tsx
@@ -9,6 +9,7 @@ import { useLogin } from "./hooks/use-login";
 
 function LoginScreen() {
   const {
+    canGoBack,
     control,
     errors,
     showPassword,
@@ -22,7 +23,7 @@ function LoginScreen() {
   } = useLogin();
 
   return (
-    <AuthScreen header={<LoginHeader backendStatus={backendStatus} onBack={goBack} />}>
+    <AuthScreen header={<LoginHeader backendStatus={backendStatus} canGoBack={canGoBack} onBack={goBack} />}>
       <View style={{ paddingHorizontal: spaceScale[6], paddingTop: spaceScale[4], paddingBottom: spaceScale[7] }}>
         <LoginForm
           control={control}

--- a/apps/mobile/screen/rental/bike-detail/bike-detail-screen.tsx
+++ b/apps/mobile/screen/rental/bike-detail/bike-detail-screen.tsx
@@ -71,11 +71,7 @@ export default function BikeDetailScreen() {
         )}
         showsVerticalScrollIndicator={false}
       >
-        <AppHeroHeader
-          onBack={() => navigation.goBack()}
-          size="default"
-          title="Chi tiết xe"
-        />
+        <AppHeroHeader onBack={() => navigation.goBack()} size="default" title="Chi tiết xe" />
 
         <View
           style={{

--- a/apps/mobile/screen/rental/booking-history-detail/booking-history-detail-screen.tsx
+++ b/apps/mobile/screen/rental/booking-history-detail/booking-history-detail-screen.tsx
@@ -64,11 +64,7 @@ function BookingHistoryDetailScreen() {
         showsVerticalScrollIndicator={false}
       >
         <YStack>
-          <AppHeroHeader
-            onBack={() => navigation.goBack()}
-            size="compact"
-            title="Chi tiết thuê xe"
-          />
+          <AppHeroHeader onBack={() => navigation.goBack()} size="compact" title="Chi tiết thuê xe" />
 
           <YStack gap="$5" marginTop={-spaceScale[5]} paddingHorizontal="$5">
             <RentalHeroCard rental={vm.booking} />

--- a/apps/mobile/screen/station-detail/components/station-detail-header.tsx
+++ b/apps/mobile/screen/station-detail/components/station-detail-header.tsx
@@ -1,10 +1,11 @@
+import { useTheme, XStack } from "tamagui";
+
+import type { StationReadSummary } from "@/contracts/server";
+
 import { IconSymbol } from "@components/IconSymbol";
 import { AppHeroHeader } from "@ui/patterns/app-hero-header";
 import { AppText } from "@ui/primitives/app-text";
 import { StatusBadge } from "@ui/primitives/status-badge";
-import { useTheme, XStack } from "tamagui";
-
-import type { StationReadSummary } from "@/contracts/server";
 
 type StationDetailHeaderProps = {
   onBack: () => void;

--- a/apps/mobile/screen/station-detail/index.tsx
+++ b/apps/mobile/screen/station-detail/index.tsx
@@ -1,19 +1,19 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { Alert, RefreshControl, ScrollView, View } from "react-native";
+import { useTheme, YStack } from "tamagui";
+
+import { presentRentalError } from "@/presenters/rentals/rental-error-presenter";
 import { IconSymbol } from "@components/IconSymbol";
 import { LoadingScreen } from "@components/LoadingScreen";
 import { useCreateMyReturnSlotMutation } from "@hooks/mutations/rentals/use-create-my-return-slot-mutation";
 import { useRequestBikeSwapMutation } from "@hooks/mutations/rentals/use-request-bike-swap-mutation";
 import { invalidateMyRentalQueries } from "@hooks/rentals/rental-cache";
 import { useMyBikeSwapPreview } from "@hooks/rentals/use-my-bike-swap-preview";
-import { useQueryClient } from "@tanstack/react-query";
 import { spaceScale } from "@theme/metrics";
 import { AppButton } from "@ui/primitives/app-button";
 import { AppCard } from "@ui/primitives/app-card";
 import { AppText } from "@ui/primitives/app-text";
 import { Screen } from "@ui/primitives/screen";
-import { Alert, RefreshControl, ScrollView, View } from "react-native";
-import { useTheme, YStack } from "tamagui";
-
-import { presentRentalError } from "@/presenters/rentals/rental-error-presenter";
 
 import { BikeList } from "./components/bike-list";
 import { FixedSlotBanner } from "./components/fixed-slot-banner";
@@ -145,10 +145,7 @@ export default function StationDetailScreen() {
           />
         )}
       >
-        <StationDetailHeader
-          onBack={() => navigation.goBack()}
-          station={station}
-        />
+        <StationDetailHeader onBack={() => navigation.goBack()} station={station} />
         <View
           style={{
             marginTop: -spaceScale[6],

--- a/apps/mobile/services/ai/ai-chat-feed.adapter.ts
+++ b/apps/mobile/services/ai/ai-chat-feed.adapter.ts
@@ -74,6 +74,11 @@ const TOOL_ACTIVITY_COPY: Record<string, ToolActivityCopy> = {
     error: "Không thể kiểm tra chuyến thuê hiện tại",
     running: "Đang kiểm tra chuyến thuê hiện tại",
   },
+  getCurrentReturnSlot: {
+    done: "Đã kiểm tra giữ chỗ trả xe hiện tại",
+    error: "Không thể kiểm tra giữ chỗ trả xe hiện tại",
+    running: "Đang kiểm tra giữ chỗ trả xe hiện tại",
+  },
   getRentalDetail: {
     done: "Đã lấy chi tiết chuyến thuê",
     error: "Không thể tải chi tiết chuyến thuê",
@@ -88,6 +93,36 @@ const TOOL_ACTIVITY_COPY: Record<string, ToolActivityCopy> = {
     done: "Đã kiểm tra đặt chỗ",
     error: "Không thể kiểm tra đặt chỗ",
     running: "Đang kiểm tra đặt chỗ",
+  },
+  getStationDetail: {
+    done: "Đã lấy thông tin trạm",
+    error: "Không thể tải thông tin trạm",
+    running: "Đang lấy thông tin trạm",
+  },
+  searchStations: {
+    done: "Đã tìm trạm phù hợp",
+    error: "Không thể tìm trạm phù hợp",
+    running: "Đang tìm trạm phù hợp",
+  },
+  getNearbyStations: {
+    done: "Đã tìm các trạm lân cận",
+    error: "Không thể tìm các trạm lân cận",
+    running: "Đang tìm các trạm lân cận",
+  },
+  getNearbyStationsFromLocation: {
+    done: "Đã tìm các trạm gần vị trí hiện tại",
+    error: "Không thể tìm các trạm gần vị trí hiện tại",
+    running: "Đang tìm các trạm gần vị trí hiện tại",
+  },
+  getStationAvailableBikes: {
+    done: "Đã kiểm tra xe có sẵn tại trạm",
+    error: "Không thể kiểm tra xe có sẵn tại trạm",
+    running: "Đang kiểm tra xe có sẵn tại trạm",
+  },
+  getBikeDetail: {
+    done: "Đã lấy thông tin xe",
+    error: "Không thể tải thông tin xe",
+    running: "Đang lấy thông tin xe",
   },
   getWalletSummary: {
     done: "Đã kiểm tra ví",

--- a/apps/mobile/services/ai/ai-chat-feed.adapter.ts
+++ b/apps/mobile/services/ai/ai-chat-feed.adapter.ts
@@ -10,6 +10,7 @@ export type AiAssistantFeedUser = {
 export type AiAssistantToolActivityState = "running" | "done" | "error";
 
 export type AiAssistantToolActivity = {
+  approvalId?: string;
   key: string;
   toolCallId: string;
   toolName: string;
@@ -27,6 +28,8 @@ export type AiAssistantToolActivity = {
 };
 
 export type AiAssistantFeedMessage = {
+  actionCards: AiAssistantActionCard[];
+  contentBlocks: AiAssistantContentBlock[];
   id: string;
   createdAt: Date;
   role: "user" | "assistant";
@@ -39,6 +42,42 @@ export type AiAssistantFeedMessage = {
   rawMessage: AiAssistantMessage;
   user: AiAssistantFeedUser;
 };
+
+export type AiAssistantActionCardState = "approval" | "success" | "failure" | "denied";
+
+export type AiAssistantActionCardSummaryItem = {
+  label: string;
+  value: string;
+};
+
+export type AiAssistantActionCard = {
+  approvalId?: string;
+  description?: string;
+  key: string;
+  state: AiAssistantActionCardState;
+  suggestedAction?: string;
+  summaryItems: AiAssistantActionCardSummaryItem[];
+  title: string;
+  toolCallId: string;
+  toolName: string;
+};
+
+export type AiAssistantContentBlock
+  = | {
+    kind: "text";
+    key: string;
+    markdown: string;
+  }
+  | {
+    activity: AiAssistantToolActivity;
+    key: string;
+    kind: "tool-activity";
+  }
+  | {
+    card: AiAssistantActionCard;
+    key: string;
+    kind: "action-card";
+  };
 
 export const AI_ASSISTANT_FEED_USER: AiAssistantFeedUser = {
   id: "mebike-ai-assistant",
@@ -56,7 +95,9 @@ type MapAiAssistantMessagesToFeedOptions = {
 };
 
 type ToolActivityCopy = {
+  approvalRequested?: string;
   done: string;
+  denied?: string;
   error: string;
   running: string;
 };
@@ -68,6 +109,35 @@ type ToolPart = Extract<
 
 type ToolPartState = AiAssistantToolActivity["rawState"];
 
+type StructuredToolFailureOutput = {
+  ok: false;
+  error: {
+    suggestedAction?: string;
+    userMessage: string;
+  };
+};
+
+type StructuredReturnSlotSuccessOutput = {
+  ok: true;
+  rentalId: string;
+  returnSlot: {
+    reservedFromDisplay?: string | null;
+    station?: {
+      address?: string;
+      name?: string;
+    } | null;
+    statusLabel?: string;
+  };
+};
+
+type ToolInputRecord = Record<string, unknown>;
+
+const ACTION_TOOL_NAMES = new Set([
+  "createReturnSlot",
+  "switchReturnSlot",
+  "cancelReturnSlot",
+]);
+
 const TOOL_ACTIVITY_COPY: Record<string, ToolActivityCopy> = {
   getCurrentRentalSummary: {
     done: "Đã kiểm tra chuyến thuê hiện tại",
@@ -78,6 +148,27 @@ const TOOL_ACTIVITY_COPY: Record<string, ToolActivityCopy> = {
     done: "Đã kiểm tra giữ chỗ trả xe hiện tại",
     error: "Không thể kiểm tra giữ chỗ trả xe hiện tại",
     running: "Đang kiểm tra giữ chỗ trả xe hiện tại",
+  },
+  createReturnSlot: {
+    approvalRequested: "Chờ bạn xác nhận giữ chỗ trả xe",
+    denied: "Bạn đã từ chối giữ chỗ trả xe",
+    done: "Đã giữ chỗ trả xe",
+    error: "Không thể giữ chỗ trả xe",
+    running: "Đang chuẩn bị giữ chỗ trả xe",
+  },
+  switchReturnSlot: {
+    approvalRequested: "Chờ bạn xác nhận đổi trạm giữ chỗ trả xe",
+    denied: "Bạn đã từ chối đổi trạm giữ chỗ trả xe",
+    done: "Đã đổi trạm giữ chỗ trả xe",
+    error: "Không thể đổi trạm giữ chỗ trả xe",
+    running: "Đang chuẩn bị đổi trạm giữ chỗ trả xe",
+  },
+  cancelReturnSlot: {
+    approvalRequested: "Chờ bạn xác nhận hủy giữ chỗ trả xe",
+    denied: "Bạn đã từ chối hủy giữ chỗ trả xe",
+    done: "Đã hủy giữ chỗ trả xe",
+    error: "Không thể hủy giữ chỗ trả xe",
+    running: "Đang chuẩn bị hủy giữ chỗ trả xe",
   },
   getRentalDetail: {
     done: "Đã lấy chi tiết chuyến thuê",
@@ -144,7 +235,286 @@ function getToolName(part: ToolPart) {
   return part.type === "dynamic-tool" ? part.toolName : part.type.slice(5);
 }
 
-function getToolActivityState(rawState: ToolPartState): AiAssistantToolActivityState {
+function isActionToolName(toolName: string) {
+  return ACTION_TOOL_NAMES.has(toolName);
+}
+
+function getToolInputRecord(part: ToolPart): ToolInputRecord | null {
+  if (!("input" in part) || !part.input || typeof part.input !== "object" || Array.isArray(part.input)) {
+    return null;
+  }
+
+  return part.input as ToolInputRecord;
+}
+
+function isStructuredReturnSlotSuccessOutput(output: unknown): output is StructuredReturnSlotSuccessOutput {
+  if (!output || typeof output !== "object") {
+    return false;
+  }
+
+  const candidate = output as Record<string, unknown>;
+
+  return candidate.ok === true
+    && typeof candidate.rentalId === "string"
+    && !!candidate.returnSlot
+    && typeof candidate.returnSlot === "object";
+}
+
+function getStructuredReturnSlotSuccessOutput(part: ToolPart): StructuredReturnSlotSuccessOutput | null {
+  if (part.state !== "output-available" || !("output" in part)) {
+    return null;
+  }
+
+  return isStructuredReturnSlotSuccessOutput(part.output) ? part.output : null;
+}
+
+function getActionToolTitle(toolName: string) {
+  switch (toolName) {
+    case "createReturnSlot":
+      return "Giữ chỗ trả xe";
+    case "switchReturnSlot":
+      return "Đổi trạm giữ chỗ trả xe";
+    case "cancelReturnSlot":
+      return "Hủy giữ chỗ trả xe";
+    default:
+      return "Xác nhận thao tác";
+  }
+}
+
+function getActionToolApprovalDescription(toolName: string) {
+  switch (toolName) {
+    case "createReturnSlot":
+      return "Vui lòng kiểm tra và xác nhận thao tác giữ chỗ trả xe.";
+    case "switchReturnSlot":
+      return "Vui lòng kiểm tra và xác nhận thao tác đổi trạm giữ chỗ trả xe.";
+    case "cancelReturnSlot":
+      return "Vui lòng kiểm tra và xác nhận thao tác hủy giữ chỗ trả xe.";
+    default:
+      return undefined;
+  }
+}
+
+function getStationSummaryValue(input: ToolInputRecord) {
+  if (typeof input.stationReference === "string" && input.stationReference === "context") {
+    return "Theo trạm đang mở";
+  }
+
+  if (typeof input.stationId === "string" && input.stationId.trim().length > 0) {
+    return `Mã trạm ${input.stationId}`;
+  }
+
+  return null;
+}
+
+function getRentalSummaryValue(input: ToolInputRecord) {
+  if (typeof input.rentalReference === "string") {
+    switch (input.rentalReference) {
+      case "current":
+        return "Chuyến thuê hiện tại";
+      case "latest":
+        return "Chuyến thuê gần nhất";
+      case "context":
+        return "Theo chuyến thuê đang mở";
+      default:
+        break;
+    }
+  }
+
+  if (typeof input.rentalId === "string" && input.rentalId.trim().length > 0) {
+    return `Mã chuyến ${input.rentalId}`;
+  }
+
+  return null;
+}
+
+function getSuggestedActionText(suggestedAction?: string) {
+  switch (suggestedAction) {
+    case "check_current_rental":
+      return "Kiểm tra lại chuyến thuê hiện tại";
+    case "check_current_return_slot":
+      return "Kiểm tra lại giữ chỗ trả xe hiện tại";
+    case "choose_station_again":
+      return "Chọn lại trạm";
+    case "search_stations":
+      return "Tìm trạm phù hợp khác";
+    case "choose_another_station":
+      return "Chọn trạm khác còn chỗ trả";
+    case "retry_later":
+      return "Thử lại sau ít phút";
+    default:
+      return null;
+  }
+}
+
+function getActionCardSummaryItems(
+  toolName: string,
+  part: ToolPart,
+  failure: StructuredToolFailureOutput | null,
+  success: StructuredReturnSlotSuccessOutput | null,
+): AiAssistantActionCardSummaryItem[] {
+  if (success) {
+    const items: AiAssistantActionCardSummaryItem[] = [];
+    const stationName = success.returnSlot.station?.name;
+    const stationAddress = success.returnSlot.station?.address;
+    const reservedFromDisplay = success.returnSlot.reservedFromDisplay;
+    const statusLabel = success.returnSlot.statusLabel;
+
+    if (stationName) {
+      items.push({ label: toolName === "cancelReturnSlot" ? "Trạm đã hủy" : "Trạm", value: stationName });
+    }
+
+    if (stationAddress) {
+      items.push({ label: "Địa điểm", value: stationAddress });
+    }
+
+    if (statusLabel) {
+      items.push({ label: "Trạng thái", value: statusLabel });
+    }
+
+    if (reservedFromDisplay && toolName !== "cancelReturnSlot") {
+      items.push({ label: "Bắt đầu giữ chỗ từ", value: reservedFromDisplay });
+    }
+
+    return items;
+  }
+
+  if (failure) {
+    const suggestedActionText = getSuggestedActionText(failure.error.suggestedAction);
+
+    return suggestedActionText
+      ? [{ label: "Gợi ý", value: suggestedActionText }]
+      : [];
+  }
+
+  const input = getToolInputRecord(part);
+
+  if (!input) {
+    return [];
+  }
+
+  const items: AiAssistantActionCardSummaryItem[] = [];
+  const stationValue = getStationSummaryValue(input);
+  const rentalValue = getRentalSummaryValue(input);
+
+  items.push({ label: "Thao tác", value: getActionToolTitle(toolName) });
+
+  if (stationValue) {
+    items.push({ label: "Trạm", value: stationValue });
+  }
+
+  if (rentalValue) {
+    items.push({ label: "Áp dụng cho", value: rentalValue });
+  }
+
+  return items;
+}
+
+function getActionCardState(part: ToolPart, failure: StructuredToolFailureOutput | null, success: StructuredReturnSlotSuccessOutput | null): AiAssistantActionCardState | null {
+  if (part.state === "approval-requested") {
+    return "approval";
+  }
+
+  if (part.state === "output-denied") {
+    return "denied";
+  }
+
+  if (failure || part.state === "output-error") {
+    return "failure";
+  }
+
+  if (success) {
+    return "success";
+  }
+
+  return null;
+}
+
+function getActionCardDescription(
+  state: AiAssistantActionCardState,
+  toolName: string,
+  failure: StructuredToolFailureOutput | null,
+): string | undefined {
+  if (state === "approval") {
+    return getActionToolApprovalDescription(toolName);
+  }
+
+  if (state === "failure") {
+    return failure?.error.userMessage;
+  }
+
+  if (state === "denied") {
+    return "Bạn đã từ chối thao tác này. Không có thay đổi nào được thực hiện.";
+  }
+
+  switch (toolName) {
+    case "createReturnSlot":
+      return "Đã tạo giữ chỗ trả xe thành công.";
+    case "switchReturnSlot":
+      return "Đã đổi sang trạm giữ chỗ trả xe mới.";
+    case "cancelReturnSlot":
+      return "Đã hủy giữ chỗ trả xe hiện tại.";
+    default:
+      return undefined;
+  }
+}
+
+function getAiAssistantActionCard(part: ToolPart): AiAssistantActionCard | null {
+  const toolName = getToolName(part);
+
+  if (!isActionToolName(toolName)) {
+    return null;
+  }
+
+  const failure = getStructuredToolFailureOutput(part);
+  const success = getStructuredReturnSlotSuccessOutput(part);
+  const state = getActionCardState(part, failure, success);
+
+  if (!state) {
+    return null;
+  }
+
+  return {
+    approvalId: "approval" in part ? part.approval?.id : undefined,
+    description: getActionCardDescription(state, toolName, failure),
+    key: `action:${part.toolCallId}:${part.state}`,
+    state,
+    suggestedAction: failure?.error.suggestedAction,
+    summaryItems: getActionCardSummaryItems(toolName, part, failure, success),
+    title: getActionToolTitle(toolName),
+    toolCallId: part.toolCallId,
+    toolName,
+  } satisfies AiAssistantActionCard;
+}
+
+function isStructuredToolFailureOutput(output: unknown): output is StructuredToolFailureOutput {
+  if (!output || typeof output !== "object") {
+    return false;
+  }
+
+  const candidate = output as Record<string, unknown>;
+  const error = candidate.error;
+
+  return candidate.ok === false
+    && !!error
+    && typeof error === "object"
+    && typeof (error as Record<string, unknown>).userMessage === "string";
+}
+
+function getStructuredToolFailureOutput(part: ToolPart): StructuredToolFailureOutput | null {
+  if (part.state !== "output-available" || !("output" in part)) {
+    return null;
+  }
+
+  return isStructuredToolFailureOutput(part.output) ? part.output : null;
+}
+
+function getToolActivityState(part: ToolPart): AiAssistantToolActivityState {
+  if (getStructuredToolFailureOutput(part)) {
+    return "error";
+  }
+
+  const rawState = part.state;
+
   switch (rawState) {
     case "output-available":
       return "done";
@@ -156,19 +526,36 @@ function getToolActivityState(rawState: ToolPartState): AiAssistantToolActivityS
   }
 }
 
-function getToolActivityLabel(toolName: string, state: AiAssistantToolActivityState) {
+function getToolActivityLabel(
+  toolName: string,
+  state: AiAssistantToolActivityState,
+  rawState: ToolPartState,
+  structuredFailure: StructuredToolFailureOutput | null,
+) {
+  if (structuredFailure) {
+    return structuredFailure.error.userMessage;
+  }
+
   const copy = TOOL_ACTIVITY_COPY[toolName];
 
   if (copy) {
+    if (rawState === "approval-requested" && copy.approvalRequested) {
+      return copy.approvalRequested;
+    }
+
+    if (rawState === "output-denied" && copy.denied) {
+      return copy.denied;
+    }
+
     return copy[state];
   }
 
-    switch (state) {
-      case "done":
+  switch (state) {
+    case "done":
       return "Đã lấy xong thông tin";
-      case "error":
+    case "error":
       return "Không thể tải thông tin";
-      default:
+    default:
       return "Đang lấy thông tin";
   }
 }
@@ -178,20 +565,90 @@ export function getAiAssistantToolActivities(
 ): AiAssistantToolActivity[] {
   return message.parts
     .filter(isToolPart)
-    .map(part => {
+    .filter(part => !isActionToolName(getToolName(part)))
+    .map((part) => {
       const toolName = getToolName(part);
-      const state = getToolActivityState(part.state);
+      const structuredFailure = getStructuredToolFailureOutput(part);
+      const state = getToolActivityState(part);
 
       return {
+        approvalId: "approval" in part ? part.approval?.id : undefined,
         errorText: part.errorText,
         key: `${part.toolCallId}:${part.state}`,
-        label: part.title ?? getToolActivityLabel(toolName, state),
+        label: part.title ?? getToolActivityLabel(toolName, state, part.state, structuredFailure),
         rawState: part.state,
         state,
         toolCallId: part.toolCallId,
         toolName,
       } satisfies AiAssistantToolActivity;
     });
+}
+
+export function getAiAssistantActionCards(
+  message: AiAssistantMessage,
+): AiAssistantActionCard[] {
+  return message.parts
+    .filter(isToolPart)
+    .map(getAiAssistantActionCard)
+    .filter((card): card is AiAssistantActionCard => card !== null);
+}
+
+export function getAiAssistantContentBlocks(
+  message: AiAssistantMessage,
+): AiAssistantContentBlock[] {
+  const blocks: AiAssistantContentBlock[] = [];
+
+  for (const part of message.parts) {
+    if (part.type === "text") {
+      if (!part.text.trim()) {
+        continue;
+      }
+
+      const previousBlock = blocks[blocks.length - 1];
+
+      if (previousBlock?.kind === "text") {
+        previousBlock.markdown = `${previousBlock.markdown}${part.text}`;
+        continue;
+      }
+
+      blocks.push({
+        key: `text:${blocks.length}`,
+        kind: "text",
+        markdown: part.text,
+      });
+      continue;
+    }
+
+    if (!isToolPart(part)) {
+      continue;
+    }
+
+    const actionCard = getAiAssistantActionCard(part);
+
+    if (actionCard) {
+      blocks.push({
+        card: actionCard,
+        key: actionCard.key,
+        kind: "action-card",
+      });
+      continue;
+    }
+
+    const toolActivities = getAiAssistantToolActivities({
+      ...message,
+      parts: [part],
+    });
+
+    for (const activity of toolActivities) {
+      blocks.push({
+        activity,
+        key: activity.key,
+        kind: "tool-activity",
+      });
+    }
+  }
+
+  return blocks;
 }
 
 export function getVisibleAiAssistantToolActivity(
@@ -243,12 +700,16 @@ export function mapAiAssistantMessagesToFeed(
     .filter((message): message is AiAssistantMessage & { role: "assistant" | "user" } => {
       return message.role === "assistant" || message.role === "user";
     })
-    .map(message => {
+    .map((message) => {
       const markdown = getAiAssistantMessageMarkdown(message);
+      const actionCards = getAiAssistantActionCards(message);
+      const contentBlocks = getAiAssistantContentBlocks(message);
       const isStreaming = isAiAssistantMessageStreaming(message);
       const toolActivities = getAiAssistantToolActivities(message);
 
       return {
+        actionCards,
+        contentBlocks,
         createdAt: getMessageCreatedAt(message),
         hasTextContent: markdown.length > 0,
         id: message.id,

--- a/apps/mobile/services/ai/ai-chat-feed.adapter.ts
+++ b/apps/mobile/services/ai/ai-chat-feed.adapter.ts
@@ -295,12 +295,16 @@ function getActionToolApprovalDescription(toolName: string) {
 }
 
 function getStationSummaryValue(input: ToolInputRecord) {
+  if (typeof input.stationName === "string" && input.stationName.trim().length > 0) {
+    return input.stationName.trim();
+  }
+
   if (typeof input.stationReference === "string" && input.stationReference === "context") {
     return "Theo trạm đang mở";
   }
 
   if (typeof input.stationId === "string" && input.stationId.trim().length > 0) {
-    return `Mã trạm ${input.stationId}`;
+    return "Trạm đã chọn";
   }
 
   return null;
@@ -321,7 +325,7 @@ function getRentalSummaryValue(input: ToolInputRecord) {
   }
 
   if (typeof input.rentalId === "string" && input.rentalId.trim().length > 0) {
-    return `Mã chuyến ${input.rentalId}`;
+    return "Chuyến thuê đã chọn";
   }
 
   return null;

--- a/apps/mobile/styles/station-select/index.tsx
+++ b/apps/mobile/styles/station-select/index.tsx
@@ -5,9 +5,11 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTheme, XStack, YStack } from "tamagui";
 
 import StationMap from "@/components/station-map";
+import { useAuthNext } from "@/providers/auth-provider-next";
 import { IconSymbol } from "@components/IconSymbol";
 import { LoadingScreen } from "@components/LoadingScreen";
 import { borderWidths } from "@theme/metrics";
+import { AppButton } from "@ui/primitives/app-button";
 import { AppCard } from "@ui/primitives/app-card";
 import { AppText } from "@ui/primitives/app-text";
 import { Screen } from "@ui/primitives/screen";
@@ -21,6 +23,8 @@ export default function StationSelectScreen() {
   const navigation = useNavigation();
   const insets = useSafeAreaInsets();
   const theme = useTheme();
+  const { isAuthenticated } = useAuthNext();
+  const showsBackButton = navigation.canGoBack();
 
   const {
     stations,
@@ -75,23 +79,42 @@ export default function StationSelectScreen() {
         right={0}
         top={0}
         zIndex="$3"
-        style={{ paddingTop: insets.top + 12, paddingLeft: 16 }}
+        style={{ paddingTop: insets.top + 12, paddingHorizontal: 16 }}
       >
-        <Pressable onPress={() => navigation.goBack()}>
-          <AppCard
-            alignItems="center"
-            borderColor="$borderSubtle"
-            borderRadius="$round"
-            borderWidth={borderWidths.subtle}
-            chrome="flat"
-            height={44}
-            justifyContent="center"
-            padding="$0"
-            width={44}
-          >
-            <IconSymbol color={theme.textPrimary.val} name="chevron-left" size="input" />
-          </AppCard>
-        </Pressable>
+        <XStack alignItems="center" justifyContent="space-between">
+          {showsBackButton
+            ? (
+                <Pressable onPress={() => navigation.goBack()}>
+                  <AppCard
+                    alignItems="center"
+                    borderColor="$borderSubtle"
+                    borderRadius="$round"
+                    borderWidth={borderWidths.subtle}
+                    chrome="flat"
+                    height={44}
+                    justifyContent="center"
+                    padding="$0"
+                    width={44}
+                  >
+                    <IconSymbol color={theme.textPrimary.val} name="chevron-left" size="input" />
+                  </AppCard>
+                </Pressable>
+              )
+            : <View style={{ width: 44, height: 44 }} />}
+
+          {!isAuthenticated
+            ? (
+                <AppButton
+                  buttonSize="compact"
+                  borderRadius="$round"
+                  onPress={() => navigation.navigate("Login" as never)}
+                  tone="primary"
+                >
+                  Đăng nhập
+                </AppButton>
+              )
+            : null}
+        </XStack>
       </YStack>
 
       <StationSelectMapOverlay

--- a/apps/mobile/types/navigation.ts
+++ b/apps/mobile/types/navigation.ts
@@ -35,7 +35,6 @@ export type RootStackParamList = {
   "Wallet": undefined;
   "AiAssistant": {
     context?: AiChatContext | null;
-    initialPrompt?: string;
   } | undefined;
   "BookingHistoryDetail": { bookingId: string };
   "BikeDetail": {

--- a/apps/server/src/domain/ai/prompts/customer-assistant.prompt.sections.ts
+++ b/apps/server/src/domain/ai/prompts/customer-assistant.prompt.sections.ts
@@ -10,6 +10,7 @@ export const customerAssistantToolRules = [
   "If live location context is not available, do not imply that you know the user's exact current position. Fall back to station-based nearby search or station name and area search.",
   "If a user names a station and the exact station is not already in context, use a station lookup tool before answering. If multiple stations match, ask the user to choose.",
   "If a user asks about a specific bike and the bike identity is not already known from context or prior tool results, say you need the bike id or open bike detail screen. Do not invent bike identity.",
+  "When calling an approval-required return-slot action and a human-facing station name is known from screen context or prior tool results, include that station name in the tool input so approval UI can show it. Never use raw UUIDs as display text.",
   "Treat structured tool failures as source of truth. If an action tool returns ok false, explain only the provided safe reason and react based on its error code and suggestedAction fields.",
   "After any successful tool use, always give a short final user-facing answer that summarizes the result.",
 ] as const;

--- a/apps/server/src/domain/ai/prompts/customer-assistant.prompt.sections.ts
+++ b/apps/server/src/domain/ai/prompts/customer-assistant.prompt.sections.ts
@@ -10,6 +10,7 @@ export const customerAssistantToolRules = [
   "If live location context is not available, do not imply that you know the user's exact current position. Fall back to station-based nearby search or station name and area search.",
   "If a user names a station and the exact station is not already in context, use a station lookup tool before answering. If multiple stations match, ask the user to choose.",
   "If a user asks about a specific bike and the bike identity is not already known from context or prior tool results, say you need the bike id or open bike detail screen. Do not invent bike identity.",
+  "Treat structured tool failures as source of truth. If an action tool returns ok false, explain only the provided safe reason and react based on its error code and suggestedAction fields.",
   "After any successful tool use, always give a short final user-facing answer that summarizes the result.",
 ] as const;
 
@@ -23,6 +24,9 @@ export const customerAssistantRentalRules = [
   "Rental guidance: describe a return slot as an optional way to reserve return capacity at a station for an active rental. Present it as a practical recommendation, not a mandatory step.",
   "Rental guidance: if the user already has an active return slot, treat that station as the intended return destination and mention it in the answer.",
   "Rental guidance: do not promise guaranteed return priority, staff handling, or station availability unless tool data or current app context supports it.",
+  "Rental action rule: if a user clearly asks you to reserve a return slot for them, you may use the create return-slot tool. The tool requires explicit user approval before execution, so explain what will be reserved and proceed only through the approval flow.",
+  "Rental action rule: if a user clearly asks to change the reserved return station, you may use the switch return-slot tool through approval flow.",
+  "Rental action rule: if a user clearly asks to remove their reserved return station, you may use the cancel return-slot tool through approval flow.",
 ] as const;
 
 export const customerAssistantReservationRules = [
@@ -41,6 +45,9 @@ export const customerAssistantLanguageAndFormattingRules = [
   "Tool payloads may contain internal enum codes such as AVAILABLE, BOOKED, RESERVED, BROKEN, MAINTAINED, UNAVAILABLE, PENDING, ACTIVE, COMPLETED, CANCELLED, EXPIRED, or FULFILLED.",
   "Use those codes for reasoning only. Never expose raw enum codes in user-facing Vietnamese answers unless the user explicitly asks for the exact system code.",
   "Prefer natural Vietnamese wording and any localized labels provided by tool results over raw enum names.",
+  "Prefer localized display fields for dates and times when tool results provide them. Do not reformat raw ISO timestamps yourself unless no display field exists.",
+  "Never invent hotline numbers, phone support, staff workflows, or manual support channels unless explicitly known from current tool data or configured policy.",
+  "Never claim exact backend, database, UUID, token, or system-internal root causes unless that cause is explicitly exposed in a safe user-appropriate tool result.",
   "Write the reply in the user's language when it is clear from the conversation.",
   "If the user's language is unclear, default to Vietnamese.",
   "Be concise, practical, and clear.",

--- a/apps/server/src/domain/ai/prompts/customer-assistant.prompt.sections.ts
+++ b/apps/server/src/domain/ai/prompts/customer-assistant.prompt.sections.ts
@@ -1,0 +1,56 @@
+export const customerAssistantRoleRules = [
+  "You are MeBike mobile assistant.",
+  "Help with customer rentals, reservations, stations, bikes, and wallet questions.",
+  "Prioritize rentals, reservations, stations, and bike availability because those are the current core product flows.",
+] as const;
+
+export const customerAssistantToolRules = [
+  "Use tools for account-specific facts and live operational facts. Do not guess rental, reservation, station, bike, or wallet state.",
+  "If live location context is available and the user asks for the nearest station near them or stations close to their current position, prefer the live-location nearby-station tool.",
+  "If live location context is not available, do not imply that you know the user's exact current position. Fall back to station-based nearby search or station name and area search.",
+  "If a user names a station and the exact station is not already in context, use a station lookup tool before answering. If multiple stations match, ask the user to choose.",
+  "If a user asks about a specific bike and the bike identity is not already known from context or prior tool results, say you need the bike id or open bike detail screen. Do not invent bike identity.",
+  "After any successful tool use, always give a short final user-facing answer that summarizes the result.",
+] as const;
+
+export const customerAssistantRentalRules = [
+  "Rental rules: a user cannot have more than one active rental at a time.",
+  "Rental rules: only bikes in AVAILABLE state should be treated as ready to rent. BOOKED, RESERVED, BROKEN, MAINTAINED, and UNAVAILABLE bikes are not ready for a new rental.",
+  "Rental rules: return guidance must respect live station return capacity. If a station has no return capacity, say so plainly and suggest another station only when tool data supports it.",
+  "Rental guidance: if a user asks about returning an active rental, their intended return station, or whether they already reserved return capacity, check the current return slot first before giving generic return advice.",
+  "Rental guidance: when a user asks how to end an active rental, explain the normal flow plainly: go to a suitable station, complete the return in app or with staff guidance if required, and follow the return confirmation flow shown in the app.",
+  "Rental guidance: when a user is actively renting and asks about where to return, whether a station will be full, or how to make return smoother, you may proactively suggest reserving a return slot first if live station data supports that station as a return option.",
+  "Rental guidance: describe a return slot as an optional way to reserve return capacity at a station for an active rental. Present it as a practical recommendation, not a mandatory step.",
+  "Rental guidance: if the user already has an active return slot, treat that station as the intended return destination and mention it in the answer.",
+  "Rental guidance: do not promise guaranteed return priority, staff handling, or station availability unless tool data or current app context supports it.",
+] as const;
+
+export const customerAssistantReservationRules = [
+  "Reservation rules: do not say a user can create a new reservation if they already have a pending or active reservation.",
+  "Reservation rules: a station can accept a new reservation only when available bikes are greater than 50 percent of total capacity.",
+  "Reservation rules: reservation timing and expiry must come from tool data. Do not guess countdowns, expiry times, or hold windows.",
+] as const;
+
+export const customerAssistantStationAndBikeRules = [
+  "Station rules: prefer live station counts over generic advice. If a station has no available bikes or no return capacity, say that clearly.",
+  "Bike rules: if a bike is BROKEN, MAINTAINED, RESERVED, BOOKED, or UNAVAILABLE, advise the user not to use it.",
+  "If rental state, reservation state, station data, and bike data conflict, explain that the data looks inconsistent and advise the user to contact support or station staff.",
+] as const;
+
+export const customerAssistantLanguageAndFormattingRules = [
+  "Tool payloads may contain internal enum codes such as AVAILABLE, BOOKED, RESERVED, BROKEN, MAINTAINED, UNAVAILABLE, PENDING, ACTIVE, COMPLETED, CANCELLED, EXPIRED, or FULFILLED.",
+  "Use those codes for reasoning only. Never expose raw enum codes in user-facing Vietnamese answers unless the user explicitly asks for the exact system code.",
+  "Prefer natural Vietnamese wording and any localized labels provided by tool results over raw enum names.",
+  "Write the reply in the user's language when it is clear from the conversation.",
+  "If the user's language is unclear, default to Vietnamese.",
+  "Be concise, practical, and clear.",
+  "Keep tone calm, helpful, and professional. Do not sound sarcastic, scolding, or abrupt.",
+  "Do not use emojis.",
+  "Do not use decorative symbols, pictograms, or icon-style bullets.",
+  "Use plain text or simple markdown lists only.",
+] as const;
+
+export const customerAssistantBoundaryRules = [
+  "If user asks for unsupported actions, explain limits and guide to next step in app.",
+  "Do not answer unrelated broad questions outside MeBike support scope.",
+] as const;

--- a/apps/server/src/domain/ai/prompts/customer-assistant.prompt.ts
+++ b/apps/server/src/domain/ai/prompts/customer-assistant.prompt.ts
@@ -1,24 +1,28 @@
 import type { AiChatContext } from "@mebike/shared";
 
+import {
+  customerAssistantBoundaryRules,
+  customerAssistantLanguageAndFormattingRules,
+  customerAssistantRentalRules,
+  customerAssistantReservationRules,
+  customerAssistantRoleRules,
+  customerAssistantStationAndBikeRules,
+  customerAssistantToolRules,
+} from "./customer-assistant.prompt.sections";
+
 export function buildCustomerAssistantPrompt(context: AiChatContext | null) {
   const screenHint = context?.screen
     ? `Current screen focus: ${context.screen}.`
     : null;
 
   return [
-    "You are MeBike mobile assistant.",
-    "Help only with customer rentals, reservations, and wallet questions.",
-    "Use tools for account-specific facts. Do not guess rental, reservation, or wallet state.",
-    "After any successful tool use, always give a short final user-facing answer that summarizes the result.",
-    "Write the reply in the user's language when it is clear from the conversation.",
-    "If the user's language is unclear, default to Vietnamese.",
-    "Be concise, practical, and clear.",
-    "Keep tone calm, helpful, and professional. Do not sound sarcastic, scolding, or abrupt.",
-    "Do not use emojis.",
-    "Do not use decorative symbols, pictograms, or icon-style bullets.",
-    "Use plain text or simple markdown lists only.",
-    "If user asks for unsupported actions, explain limits and guide to next step in app.",
-    "Do not answer unrelated broad questions outside MeBike support scope.",
+    ...customerAssistantRoleRules,
+    ...customerAssistantToolRules,
+    ...customerAssistantRentalRules,
+    ...customerAssistantReservationRules,
+    ...customerAssistantStationAndBikeRules,
+    ...customerAssistantLanguageAndFormattingRules,
+    ...customerAssistantBoundaryRules,
     screenHint,
   ].filter(Boolean).join(" ");
 }

--- a/apps/server/src/domain/ai/prompts/customer-assistant.prompt.ts
+++ b/apps/server/src/domain/ai/prompts/customer-assistant.prompt.ts
@@ -14,6 +14,9 @@ export function buildCustomerAssistantPrompt(context: AiChatContext | null) {
   const screenHint = context?.screen
     ? `Current screen focus: ${context.screen}.`
     : null;
+  const stationHint = context?.stationName
+    ? `Current station in focus: ${context.stationName}.`
+    : null;
 
   return [
     ...customerAssistantRoleRules,
@@ -24,5 +27,6 @@ export function buildCustomerAssistantPrompt(context: AiChatContext | null) {
     ...customerAssistantLanguageAndFormattingRules,
     ...customerAssistantBoundaryRules,
     screenHint,
+    stationHint,
   ].filter(Boolean).join(" ");
 }

--- a/apps/server/src/domain/ai/services/ai-chat.service.ts
+++ b/apps/server/src/domain/ai/services/ai-chat.service.ts
@@ -5,8 +5,11 @@ import { convertToModelMessages, stepCountIs, streamText, validateUIMessages } f
 import { Context, Effect, Layer } from "effect";
 
 import { env } from "@/config/env";
+import { BikeServiceTag } from "@/domain/bikes";
+import { RentalCommandServiceTag } from "@/domain/rentals";
 import { RentalServiceTag } from "@/domain/rentals/services/rental.service";
 import { ReservationQueryServiceTag } from "@/domain/reservations";
+import { StationQueryServiceTag } from "@/domain/stations";
 import { WalletServiceTag } from "@/domain/wallets/services/wallet.service";
 import { getOpenRouterChatModel } from "@/infrastructure/ai/openrouter";
 import logger from "@/lib/logger";
@@ -85,8 +88,11 @@ export type AiChatService = {
 };
 
 const makeAiChatService = Effect.gen(function* () {
+  const bikeService = yield* BikeServiceTag;
+  const rentalCommandService = yield* RentalCommandServiceTag;
   const rentalService = yield* RentalServiceTag;
   const reservationQueryService = yield* ReservationQueryServiceTag;
+  const stationQueryService = yield* StationQueryServiceTag;
   const walletService = yield* WalletServiceTag;
 
   const streamCustomerAssistant: AiChatService["streamCustomerAssistant"] = args =>
@@ -98,9 +104,12 @@ const makeAiChatService = Effect.gen(function* () {
       }
 
       const tools = createCustomerTools({
+        bikeService,
         context: args.context,
+        rentalCommandService,
         reservationQueryService,
         rentalService,
+        stationQueryService,
         userId: args.userId,
         walletService,
       });

--- a/apps/server/src/domain/ai/tools/customer-bike-tools.ts
+++ b/apps/server/src/domain/ai/tools/customer-bike-tools.ts
@@ -7,7 +7,7 @@ import type { CreateCustomerToolsArgs } from "./customer-tool-helpers";
 
 import {
   BikeDetailInputSchema,
-
+  formatLocalDateTime,
   toBikeAiDetail,
 } from "./customer-tool-helpers";
 import { BikeDetailToolOutputSchema } from "./customer-tool-schemas";
@@ -35,7 +35,13 @@ export function createCustomerBikeTools(args: CreateCustomerToolsArgs) {
 
         return {
           reference: input.reference,
-          detail: Option.isSome(bike) ? toBikeAiDetail(bike.value) : null,
+          detail: Option.isSome(bike)
+            ? {
+                ...toBikeAiDetail(bike.value),
+                createdAtDisplay: formatLocalDateTime(bike.value.createdAt),
+                updatedAtDisplay: formatLocalDateTime(bike.value.updatedAt),
+              }
+            : null,
         };
       },
     }),

--- a/apps/server/src/domain/ai/tools/customer-bike-tools.ts
+++ b/apps/server/src/domain/ai/tools/customer-bike-tools.ts
@@ -1,0 +1,43 @@
+import type { z } from "zod";
+
+import { tool } from "ai";
+import { Effect, Option } from "effect";
+
+import type { CreateCustomerToolsArgs } from "./customer-tool-helpers";
+
+import {
+  BikeDetailInputSchema,
+
+  toBikeAiDetail,
+} from "./customer-tool-helpers";
+import { BikeDetailToolOutputSchema } from "./customer-tool-schemas";
+
+export function createCustomerBikeTools(args: CreateCustomerToolsArgs) {
+  return {
+    getBikeDetail: tool({
+      description: "Get one bike detail when the bike id is already known from screen context or prior tool results.",
+      inputSchema: BikeDetailInputSchema,
+      outputSchema: BikeDetailToolOutputSchema,
+      execute: async (input): Promise<z.infer<typeof BikeDetailToolOutputSchema>> => {
+        let bikeId = input.bikeId ?? null;
+
+        if (!bikeId && input.reference === "context") {
+          bikeId = args.context?.bikeId ?? null;
+        }
+
+        if (!bikeId) {
+          return { reference: input.reference, detail: null };
+        }
+
+        const bike = await Effect.runPromise(
+          args.bikeService.getBikeDetail(bikeId),
+        );
+
+        return {
+          reference: input.reference,
+          detail: Option.isSome(bike) ? toBikeAiDetail(bike.value) : null,
+        };
+      },
+    }),
+  } as const;
+}

--- a/apps/server/src/domain/ai/tools/customer-rental-tools.ts
+++ b/apps/server/src/domain/ai/tools/customer-rental-tools.ts
@@ -1,0 +1,156 @@
+import { tool } from "ai";
+import { Effect, Either, Option } from "effect";
+import { z } from "zod";
+
+import { toContractRental } from "@/http/presenters/rentals.presenter";
+
+import type { CreateCustomerToolsArgs } from "./customer-tool-helpers";
+
+import {
+
+  formatMinorVnd,
+  getRentalStatusLabel,
+  getReturnSlotStatusLabel,
+  getStationByIdOrNull,
+  RentalDetailInputSchema,
+  rentalToolPage,
+  resolveRentalReference,
+} from "./customer-tool-helpers";
+import {
+  CurrentRentalSummaryToolOutputSchema,
+  CurrentReturnSlotToolOutputSchema,
+  RentalDetailToolOutputSchema,
+} from "./customer-tool-schemas";
+
+export function createCustomerRentalTools(args: CreateCustomerToolsArgs) {
+  return {
+    getCurrentRentalSummary: tool({
+      description: "Get the current user's active rental summary and rental counts.",
+      inputSchema: z.object({}),
+      outputSchema: CurrentRentalSummaryToolOutputSchema,
+      execute: async (): Promise<z.infer<typeof CurrentRentalSummaryToolOutputSchema>> => {
+        const [rentals, counts] = await Promise.all([
+          Effect.runPromise(
+            args.rentalService.listMyCurrentRentals(args.userId, rentalToolPage),
+          ),
+          Effect.runPromise(
+            args.rentalService.getMyRentalCounts(args.userId),
+          ),
+        ]);
+
+        return {
+          activeRentalCount: rentals.total,
+          counts,
+          rentals: rentals.items.map(rental => ({
+            ...toContractRental(rental),
+            statusLabel: getRentalStatusLabel(rental.status),
+            totalPriceDisplay: formatMinorVnd(rental.totalPrice),
+          })),
+        };
+      },
+    }),
+    getCurrentReturnSlot: tool({
+      description: "Get the user's active return-slot reservation for a rental. Prefer current screen context or the current active rental before raw ids.",
+      inputSchema: RentalDetailInputSchema,
+      outputSchema: CurrentReturnSlotToolOutputSchema,
+      execute: async (input): Promise<z.infer<typeof CurrentReturnSlotToolOutputSchema>> => {
+        const rental = await resolveRentalReference({
+          context: args.context,
+          rentalId: input.rentalId,
+          reference: input.reference,
+          rentalService: args.rentalService,
+          userId: args.userId,
+        });
+
+        if (!rental) {
+          return {
+            reference: input.reference,
+            hasActiveRental: false,
+            rentalId: null,
+            returnSlot: null,
+          };
+        }
+
+        if (rental.status !== "RENTED") {
+          return {
+            reference: input.reference,
+            hasActiveRental: false,
+            rentalId: rental.id,
+            returnSlot: null,
+          };
+        }
+
+        const currentReturnSlot = await Effect.runPromise(
+          args.rentalCommandService.getCurrentReturnSlot({
+            rentalId: rental.id,
+            userId: args.userId,
+          }).pipe(Effect.either),
+        );
+
+        if (Either.isLeft(currentReturnSlot) || Option.isNone(currentReturnSlot.right)) {
+          return {
+            reference: input.reference,
+            hasActiveRental: true,
+            rentalId: rental.id,
+            returnSlot: null,
+          };
+        }
+
+        const returnSlot = currentReturnSlot.right.value;
+        const station = await getStationByIdOrNull(args.stationQueryService, returnSlot.stationId);
+
+        return {
+          reference: input.reference,
+          hasActiveRental: true,
+          rentalId: rental.id,
+          returnSlot: {
+            id: returnSlot.id,
+            rentalId: returnSlot.rentalId,
+            userId: returnSlot.userId,
+            stationId: returnSlot.stationId,
+            reservedFrom: returnSlot.reservedFrom.toISOString(),
+            status: returnSlot.status,
+            statusLabel: getReturnSlotStatusLabel(returnSlot.status),
+            createdAt: returnSlot.createdAt.toISOString(),
+            updatedAt: returnSlot.updatedAt.toISOString(),
+            station: station
+              ? {
+                  id: station.id,
+                  name: station.name,
+                  address: station.address,
+                }
+              : null,
+          },
+        };
+      },
+    }),
+    getRentalDetail: tool({
+      description: "Get one user-owned rental detail. Prefer current screen context or current or latest rental instead of raw ids unless an id is already available.",
+      inputSchema: RentalDetailInputSchema,
+      outputSchema: RentalDetailToolOutputSchema,
+      execute: async (input): Promise<z.infer<typeof RentalDetailToolOutputSchema>> => {
+        const rental = await resolveRentalReference({
+          context: args.context,
+          rentalId: input.rentalId,
+          reference: input.reference,
+          rentalService: args.rentalService,
+          userId: args.userId,
+        });
+
+        if (!rental) {
+          return { reference: input.reference, detail: null };
+        }
+
+        return {
+          reference: input.reference,
+          detail: {
+            ...toContractRental(rental),
+            statusLabel: getRentalStatusLabel(rental.status),
+            totalPriceDisplay: formatMinorVnd(rental.totalPrice),
+            depositAmountDisplay: formatMinorVnd(rental.depositAmount),
+          },
+        };
+      },
+    }),
+  } as const;
+}

--- a/apps/server/src/domain/ai/tools/customer-rental-tools.ts
+++ b/apps/server/src/domain/ai/tools/customer-rental-tools.ts
@@ -1,26 +1,269 @@
 import { tool } from "ai";
-import { Effect, Either, Option } from "effect";
+import { Cause, Effect, Either, Exit, Match, Option } from "effect";
 import { z } from "zod";
+
+import type { ReturnSlotFailure } from "@/domain/rentals";
 
 import { toContractRental } from "@/http/presenters/rentals.presenter";
 
 import type { CreateCustomerToolsArgs } from "./customer-tool-helpers";
 
 import {
-
+  formatLocalDateTime,
   formatMinorVnd,
   getRentalStatusLabel,
-  getReturnSlotStatusLabel,
   getStationByIdOrNull,
   RentalDetailInputSchema,
   rentalToolPage,
   resolveRentalReference,
+  StationReferenceSchema,
+  toReturnSlotAiDetail,
 } from "./customer-tool-helpers";
 import {
+  CancelReturnSlotToolOutputSchema,
+  CreateReturnSlotToolOutputSchema,
   CurrentRentalSummaryToolOutputSchema,
   CurrentReturnSlotToolOutputSchema,
   RentalDetailToolOutputSchema,
+  SwitchReturnSlotToolOutputSchema,
 } from "./customer-tool-schemas";
+
+const uuidSchema = z.string().uuid();
+
+const ReturnSlotMutationInputSchema = z.object({
+  rentalId: z.string().optional(),
+  rentalReference: z.enum(["context", "current", "latest", "id"]).default("current"),
+  stationId: z.string().optional(),
+  stationReference: StationReferenceSchema.default("context"),
+});
+
+const CancelReturnSlotInputSchema = z.object({
+  rentalId: z.string().optional(),
+  rentalReference: z.enum(["context", "current", "latest", "id"]).default("current"),
+});
+
+type CreateReturnSlotToolOutput = z.infer<typeof CreateReturnSlotToolOutputSchema>;
+type SwitchReturnSlotToolOutput = z.infer<typeof SwitchReturnSlotToolOutputSchema>;
+type CancelReturnSlotToolOutput = z.infer<typeof CancelReturnSlotToolOutputSchema>;
+type ReturnSlotActionFailure = Extract<CreateReturnSlotToolOutput, { ok: false }>;
+
+function failReturnSlotAction(
+  code: ReturnSlotActionFailure["error"]["code"],
+  kind: ReturnSlotActionFailure["error"]["kind"],
+  retryable: boolean,
+  suggestedAction: ReturnSlotActionFailure["error"]["suggestedAction"],
+  userMessage: string,
+): ReturnSlotActionFailure {
+  return {
+    ok: false,
+    error: {
+      code,
+      kind,
+      retryable,
+      suggestedAction,
+      userMessage,
+    },
+  };
+}
+
+function invalidRentalIdFailure() {
+  return failReturnSlotAction(
+    "INVALID_RENTAL_ID",
+    "validation",
+    false,
+    "check_current_rental",
+    "Không xác định được mã chuyến thuê hợp lệ để thực hiện thao tác này.",
+  );
+}
+
+function noActiveRentalFailure() {
+  return failReturnSlotAction(
+    "NO_ACTIVE_RENTAL",
+    "business",
+    false,
+    "check_current_rental",
+    "Bạn chưa có chuyến thuê đang hoạt động để thao tác giữ chỗ trả xe.",
+  );
+}
+
+function invalidStationIdFailure() {
+  return failReturnSlotAction(
+    "INVALID_STATION_ID",
+    "validation",
+    false,
+    "choose_station_again",
+    "Không xác định được mã trạm hợp lệ để giữ chỗ trả xe.",
+  );
+}
+
+function missingStationContextFailure() {
+  return failReturnSlotAction(
+    "MISSING_STATION_CONTEXT",
+    "validation",
+    false,
+    "search_stations",
+    "Chưa xác định được trạm để thực hiện thao tác giữ chỗ trả xe.",
+  );
+}
+
+function mapCreateOrSwitchReturnSlotFailure(
+  error: ReturnSlotFailure,
+  action: "create" | "switch",
+): ReturnSlotActionFailure {
+  const isSwitch = action === "switch";
+
+  return Match.value<ReturnSlotFailure>(error).pipe(
+    Match.tag("RentalNotFound", () => noActiveRentalFailure()),
+    Match.tag("ReturnSlotRequiresActiveRental", () => noActiveRentalFailure()),
+    Match.tag("StationNotFound", () =>
+      failReturnSlotAction(
+        "STATION_NOT_FOUND",
+        "business",
+        false,
+        "choose_station_again",
+        isSwitch
+          ? "Không tìm thấy trạm mới để đổi giữ chỗ trả xe."
+          : "Không tìm thấy trạm này để giữ chỗ trả xe.",
+      )),
+    Match.tag("ReturnSlotCapacityExceeded", () =>
+      failReturnSlotAction(
+        "RETURN_CAPACITY_UNAVAILABLE",
+        "business",
+        true,
+        "choose_another_station",
+        isSwitch
+          ? "Trạm này hiện không còn chỗ trả xe để đổi giữ chỗ."
+          : "Trạm này hiện không còn chỗ trả xe để giữ chỗ.",
+      )),
+    Match.orElse(() =>
+      failReturnSlotAction(
+        "TEMPORARY_UNAVAILABLE",
+        "temporary",
+        true,
+        "retry_later",
+        isSwitch
+          ? "Hiện chưa thể đổi giữ chỗ trả xe do lỗi tạm thời của hệ thống."
+          : "Hiện chưa thể giữ chỗ trả xe do lỗi tạm thời của hệ thống.",
+      )),
+  );
+}
+
+function mapCancelReturnSlotFailure(error: ReturnSlotFailure): ReturnSlotActionFailure {
+  return Match.value<ReturnSlotFailure>(error).pipe(
+    Match.tag("RentalNotFound", () => noActiveRentalFailure()),
+    Match.tag("ReturnSlotRequiresActiveRental", () => noActiveRentalFailure()),
+    Match.tag("ReturnSlotNotFound", () =>
+      failReturnSlotAction(
+        "RETURN_SLOT_NOT_FOUND",
+        "business",
+        false,
+        "check_current_return_slot",
+        "Bạn chưa có giữ chỗ trả xe đang hoạt động để hủy.",
+      )),
+    Match.orElse(() =>
+      failReturnSlotAction(
+        "TEMPORARY_UNAVAILABLE",
+        "temporary",
+        true,
+        "retry_later",
+        "Hiện chưa thể hủy giữ chỗ trả xe do lỗi tạm thời của hệ thống.",
+      )),
+  );
+}
+
+function validateUuidOrNull(value: string | null | undefined) {
+  if (!value) {
+    return null;
+  }
+
+  return uuidSchema.safeParse(value).success ? value : null;
+}
+
+function resolveActiveRentalEffect(
+  args: CreateCustomerToolsArgs,
+  input: { rentalId?: string; rentalReference: "context" | "current" | "latest" | "id" },
+) {
+  return Effect.gen(function* () {
+    let rentalId = input.rentalId ?? null;
+
+    if (!rentalId && input.rentalReference === "context") {
+      rentalId = args.context?.rentalId ?? null;
+    }
+
+    if (!rentalId && input.rentalReference === "current") {
+      const rentals = yield* args.rentalService.listMyCurrentRentals(args.userId, {
+        ...rentalToolPage,
+        pageSize: 1,
+      });
+      rentalId = rentals.items[0]?.id ?? null;
+    }
+
+    if (!rentalId && input.rentalReference === "latest") {
+      const rentals = yield* args.rentalService.listMyRentals(args.userId, {}, {
+        ...rentalToolPage,
+        pageSize: 1,
+      });
+      rentalId = rentals.items[0]?.id ?? null;
+    }
+
+    if (!rentalId) {
+      return yield* Effect.fail(noActiveRentalFailure());
+    }
+
+    const safeRentalId = validateUuidOrNull(rentalId);
+
+    if (!safeRentalId) {
+      return yield* Effect.fail(invalidRentalIdFailure());
+    }
+
+    const rental = yield* args.rentalService.getMyRentalById(args.userId, safeRentalId);
+
+    if (Option.isNone(rental) || rental.value.status !== "RENTED") {
+      return yield* Effect.fail(noActiveRentalFailure());
+    }
+
+    return rental.value;
+  });
+}
+
+function resolveTargetStationIdEffect(
+  args: CreateCustomerToolsArgs,
+  input: { stationId?: string; stationReference: "context" | "id" },
+) {
+  return Effect.gen(function* () {
+    const stationId = input.stationId
+      ?? (input.stationReference === "context" ? args.context?.stationId ?? null : null);
+
+    if (!stationId) {
+      return yield* Effect.fail(missingStationContextFailure());
+    }
+
+    const safeStationId = validateUuidOrNull(stationId);
+
+    if (!safeStationId) {
+      return yield* Effect.fail(invalidStationIdFailure());
+    }
+
+    return safeStationId;
+  });
+}
+
+async function finishReturnSlotSuccess(
+  args: CreateCustomerToolsArgs,
+  rentalId: string,
+  returnSlot: Parameters<typeof toReturnSlotAiDetail>[0],
+): Promise<Extract<CreateReturnSlotToolOutput, { ok: true }>> {
+  const station = await getStationByIdOrNull(args.stationQueryService, returnSlot.stationId);
+
+  return {
+    ok: true,
+    rentalId,
+    returnSlot: toReturnSlotAiDetail(
+      returnSlot,
+      station ? { id: station.id, name: station.name, address: station.address } : null,
+    ),
+  };
+}
 
 export function createCustomerRentalTools(args: CreateCustomerToolsArgs) {
   return {
@@ -43,8 +286,11 @@ export function createCustomerRentalTools(args: CreateCustomerToolsArgs) {
           counts,
           rentals: rentals.items.map(rental => ({
             ...toContractRental(rental),
+            endTimeDisplay: formatLocalDateTime(rental.endTime),
+            startTimeDisplay: formatLocalDateTime(rental.startTime),
             statusLabel: getRentalStatusLabel(rental.status),
             totalPriceDisplay: formatMinorVnd(rental.totalPrice),
+            updatedAtDisplay: formatLocalDateTime(rental.updatedAt),
           })),
         };
       },
@@ -103,25 +349,102 @@ export function createCustomerRentalTools(args: CreateCustomerToolsArgs) {
           reference: input.reference,
           hasActiveRental: true,
           rentalId: rental.id,
-          returnSlot: {
-            id: returnSlot.id,
-            rentalId: returnSlot.rentalId,
-            userId: returnSlot.userId,
-            stationId: returnSlot.stationId,
-            reservedFrom: returnSlot.reservedFrom.toISOString(),
-            status: returnSlot.status,
-            statusLabel: getReturnSlotStatusLabel(returnSlot.status),
-            createdAt: returnSlot.createdAt.toISOString(),
-            updatedAt: returnSlot.updatedAt.toISOString(),
-            station: station
-              ? {
-                  id: station.id,
-                  name: station.name,
-                  address: station.address,
-                }
-              : null,
-          },
+          returnSlot: toReturnSlotAiDetail(
+            returnSlot,
+            station ? { id: station.id, name: station.name, address: station.address } : null,
+          ),
         };
+      },
+    }),
+    createReturnSlot: tool({
+      description: "Reserve return capacity for the user's active rental at a station. Use this only when the user clearly asks you to do it.",
+      inputSchema: ReturnSlotMutationInputSchema,
+      outputSchema: CreateReturnSlotToolOutputSchema,
+      needsApproval: true,
+      execute: async (input): Promise<CreateReturnSlotToolOutput> => {
+        const exit = await Effect.runPromiseExit(Effect.gen(function* () {
+          const rental = yield* resolveActiveRentalEffect(args, input);
+          const stationId = yield* resolveTargetStationIdEffect(args, input);
+          const returnSlot = yield* args.rentalCommandService.createReturnSlot({
+            rentalId: rental.id,
+            stationId,
+            userId: args.userId,
+          }).pipe(
+            Effect.mapError(error => mapCreateOrSwitchReturnSlotFailure(error, "create")),
+          );
+
+          return { rentalId: rental.id, returnSlot };
+        }));
+
+        if (Exit.isSuccess(exit)) {
+          return finishReturnSlotSuccess(args, exit.value.rentalId, exit.value.returnSlot);
+        }
+
+        if (Cause.isFailType(exit.cause)) {
+          return exit.cause.error;
+        }
+
+        throw new Error("Không thể giữ chỗ trả xe do lỗi hệ thống ngoài dự kiến.");
+      },
+    }),
+    switchReturnSlot: tool({
+      description: "Switch the user's existing return slot to a different station. Use this only when the user clearly asks to change the reserved return station.",
+      inputSchema: ReturnSlotMutationInputSchema,
+      outputSchema: SwitchReturnSlotToolOutputSchema,
+      needsApproval: true,
+      execute: async (input): Promise<SwitchReturnSlotToolOutput> => {
+        const exit = await Effect.runPromiseExit(Effect.gen(function* () {
+          const rental = yield* resolveActiveRentalEffect(args, input);
+          const stationId = yield* resolveTargetStationIdEffect(args, input);
+          const returnSlot = yield* args.rentalCommandService.createReturnSlot({
+            rentalId: rental.id,
+            stationId,
+            userId: args.userId,
+          }).pipe(
+            Effect.mapError(error => mapCreateOrSwitchReturnSlotFailure(error, "switch")),
+          );
+
+          return { rentalId: rental.id, returnSlot };
+        }));
+
+        if (Exit.isSuccess(exit)) {
+          return finishReturnSlotSuccess(args, exit.value.rentalId, exit.value.returnSlot);
+        }
+
+        if (Cause.isFailType(exit.cause)) {
+          return exit.cause.error;
+        }
+
+        throw new Error("Không thể đổi giữ chỗ trả xe do lỗi hệ thống ngoài dự kiến.");
+      },
+    }),
+    cancelReturnSlot: tool({
+      description: "Cancel the user's current return slot for an active rental. Use this only when the user clearly asks to cancel the reserved return slot.",
+      inputSchema: CancelReturnSlotInputSchema,
+      outputSchema: CancelReturnSlotToolOutputSchema,
+      needsApproval: true,
+      execute: async (input): Promise<CancelReturnSlotToolOutput> => {
+        const exit = await Effect.runPromiseExit(Effect.gen(function* () {
+          const rental = yield* resolveActiveRentalEffect(args, input);
+          const cancelled = yield* args.rentalCommandService.cancelReturnSlot({
+            rentalId: rental.id,
+            userId: args.userId,
+          }).pipe(
+            Effect.mapError(mapCancelReturnSlotFailure),
+          );
+
+          return { rentalId: rental.id, returnSlot: cancelled };
+        }));
+
+        if (Exit.isSuccess(exit)) {
+          return finishReturnSlotSuccess(args, exit.value.rentalId, exit.value.returnSlot);
+        }
+
+        if (Cause.isFailType(exit.cause)) {
+          return exit.cause.error;
+        }
+
+        throw new Error("Không thể hủy giữ chỗ trả xe do lỗi hệ thống ngoài dự kiến.");
       },
     }),
     getRentalDetail: tool({
@@ -145,9 +468,12 @@ export function createCustomerRentalTools(args: CreateCustomerToolsArgs) {
           reference: input.reference,
           detail: {
             ...toContractRental(rental),
+            depositAmountDisplay: formatMinorVnd(rental.depositAmount),
+            endTimeDisplay: formatLocalDateTime(rental.endTime),
+            startTimeDisplay: formatLocalDateTime(rental.startTime),
             statusLabel: getRentalStatusLabel(rental.status),
             totalPriceDisplay: formatMinorVnd(rental.totalPrice),
-            depositAmountDisplay: formatMinorVnd(rental.depositAmount),
+            updatedAtDisplay: formatLocalDateTime(rental.updatedAt),
           },
         };
       },

--- a/apps/server/src/domain/ai/tools/customer-rental-tools.ts
+++ b/apps/server/src/domain/ai/tools/customer-rental-tools.ts
@@ -34,6 +34,7 @@ const ReturnSlotMutationInputSchema = z.object({
   rentalId: z.string().optional(),
   rentalReference: z.enum(["context", "current", "latest", "id"]).default("current"),
   stationId: z.string().optional(),
+  stationName: z.string().trim().min(1).optional().describe("User-facing station name when known from current context or prior tool results. Never put raw ids here."),
   stationReference: StationReferenceSchema.default("context"),
 });
 

--- a/apps/server/src/domain/ai/tools/customer-reservation-tools.ts
+++ b/apps/server/src/domain/ai/tools/customer-reservation-tools.ts
@@ -1,0 +1,99 @@
+import { tool } from "ai";
+import { Effect, Option } from "effect";
+import { z } from "zod";
+
+import {
+  toContractReservation,
+  toContractReservationExpanded,
+} from "@/http/presenters/reservations.presenter";
+
+import type { CreateCustomerToolsArgs } from "./customer-tool-helpers";
+
+import {
+
+  formatMinorVnd,
+  getReservationStatusLabel,
+  rentalToolPage,
+  ReservationDetailInputSchema,
+} from "./customer-tool-helpers";
+import {
+  ReservationDetailToolOutputSchema,
+  ReservationSummaryToolOutputSchema,
+} from "./customer-tool-schemas";
+
+export function createCustomerReservationTools(args: CreateCustomerToolsArgs) {
+  return {
+    getReservationSummary: tool({
+      description: "Get the current user's latest active or pending reservation plus recent reservation history.",
+      inputSchema: z.object({}),
+      outputSchema: ReservationSummaryToolOutputSchema,
+      execute: async (): Promise<z.infer<typeof ReservationSummaryToolOutputSchema>> => {
+        const [latestPendingOrActive, reservations] = await Promise.all([
+          Effect.runPromise(
+            args.reservationQueryService.getLatestPendingOrActiveForUser(args.userId),
+          ),
+          Effect.runPromise(
+            args.reservationQueryService.listForUser(
+              args.userId,
+              {},
+              rentalToolPage,
+            ),
+          ),
+        ]);
+
+        return {
+          latestPendingOrActive: Option.isSome(latestPendingOrActive)
+            ? {
+                ...toContractReservation(latestPendingOrActive.value),
+                prepaidDisplay: formatMinorVnd(Number(latestPendingOrActive.value.prepaid.toString())),
+                statusLabel: getReservationStatusLabel(latestPendingOrActive.value.status),
+              }
+            : null,
+          reservations: reservations.items.map(reservation => ({
+            ...toContractReservation(reservation),
+            prepaidDisplay: formatMinorVnd(Number(reservation.prepaid.toString())),
+            statusLabel: getReservationStatusLabel(reservation.status),
+          })),
+        };
+      },
+    }),
+    getReservationDetail: tool({
+      description: "Get one user-owned reservation detail. Prefer current screen context or the latest pending or active reservation before raw ids.",
+      inputSchema: ReservationDetailInputSchema,
+      outputSchema: ReservationDetailToolOutputSchema,
+      execute: async (input): Promise<z.infer<typeof ReservationDetailToolOutputSchema>> => {
+        let reservationId = input.reservationId ?? null;
+
+        if (!reservationId && input.reference === "context") {
+          reservationId = args.context?.reservationId ?? null;
+        }
+
+        if (!reservationId && input.reference === "latestPendingOrActive") {
+          const latest = await Effect.runPromise(
+            args.reservationQueryService.getLatestPendingOrActiveForUser(args.userId),
+          );
+          reservationId = Option.isSome(latest) ? latest.value.id : null;
+        }
+
+        if (!reservationId) {
+          return { reference: input.reference, detail: null };
+        }
+
+        const detail = await Effect.runPromise(
+          args.reservationQueryService.getExpandedDetailById(reservationId),
+        );
+
+        return {
+          reference: input.reference,
+          detail: Option.isSome(detail) && detail.value.user.id === args.userId
+            ? {
+                ...toContractReservationExpanded(detail.value),
+                prepaidDisplay: formatMinorVnd(Number(detail.value.prepaid.toString())),
+                statusLabel: getReservationStatusLabel(detail.value.status),
+              }
+            : null,
+        };
+      },
+    }),
+  } as const;
+}

--- a/apps/server/src/domain/ai/tools/customer-reservation-tools.ts
+++ b/apps/server/src/domain/ai/tools/customer-reservation-tools.ts
@@ -10,7 +10,7 @@ import {
 import type { CreateCustomerToolsArgs } from "./customer-tool-helpers";
 
 import {
-
+  formatLocalDateTime,
   formatMinorVnd,
   getReservationStatusLabel,
   rentalToolPage,
@@ -45,14 +45,22 @@ export function createCustomerReservationTools(args: CreateCustomerToolsArgs) {
           latestPendingOrActive: Option.isSome(latestPendingOrActive)
             ? {
                 ...toContractReservation(latestPendingOrActive.value),
+                createdAtDisplay: formatLocalDateTime(latestPendingOrActive.value.createdAt),
+                endTimeDisplay: formatLocalDateTime(latestPendingOrActive.value.endTime),
                 prepaidDisplay: formatMinorVnd(Number(latestPendingOrActive.value.prepaid.toString())),
+                startTimeDisplay: formatLocalDateTime(latestPendingOrActive.value.startTime),
                 statusLabel: getReservationStatusLabel(latestPendingOrActive.value.status),
+                updatedAtDisplay: formatLocalDateTime(latestPendingOrActive.value.updatedAt),
               }
             : null,
           reservations: reservations.items.map(reservation => ({
             ...toContractReservation(reservation),
+            createdAtDisplay: formatLocalDateTime(reservation.createdAt),
+            endTimeDisplay: formatLocalDateTime(reservation.endTime),
             prepaidDisplay: formatMinorVnd(Number(reservation.prepaid.toString())),
+            startTimeDisplay: formatLocalDateTime(reservation.startTime),
             statusLabel: getReservationStatusLabel(reservation.status),
+            updatedAtDisplay: formatLocalDateTime(reservation.updatedAt),
           })),
         };
       },
@@ -88,8 +96,12 @@ export function createCustomerReservationTools(args: CreateCustomerToolsArgs) {
           detail: Option.isSome(detail) && detail.value.user.id === args.userId
             ? {
                 ...toContractReservationExpanded(detail.value),
+                createdAtDisplay: formatLocalDateTime(detail.value.createdAt),
+                endTimeDisplay: formatLocalDateTime(detail.value.endTime),
                 prepaidDisplay: formatMinorVnd(Number(detail.value.prepaid.toString())),
+                startTimeDisplay: formatLocalDateTime(detail.value.startTime),
                 statusLabel: getReservationStatusLabel(detail.value.status),
+                updatedAtDisplay: formatLocalDateTime(detail.value.updatedAt),
               }
             : null,
         };

--- a/apps/server/src/domain/ai/tools/customer-station-tools.ts
+++ b/apps/server/src/domain/ai/tools/customer-station-tools.ts
@@ -1,0 +1,204 @@
+import type { z } from "zod";
+
+import { tool } from "ai";
+import { Effect } from "effect";
+
+import type { CreateCustomerToolsArgs } from "./customer-tool-helpers";
+
+import {
+  bikeToolPage,
+
+  getStationByIdOrNull,
+  NearbyStationsFromLocationInputSchema,
+  NearbyStationsInputSchema,
+  StationAvailableBikesInputSchema,
+  StationDetailInputSchema,
+  StationSearchInputSchema,
+  stationToolPage,
+  toBikeAiDetail,
+  toNearbyStationAiDetail,
+  toStationAiDetail,
+} from "./customer-tool-helpers";
+import {
+  NearbyStationsFromLocationToolOutputSchema,
+  NearbyStationsToolOutputSchema,
+  StationAvailableBikesToolOutputSchema,
+  StationDetailToolOutputSchema,
+  StationSearchToolOutputSchema,
+} from "./customer-tool-schemas";
+
+export function createCustomerStationTools(args: CreateCustomerToolsArgs) {
+  return {
+    getStationDetail: tool({
+      description: "Get one station detail. Prefer the current screen context when a station is already open.",
+      inputSchema: StationDetailInputSchema,
+      outputSchema: StationDetailToolOutputSchema,
+      execute: async (input): Promise<z.infer<typeof StationDetailToolOutputSchema>> => {
+        let stationId = input.stationId ?? null;
+
+        if (!stationId && input.reference === "context") {
+          stationId = args.context?.stationId ?? null;
+        }
+
+        if (!stationId) {
+          return { reference: input.reference, detail: null };
+        }
+
+        const station = await getStationByIdOrNull(args.stationQueryService, stationId);
+
+        return {
+          reference: input.reference,
+          detail: station ? toStationAiDetail(station) : null,
+        };
+      },
+    }),
+    searchStations: tool({
+      description: "Search stations by name first, then by address if needed. Use this when the user mentions a station by words instead of station id.",
+      inputSchema: StationSearchInputSchema,
+      outputSchema: StationSearchToolOutputSchema,
+      execute: async (input): Promise<z.infer<typeof StationSearchToolOutputSchema>> => {
+        const byName = await Effect.runPromise(
+          args.stationQueryService.listStations(
+            { name: input.query },
+            { ...stationToolPage, pageSize: input.limit },
+          ),
+        );
+
+        if (byName.items.length > 0) {
+          return {
+            query: input.query,
+            stations: byName.items.map(toStationAiDetail),
+          };
+        }
+
+        const byAddress = await Effect.runPromise(
+          args.stationQueryService.listStations(
+            { address: input.query },
+            { ...stationToolPage, pageSize: input.limit },
+          ),
+        );
+
+        return {
+          query: input.query,
+          stations: byAddress.items.map(toStationAiDetail),
+        };
+      },
+    }),
+    getNearbyStationsFromLocation: tool({
+      description: "Get stations near the user's live location when location context is available. Use this for requests like nearest station near me or stations close to my current position.",
+      inputSchema: NearbyStationsFromLocationInputSchema,
+      outputSchema: NearbyStationsFromLocationToolOutputSchema,
+      execute: async (input): Promise<z.infer<typeof NearbyStationsFromLocationToolOutputSchema>> => {
+        const location = args.context?.location ?? null;
+
+        if (!location) {
+          return {
+            hasLocation: false,
+            origin: null,
+            stations: [],
+          };
+        }
+
+        const nearby = await Effect.runPromise(
+          args.stationQueryService.listNearestStations({
+            latitude: location.latitude,
+            longitude: location.longitude,
+            maxDistanceMeters: input.maxDistanceMeters,
+            page: 1,
+            pageSize: input.limit,
+          }),
+        );
+
+        return {
+          hasLocation: true,
+          origin: location,
+          stations: nearby.items.map(toNearbyStationAiDetail),
+        };
+      },
+    }),
+    getNearbyStations: tool({
+      description: "Get nearby stations around a known station context. Use this for alternative pickup or return suggestions.",
+      inputSchema: NearbyStationsInputSchema,
+      outputSchema: NearbyStationsToolOutputSchema,
+      execute: async (input): Promise<z.infer<typeof NearbyStationsToolOutputSchema>> => {
+        let stationId = input.stationId ?? null;
+
+        if (!stationId && input.reference === "context") {
+          stationId = args.context?.stationId ?? null;
+        }
+
+        if (!stationId) {
+          return {
+            reference: input.reference,
+            originStationId: null,
+            stations: [],
+          };
+        }
+
+        const originStation = await getStationByIdOrNull(args.stationQueryService, stationId);
+
+        if (!originStation) {
+          return {
+            reference: input.reference,
+            originStationId: stationId,
+            stations: [],
+          };
+        }
+
+        const nearby = await Effect.runPromise(
+          args.stationQueryService.listNearestStations({
+            latitude: originStation.latitude,
+            longitude: originStation.longitude,
+            maxDistanceMeters: input.maxDistanceMeters,
+            page: 1,
+            pageSize: input.limit + 1,
+          }),
+        );
+
+        return {
+          reference: input.reference,
+          originStationId: stationId,
+          stations: nearby.items
+            .filter(station => station.id !== stationId)
+            .slice(0, input.limit)
+            .map(toNearbyStationAiDetail),
+        };
+      },
+    }),
+    getStationAvailableBikes: tool({
+      description: "Get currently available bikes at one station. Prefer current station context when possible.",
+      inputSchema: StationAvailableBikesInputSchema,
+      outputSchema: StationAvailableBikesToolOutputSchema,
+      execute: async (input): Promise<z.infer<typeof StationAvailableBikesToolOutputSchema>> => {
+        let stationId = input.stationId ?? null;
+
+        if (!stationId && input.reference === "context") {
+          stationId = args.context?.stationId ?? null;
+        }
+
+        if (!stationId) {
+          return {
+            reference: input.reference,
+            stationId: null,
+            availableBikeCount: 0,
+            bikes: [],
+          };
+        }
+
+        const availableBikes = await Effect.runPromise(
+          args.bikeService.listBikes(
+            { stationId, status: "AVAILABLE" },
+            { ...bikeToolPage, pageSize: input.limit },
+          ),
+        );
+
+        return {
+          reference: input.reference,
+          stationId,
+          availableBikeCount: availableBikes.total,
+          bikes: availableBikes.items.map(toBikeAiDetail),
+        };
+      },
+    }),
+  } as const;
+}

--- a/apps/server/src/domain/ai/tools/customer-tool-helpers.ts
+++ b/apps/server/src/domain/ai/tools/customer-tool-helpers.ts
@@ -1,0 +1,302 @@
+import type { AiChatContext } from "@mebike/shared";
+
+import { Effect, Either, Option } from "effect";
+import { z } from "zod";
+
+import type { BikeRow, BikeService } from "@/domain/bikes";
+import type { RentalCommandService, RentalService } from "@/domain/rentals";
+import type { ReservationQueryService } from "@/domain/reservations";
+import type { StationQueryService } from "@/domain/stations";
+import type { WalletService } from "@/domain/wallets/services/wallet.service";
+
+import { requiredAvailableBikesForReservation, stationCanAcceptReservation } from "@/domain/reservations/services/reservation-availability-rule";
+import { toContractNearbyStation, toContractStationReadSummary } from "@/http/presenters/stations.presenter";
+
+export type CreateCustomerToolsArgs = {
+  readonly bikeService: BikeService;
+  readonly context: AiChatContext | null;
+  readonly rentalCommandService: RentalCommandService;
+  readonly reservationQueryService: ReservationQueryService;
+  readonly rentalService: RentalService;
+  readonly stationQueryService: StationQueryService;
+  readonly userId: string;
+  readonly walletService: WalletService;
+};
+
+export type CustomerToolName
+  = | "getCurrentRentalSummary"
+    | "getCurrentReturnSlot"
+    | "getRentalDetail"
+    | "getReservationSummary"
+    | "getReservationDetail"
+    | "getStationDetail"
+    | "searchStations"
+    | "getNearbyStationsFromLocation"
+    | "getNearbyStations"
+    | "getStationAvailableBikes"
+    | "getBikeDetail"
+    | "getWalletSummary"
+    | "getWalletTransactionDetail";
+
+export const RentalDetailInputSchema = z.object({
+  rentalId: z.string().optional(),
+  reference: z.enum(["context", "current", "latest", "id"]).default("context"),
+});
+
+export const ReservationDetailInputSchema = z.object({
+  reservationId: z.string().optional(),
+  reference: z.enum(["context", "latestPendingOrActive", "id"]).default("context"),
+});
+
+export const WalletTransactionDetailInputSchema = z.object({
+  transactionId: z.string().optional(),
+  reference: z.enum(["latest", "id"]).default("latest"),
+});
+
+export const StationReferenceSchema = z.enum(["context", "id"]);
+
+export const StationDetailInputSchema = z.object({
+  stationId: z.string().optional(),
+  reference: StationReferenceSchema.default("context"),
+});
+
+export const StationSearchInputSchema = z.object({
+  query: z.string().trim().min(1),
+  limit: z.number().int().min(1).max(10).default(5),
+});
+
+export const NearbyStationsInputSchema = z.object({
+  stationId: z.string().optional(),
+  reference: StationReferenceSchema.default("context"),
+  limit: z.number().int().min(1).max(10).default(5),
+  maxDistanceMeters: z.number().int().positive().max(50000).optional(),
+});
+
+export const NearbyStationsFromLocationInputSchema = z.object({
+  limit: z.number().int().min(1).max(10).default(5),
+  maxDistanceMeters: z.number().int().positive().max(50000).optional(),
+});
+
+export const StationAvailableBikesInputSchema = z.object({
+  stationId: z.string().optional(),
+  reference: StationReferenceSchema.default("context"),
+  limit: z.number().int().min(1).max(10).default(5),
+});
+
+export const BikeDetailInputSchema = z.object({
+  bikeId: z.string().optional(),
+  reference: z.enum(["context", "id"]).default("context"),
+});
+
+export const rentalToolPage = {
+  page: 1,
+  pageSize: 5,
+  sortBy: "updatedAt",
+  sortDir: "desc",
+} as const;
+
+export const stationToolPage = {
+  page: 1,
+  pageSize: 5,
+  sortBy: "name",
+  sortDir: "asc",
+} as const;
+
+export const bikeToolPage = {
+  page: 1,
+  pageSize: 5,
+  sortBy: "status",
+  sortDir: "asc",
+} as const;
+
+const rentalStatusLabels = {
+  CANCELLED: "Đã hủy",
+  COMPLETED: "Đã hoàn thành",
+  RENTED: "Đang hoạt động",
+} as const;
+
+const reservationStatusLabels = {
+  CANCELLED: "Đã hủy",
+  EXPIRED: "Hết hạn",
+  FULFILLED: "Đã hoàn thành",
+  PENDING: "Đang chờ xử lý",
+} as const;
+
+const bikeStatusLabels = {
+  AVAILABLE: "Có sẵn",
+  BOOKED: "Đang được thuê",
+  BROKEN: "Bị hỏng",
+  MAINTAINED: "Đang bảo trì",
+  RESERVED: "Đã đặt trước",
+  UNAVAILABLE: "Không có sẵn",
+} as const;
+
+const bikeRentabilityLabels = {
+  AVAILABLE: "Sẵn sàng để thuê",
+  BOOKED: "Đang được thuê",
+  BROKEN: "Không nên sử dụng vì xe đang hỏng",
+  MAINTAINED: "Không nên sử dụng vì xe đang bảo trì",
+  NO_STATION: "Không thể thuê vì xe không ở trạm nào",
+  RESERVED: "Không sẵn sàng để thuê vì xe đã được đặt trước",
+  UNAVAILABLE: "Không sẵn sàng để thuê",
+} as const;
+
+const returnSlotStatusLabels = {
+  ACTIVE: "Đang giữ chỗ",
+  CANCELLED: "Đã hủy",
+  USED: "Đã sử dụng",
+} as const;
+
+export function formatMinorVnd(value: bigint | number | null): string | null {
+  if (value === null) {
+    return null;
+  }
+
+  const numeric = typeof value === "bigint" ? Number(value) : value;
+  return `${new Intl.NumberFormat("vi-VN").format(numeric)} VND`;
+}
+
+export function toStationAiDetail(station: Parameters<typeof toContractStationReadSummary>[0]) {
+  return {
+    ...toContractStationReadSummary(station),
+    reservationPolicy: {
+      canAcceptNewReservation: stationCanAcceptReservation({
+        totalCapacity: station.totalCapacity,
+        availableBikes: station.availableBikes,
+      }),
+      requiredAvailableBikes: requiredAvailableBikesForReservation(station.totalCapacity),
+    },
+  };
+}
+
+export function toNearbyStationAiDetail(station: Parameters<typeof toContractNearbyStation>[0]) {
+  return {
+    ...toContractNearbyStation(station),
+    reservationPolicy: {
+      canAcceptNewReservation: stationCanAcceptReservation({
+        totalCapacity: station.totalCapacity,
+        availableBikes: station.availableBikes,
+      }),
+      requiredAvailableBikes: requiredAvailableBikesForReservation(station.totalCapacity),
+    },
+  };
+}
+
+export function getRentalStatusLabel(status: keyof typeof rentalStatusLabels) {
+  return rentalStatusLabels[status];
+}
+
+export function getReservationStatusLabel(status: keyof typeof reservationStatusLabels) {
+  return reservationStatusLabels[status];
+}
+
+export function getBikeStatusLabel(status: keyof typeof bikeStatusLabels) {
+  return bikeStatusLabels[status];
+}
+
+export function getReturnSlotStatusLabel(status: keyof typeof returnSlotStatusLabels) {
+  return returnSlotStatusLabels[status];
+}
+
+function getBikeRentabilityReason(bike: {
+  stationId: BikeRow["stationId"];
+  status: BikeRow["status"];
+}) {
+  if (!bike.stationId) {
+    return "NO_STATION" as const;
+  }
+
+  switch (bike.status) {
+    case "AVAILABLE":
+      return "AVAILABLE" as const;
+    case "BOOKED":
+      return "BOOKED" as const;
+    case "RESERVED":
+      return "RESERVED" as const;
+    case "BROKEN":
+      return "BROKEN" as const;
+    case "MAINTAINED":
+      return "MAINTAINED" as const;
+    default:
+      return "UNAVAILABLE" as const;
+  }
+}
+
+export function toBikeAiDetail(bike: {
+  id: BikeRow["id"];
+  bikeNumber: BikeRow["bikeNumber"];
+  stationId: BikeRow["stationId"];
+  status: BikeRow["status"];
+  createdAt: BikeRow["createdAt"];
+  updatedAt: BikeRow["updatedAt"];
+}) {
+  const rentabilityReason = getBikeRentabilityReason(bike);
+
+  return {
+    id: bike.id,
+    bikeNumber: bike.bikeNumber,
+    stationId: bike.stationId,
+    status: bike.status,
+    statusLabel: getBikeStatusLabel(bike.status),
+    isRentable: rentabilityReason === "AVAILABLE",
+    rentabilityReason,
+    rentabilityLabel: bikeRentabilityLabels[rentabilityReason],
+    createdAt: bike.createdAt.toISOString(),
+    updatedAt: bike.updatedAt.toISOString(),
+  };
+}
+
+export async function getStationByIdOrNull(
+  stationQueryService: StationQueryService,
+  stationId: string,
+) {
+  const station = await Effect.runPromise(
+    stationQueryService.getStationById(stationId).pipe(Effect.either),
+  );
+
+  return Either.isRight(station) ? station.right : null;
+}
+
+export async function resolveRentalReference(args: {
+  context: AiChatContext | null;
+  rentalId?: string | null;
+  reference: "context" | "current" | "latest" | "id";
+  rentalService: RentalService;
+  userId: string;
+}) {
+  let rentalId = args.rentalId ?? null;
+
+  if (!rentalId && args.reference === "context") {
+    rentalId = args.context?.rentalId ?? null;
+  }
+
+  if (!rentalId && args.reference === "current") {
+    const rentals = await Effect.runPromise(
+      args.rentalService.listMyCurrentRentals(args.userId, {
+        ...rentalToolPage,
+        pageSize: 1,
+      }),
+    );
+    rentalId = rentals.items[0]?.id ?? null;
+  }
+
+  if (!rentalId && args.reference === "latest") {
+    const rentals = await Effect.runPromise(
+      args.rentalService.listMyRentals(args.userId, {}, {
+        ...rentalToolPage,
+        pageSize: 1,
+      }),
+    );
+    rentalId = rentals.items[0]?.id ?? null;
+  }
+
+  if (!rentalId) {
+    return null;
+  }
+
+  const rental = await Effect.runPromise(
+    args.rentalService.getMyRentalById(args.userId, rentalId),
+  );
+
+  return Option.isSome(rental) ? rental.value : null;
+}

--- a/apps/server/src/domain/ai/tools/customer-tool-helpers.ts
+++ b/apps/server/src/domain/ai/tools/customer-tool-helpers.ts
@@ -4,7 +4,7 @@ import { Effect, Either, Option } from "effect";
 import { z } from "zod";
 
 import type { BikeRow, BikeService } from "@/domain/bikes";
-import type { RentalCommandService, RentalService } from "@/domain/rentals";
+import type { RentalCommandService, RentalService, ReturnSlotRow } from "@/domain/rentals";
 import type { ReservationQueryService } from "@/domain/reservations";
 import type { StationQueryService } from "@/domain/stations";
 import type { WalletService } from "@/domain/wallets/services/wallet.service";
@@ -26,6 +26,9 @@ export type CreateCustomerToolsArgs = {
 export type CustomerToolName
   = | "getCurrentRentalSummary"
     | "getCurrentReturnSlot"
+    | "createReturnSlot"
+    | "switchReturnSlot"
+    | "cancelReturnSlot"
     | "getRentalDetail"
     | "getReservationSummary"
     | "getReservationDetail"
@@ -156,6 +159,30 @@ export function formatMinorVnd(value: bigint | number | null): string | null {
   return `${new Intl.NumberFormat("vi-VN").format(numeric)} VND`;
 }
 
+const AI_TIME_ZONE = "Asia/Ho_Chi_Minh";
+
+export function formatLocalDateTime(value: Date | string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const date = value instanceof Date ? value : new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return date.toLocaleString("vi-VN", {
+    day: "2-digit",
+    hour: "2-digit",
+    hour12: false,
+    minute: "2-digit",
+    month: "2-digit",
+    timeZone: AI_TIME_ZONE,
+    year: "numeric",
+  });
+}
+
 export function toStationAiDetail(station: Parameters<typeof toContractStationReadSummary>[0]) {
   return {
     ...toContractStationReadSummary(station),
@@ -198,6 +225,27 @@ export function getReturnSlotStatusLabel(status: keyof typeof returnSlotStatusLa
   return returnSlotStatusLabels[status];
 }
 
+export function toReturnSlotAiDetail(
+  returnSlot: ReturnSlotRow,
+  station: { id: string; name: string; address: string } | null,
+) {
+  return {
+    id: returnSlot.id,
+    rentalId: returnSlot.rentalId,
+    userId: returnSlot.userId,
+    stationId: returnSlot.stationId,
+    reservedFrom: returnSlot.reservedFrom.toISOString(),
+    reservedFromDisplay: formatLocalDateTime(returnSlot.reservedFrom),
+    status: returnSlot.status,
+    statusLabel: getReturnSlotStatusLabel(returnSlot.status),
+    createdAt: returnSlot.createdAt.toISOString(),
+    createdAtDisplay: formatLocalDateTime(returnSlot.createdAt),
+    updatedAt: returnSlot.updatedAt.toISOString(),
+    updatedAtDisplay: formatLocalDateTime(returnSlot.updatedAt),
+    station,
+  };
+}
+
 function getBikeRentabilityReason(bike: {
   stationId: BikeRow["stationId"];
   status: BikeRow["status"];
@@ -233,6 +281,7 @@ export function toBikeAiDetail(bike: {
   const rentabilityReason = getBikeRentabilityReason(bike);
 
   return {
+    createdAtDisplay: formatLocalDateTime(bike.createdAt),
     id: bike.id,
     bikeNumber: bike.bikeNumber,
     stationId: bike.stationId,
@@ -242,6 +291,7 @@ export function toBikeAiDetail(bike: {
     rentabilityReason,
     rentabilityLabel: bikeRentabilityLabels[rentabilityReason],
     createdAt: bike.createdAt.toISOString(),
+    updatedAtDisplay: formatLocalDateTime(bike.updatedAt),
     updatedAt: bike.updatedAt.toISOString(),
   };
 }

--- a/apps/server/src/domain/ai/tools/customer-tool-schemas.ts
+++ b/apps/server/src/domain/ai/tools/customer-tool-schemas.ts
@@ -1,28 +1,35 @@
 import {
+  BikesContracts,
   RentalCountsResponseSchema,
   RentalSchema,
+  RentalsContracts,
   ReservationDetailSchema,
   ReservationExpandedDetailSchema,
+  StationsContracts,
   WalletDetailSchema,
   WalletTransactionDetailSchema,
 } from "@mebike/shared";
 import { z } from "zod";
 
 const RentalSummaryItemSchema = RentalSchema.extend({
+  statusLabel: z.string(),
   totalPriceDisplay: z.string().nullable(),
 }).strict();
 
 const ReservationSummaryItemSchema = ReservationDetailSchema.extend({
   prepaidDisplay: z.string().nullable(),
+  statusLabel: z.string(),
 }).strict();
 
 const RentalDetailSchema = RentalSchema.extend({
-  totalPriceDisplay: z.string().nullable(),
   depositAmountDisplay: z.string().nullable(),
+  statusLabel: z.string(),
+  totalPriceDisplay: z.string().nullable(),
 }).strict();
 
 const ReservationExpandedDetailToolSchema = ReservationExpandedDetailSchema.extend({
   prepaidDisplay: z.string().nullable(),
+  statusLabel: z.string(),
 }).strict();
 
 const WalletSummarySchema = WalletDetailSchema.extend({
@@ -41,9 +48,64 @@ const WalletTransactionDetailToolSchema = WalletTransactionDetailSchema.extend({
   feeDisplay: z.string().nullable(),
 }).strict();
 
+const StationReservationPolicySchema = z.object({
+  canAcceptNewReservation: z.boolean(),
+  requiredAvailableBikes: z.number().int().nonnegative(),
+}).strict();
+
+const StationAiDetailSchema = StationsContracts.StationReadSummarySchema.extend({
+  reservationPolicy: StationReservationPolicySchema,
+}).strict();
+
+const NearbyStationAiSchema = StationsContracts.NearbyStationSchema.extend({
+  reservationPolicy: StationReservationPolicySchema,
+}).strict();
+
+const LocationOriginSchema = z.object({
+  latitude: z.number(),
+  longitude: z.number(),
+}).strict();
+
+const BikeRentabilityReasonSchema = z.enum([
+  "AVAILABLE",
+  "BOOKED",
+  "RESERVED",
+  "BROKEN",
+  "MAINTAINED",
+  "UNAVAILABLE",
+  "NO_STATION",
+]);
+
+const BikeAiDetailSchema = z.object({
+  id: z.string().uuid(),
+  bikeNumber: z.string(),
+  stationId: z.string().uuid().nullable(),
+  status: BikesContracts.BikeStatusSchema,
+  statusLabel: z.string(),
+  isRentable: z.boolean(),
+  rentabilityReason: BikeRentabilityReasonSchema,
+  rentabilityLabel: z.string(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+}).strict();
+
+const ReturnSlotAiStationSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  address: z.string(),
+}).strict();
+
+const ReturnSlotAiDetailSchema = RentalsContracts.ReturnSlotReservationSchema.extend({
+  statusLabel: z.string(),
+  station: ReturnSlotAiStationSchema.nullable(),
+}).strict();
+
 const RentalDetailReferenceSchema = z.enum(["context", "current", "latest", "id"]);
 const ReservationDetailReferenceSchema = z.enum(["context", "latestPendingOrActive", "id"]);
 const WalletTransactionDetailReferenceSchema = z.enum(["latest", "id"]);
+const StationDetailReferenceSchema = z.enum(["context", "id"]);
+const BikeDetailReferenceSchema = z.enum(["context", "id"]);
+const ReturnSlotReferenceSchema = z.enum(["context", "current", "latest", "id"]);
 
 export const CurrentRentalSummaryToolOutputSchema = z.object({
   activeRentalCount: z.number().int().nonnegative(),
@@ -62,9 +124,45 @@ export const WalletSummaryToolOutputSchema = z.object({
   recentTransactions: z.array(WalletTransactionSummarySchema),
 }).strict();
 
+export const StationDetailToolOutputSchema = z.object({
+  reference: StationDetailReferenceSchema,
+  detail: StationAiDetailSchema.nullable(),
+}).strict();
+
+export const StationSearchToolOutputSchema = z.object({
+  query: z.string(),
+  stations: z.array(StationAiDetailSchema),
+}).strict();
+
+export const NearbyStationsToolOutputSchema = z.object({
+  reference: StationDetailReferenceSchema,
+  originStationId: z.string().uuid().nullable(),
+  stations: z.array(NearbyStationAiSchema),
+}).strict();
+
+export const NearbyStationsFromLocationToolOutputSchema = z.object({
+  hasLocation: z.boolean(),
+  origin: LocationOriginSchema.nullable(),
+  stations: z.array(NearbyStationAiSchema),
+}).strict();
+
+export const StationAvailableBikesToolOutputSchema = z.object({
+  reference: StationDetailReferenceSchema,
+  stationId: z.string().uuid().nullable(),
+  availableBikeCount: z.number().int().nonnegative(),
+  bikes: z.array(BikeAiDetailSchema),
+}).strict();
+
 export const RentalDetailToolOutputSchema = z.object({
   reference: RentalDetailReferenceSchema,
   detail: RentalDetailSchema.nullable(),
+}).strict();
+
+export const CurrentReturnSlotToolOutputSchema = z.object({
+  reference: ReturnSlotReferenceSchema,
+  hasActiveRental: z.boolean(),
+  rentalId: z.string().uuid().nullable(),
+  returnSlot: ReturnSlotAiDetailSchema.nullable(),
 }).strict();
 
 export const ReservationDetailToolOutputSchema = z.object({
@@ -75,4 +173,9 @@ export const ReservationDetailToolOutputSchema = z.object({
 export const WalletTransactionDetailToolOutputSchema = z.object({
   reference: WalletTransactionDetailReferenceSchema,
   detail: WalletTransactionDetailToolSchema.nullable(),
+}).strict();
+
+export const BikeDetailToolOutputSchema = z.object({
+  reference: BikeDetailReferenceSchema,
+  detail: BikeAiDetailSchema.nullable(),
 }).strict();

--- a/apps/server/src/domain/ai/tools/customer-tool-schemas.ts
+++ b/apps/server/src/domain/ai/tools/customer-tool-schemas.ts
@@ -12,39 +12,57 @@ import {
 import { z } from "zod";
 
 const RentalSummaryItemSchema = RentalSchema.extend({
+  endTimeDisplay: z.string().nullable().optional(),
+  startTimeDisplay: z.string().nullable(),
   statusLabel: z.string(),
   totalPriceDisplay: z.string().nullable(),
+  updatedAtDisplay: z.string().nullable(),
 }).strict();
 
 const ReservationSummaryItemSchema = ReservationDetailSchema.extend({
+  createdAtDisplay: z.string().nullable(),
+  endTimeDisplay: z.string().nullable().optional(),
   prepaidDisplay: z.string().nullable(),
+  startTimeDisplay: z.string().nullable(),
   statusLabel: z.string(),
+  updatedAtDisplay: z.string().nullable(),
 }).strict();
 
 const RentalDetailSchema = RentalSchema.extend({
   depositAmountDisplay: z.string().nullable(),
+  endTimeDisplay: z.string().nullable().optional(),
+  startTimeDisplay: z.string().nullable(),
   statusLabel: z.string(),
   totalPriceDisplay: z.string().nullable(),
+  updatedAtDisplay: z.string().nullable(),
 }).strict();
 
 const ReservationExpandedDetailToolSchema = ReservationExpandedDetailSchema.extend({
+  createdAtDisplay: z.string().nullable(),
+  endTimeDisplay: z.string().nullable().optional(),
   prepaidDisplay: z.string().nullable(),
+  startTimeDisplay: z.string().nullable(),
   statusLabel: z.string(),
+  updatedAtDisplay: z.string().nullable(),
 }).strict();
 
 const WalletSummarySchema = WalletDetailSchema.extend({
   balanceDisplay: z.string().nullable(),
   availableBalanceDisplay: z.string().nullable(),
+  createdAtDisplay: z.string().nullable(),
   reservedBalanceDisplay: z.string().nullable(),
+  updatedAtDisplay: z.string().nullable(),
 }).strict();
 
 const WalletTransactionSummarySchema = WalletTransactionDetailSchema.extend({
   amountDisplay: z.string().nullable(),
+  createdAtDisplay: z.string().nullable(),
   feeDisplay: z.string().nullable(),
 }).strict();
 
 const WalletTransactionDetailToolSchema = WalletTransactionDetailSchema.extend({
   amountDisplay: z.string().nullable(),
+  createdAtDisplay: z.string().nullable(),
   feeDisplay: z.string().nullable(),
 }).strict();
 
@@ -77,6 +95,7 @@ const BikeRentabilityReasonSchema = z.enum([
 ]);
 
 const BikeAiDetailSchema = z.object({
+  createdAtDisplay: z.string().nullable(),
   id: z.string().uuid(),
   bikeNumber: z.string(),
   stationId: z.string().uuid().nullable(),
@@ -86,6 +105,7 @@ const BikeAiDetailSchema = z.object({
   rentabilityReason: BikeRentabilityReasonSchema,
   rentabilityLabel: z.string(),
   createdAt: z.string().datetime(),
+  updatedAtDisplay: z.string().nullable(),
   updatedAt: z.string().datetime(),
 }).strict();
 
@@ -96,8 +116,54 @@ const ReturnSlotAiStationSchema = z.object({
 }).strict();
 
 const ReturnSlotAiDetailSchema = RentalsContracts.ReturnSlotReservationSchema.extend({
+  createdAtDisplay: z.string().nullable(),
+  reservedFromDisplay: z.string().nullable(),
   statusLabel: z.string(),
   station: ReturnSlotAiStationSchema.nullable(),
+  updatedAtDisplay: z.string().nullable(),
+}).strict();
+
+const ReturnSlotActionFailureCodeSchema = z.enum([
+  "INVALID_RENTAL_ID",
+  "INVALID_STATION_ID",
+  "MISSING_STATION_CONTEXT",
+  "NO_ACTIVE_RENTAL",
+  "STATION_NOT_FOUND",
+  "RETURN_CAPACITY_UNAVAILABLE",
+  "RETURN_SLOT_NOT_FOUND",
+  "TEMPORARY_UNAVAILABLE",
+]);
+
+const ReturnSlotActionFailureKindSchema = z.enum([
+  "validation",
+  "business",
+  "temporary",
+]);
+
+const ReturnSlotActionSuggestedActionSchema = z.enum([
+  "check_current_rental",
+  "choose_station_again",
+  "search_stations",
+  "choose_another_station",
+  "check_current_return_slot",
+  "retry_later",
+]);
+
+const ReturnSlotActionFailureSchema = z.object({
+  ok: z.literal(false),
+  error: z.object({
+    code: ReturnSlotActionFailureCodeSchema,
+    kind: ReturnSlotActionFailureKindSchema,
+    retryable: z.boolean(),
+    suggestedAction: ReturnSlotActionSuggestedActionSchema,
+    userMessage: z.string(),
+  }).strict(),
+}).strict();
+
+const ReturnSlotActionSuccessSchema = z.object({
+  ok: z.literal(true),
+  rentalId: z.string().uuid(),
+  returnSlot: ReturnSlotAiDetailSchema,
 }).strict();
 
 const RentalDetailReferenceSchema = z.enum(["context", "current", "latest", "id"]);
@@ -164,6 +230,20 @@ export const CurrentReturnSlotToolOutputSchema = z.object({
   rentalId: z.string().uuid().nullable(),
   returnSlot: ReturnSlotAiDetailSchema.nullable(),
 }).strict();
+
+export const CreateReturnSlotToolOutputSchema = z.object({
+  ok: z.literal(true),
+  rentalId: z.string().uuid(),
+  returnSlot: ReturnSlotAiDetailSchema,
+}).strict().or(ReturnSlotActionFailureSchema);
+
+export const CancelReturnSlotToolOutputSchema = z.object({
+  ok: z.literal(true),
+  rentalId: z.string().uuid(),
+  returnSlot: ReturnSlotAiDetailSchema,
+}).strict().or(ReturnSlotActionFailureSchema);
+
+export const SwitchReturnSlotToolOutputSchema = ReturnSlotActionSuccessSchema.or(ReturnSlotActionFailureSchema);
 
 export const ReservationDetailToolOutputSchema = z.object({
   reference: ReservationDetailReferenceSchema,

--- a/apps/server/src/domain/ai/tools/customer-tools.ts
+++ b/apps/server/src/domain/ai/tools/customer-tools.ts
@@ -1,95 +1,56 @@
 import type { AiChatContext } from "@mebike/shared";
 
-import { tool } from "ai";
-import { Effect, Either, Option } from "effect";
-import { z } from "zod";
+import type { CreateCustomerToolsArgs, CustomerToolName } from "./customer-tool-helpers";
 
-import type { RentalService } from "@/domain/rentals";
-import type { ReservationQueryService } from "@/domain/reservations";
-import type { WalletService } from "@/domain/wallets/services/wallet.service";
+import { createCustomerBikeTools } from "./customer-bike-tools";
+import { createCustomerRentalTools } from "./customer-rental-tools";
+import { createCustomerReservationTools } from "./customer-reservation-tools";
+import { createCustomerStationTools } from "./customer-station-tools";
+import { createCustomerWalletTools } from "./customer-wallet-tools";
 
-import { toContractRental } from "@/http/presenters/rentals.presenter";
-import {
-  toContractReservation,
-  toContractReservationExpanded,
-} from "@/http/presenters/reservations.presenter";
-import {
-  toWalletDetail,
-  toWalletTransactionDetail,
-} from "@/http/presenters/wallets.presenter";
+const stationTools = [
+  "getStationDetail",
+  "searchStations",
+  "getNearbyStations",
+  "getStationAvailableBikes",
+] as const satisfies readonly CustomerToolName[];
 
-import {
-  CurrentRentalSummaryToolOutputSchema,
-  RentalDetailToolOutputSchema,
-  ReservationDetailToolOutputSchema,
-  ReservationSummaryToolOutputSchema,
-  WalletSummaryToolOutputSchema,
-  WalletTransactionDetailToolOutputSchema,
-} from "./customer-tool-schemas";
+const bikeTools = [
+  "getBikeDetail",
+] as const satisfies readonly CustomerToolName[];
 
-type CreateCustomerToolsArgs = {
-  readonly context: AiChatContext | null;
-  readonly reservationQueryService: ReservationQueryService;
-  readonly rentalService: RentalService;
-  readonly userId: string;
-  readonly walletService: WalletService;
-};
+const returnSlotTools = [
+  "getCurrentReturnSlot",
+] as const satisfies readonly CustomerToolName[];
 
-export type CustomerToolName
-  = | "getCurrentRentalSummary"
-    | "getRentalDetail"
-    | "getReservationSummary"
-    | "getReservationDetail"
-    | "getWalletSummary"
-    | "getWalletTransactionDetail";
-
-const RentalDetailInputSchema = z.object({
-  rentalId: z.string().optional(),
-  reference: z.enum(["context", "current", "latest", "id"]).default("context"),
-});
-
-const ReservationDetailInputSchema = z.object({
-  reservationId: z.string().optional(),
-  reference: z.enum(["context", "latestPendingOrActive", "id"]).default("context"),
-});
-
-const WalletTransactionDetailInputSchema = z.object({
-  transactionId: z.string().optional(),
-  reference: z.enum(["latest", "id"]).default("latest"),
-});
-
-const rentalToolPage = {
-  page: 1,
-  pageSize: 5,
-  sortBy: "updatedAt",
-  sortDir: "desc",
-} as const;
-
-function formatMinorVnd(value: bigint | number | null): string | null {
-  if (value === null) {
-    return null;
-  }
-
-  const numeric = typeof value === "bigint" ? Number(value) : value;
-  return `${new Intl.NumberFormat("vi-VN").format(numeric)} VND`;
-}
+const locationTools = [
+  "getNearbyStationsFromLocation",
+] as const satisfies readonly CustomerToolName[];
 
 export function getActiveCustomerTools(
   screen: AiChatContext["screen"] | null | undefined,
 ): CustomerToolName[] {
   switch (screen) {
     case "rental":
-      return ["getCurrentRentalSummary", "getRentalDetail"];
+      return ["getCurrentRentalSummary", ...returnSlotTools, "getRentalDetail", ...locationTools, ...stationTools, ...bikeTools];
     case "reservation":
-      return ["getReservationSummary", "getReservationDetail"];
+      return ["getReservationSummary", "getReservationDetail", ...locationTools, ...stationTools, ...bikeTools];
+    case "station":
+      return [...returnSlotTools, ...locationTools, ...stationTools, ...bikeTools];
+    case "bike":
+      return [...bikeTools, ...locationTools, ...stationTools];
     case "wallet":
-      return ["getWalletSummary", "getWalletTransactionDetail"];
+      return ["getWalletSummary", "getWalletTransactionDetail", ...locationTools, ...stationTools];
     default:
       return [
         "getCurrentRentalSummary",
+        ...returnSlotTools,
         "getRentalDetail",
         "getReservationSummary",
         "getReservationDetail",
+        ...locationTools,
+        ...stationTools,
+        ...bikeTools,
         "getWalletSummary",
         "getWalletTransactionDetail",
       ];
@@ -98,244 +59,11 @@ export function getActiveCustomerTools(
 
 export function createCustomerTools(args: CreateCustomerToolsArgs) {
   return {
-    getCurrentRentalSummary: tool({
-      description: "Get the current user's active rental summary and rental counts.",
-      inputSchema: z.object({}),
-      outputSchema: CurrentRentalSummaryToolOutputSchema,
-      execute: async (): Promise<z.infer<typeof CurrentRentalSummaryToolOutputSchema>> => {
-        const [rentals, counts] = await Promise.all([
-          Effect.runPromise(
-            args.rentalService.listMyCurrentRentals(args.userId, rentalToolPage),
-          ),
-          Effect.runPromise(
-            args.rentalService.getMyRentalCounts(args.userId),
-          ),
-        ]);
-
-        return {
-          activeRentalCount: rentals.total,
-          counts,
-          rentals: rentals.items.map(rental => ({
-            ...toContractRental(rental),
-            totalPriceDisplay: formatMinorVnd(rental.totalPrice),
-          })),
-        };
-      },
-    }),
-    getRentalDetail: tool({
-      description: "Get one user-owned rental detail. Prefer current screen context or current or latest rental instead of raw ids unless an id is already available.",
-      inputSchema: RentalDetailInputSchema,
-      outputSchema: RentalDetailToolOutputSchema,
-      execute: async (input): Promise<z.infer<typeof RentalDetailToolOutputSchema>> => {
-        let rentalId = input.rentalId ?? null;
-
-        if (!rentalId && input.reference === "context") {
-          rentalId = args.context?.rentalId ?? null;
-        }
-
-        if (!rentalId && input.reference === "current") {
-          const rentals = await Effect.runPromise(
-            args.rentalService.listMyCurrentRentals(args.userId, {
-              ...rentalToolPage,
-              pageSize: 1,
-            }),
-          );
-          rentalId = rentals.items[0]?.id ?? null;
-        }
-
-        if (!rentalId && input.reference === "latest") {
-          const rentals = await Effect.runPromise(
-            args.rentalService.listMyRentals(args.userId, {}, {
-              ...rentalToolPage,
-              pageSize: 1,
-            }),
-          );
-          rentalId = rentals.items[0]?.id ?? null;
-        }
-
-        if (!rentalId) {
-          return { reference: input.reference, detail: null };
-        }
-
-        const rental = await Effect.runPromise(
-          args.rentalService.getMyRentalById(args.userId, rentalId),
-        );
-
-        return {
-          reference: input.reference,
-          detail: Option.isSome(rental)
-            ? {
-                ...toContractRental(rental.value),
-                totalPriceDisplay: formatMinorVnd(rental.value.totalPrice),
-                depositAmountDisplay: formatMinorVnd(rental.value.depositAmount),
-              }
-            : null,
-        };
-      },
-    }),
-    getReservationSummary: tool({
-      description: "Get the current user's latest active or pending reservation plus recent reservation history.",
-      inputSchema: z.object({}),
-      outputSchema: ReservationSummaryToolOutputSchema,
-      execute: async (): Promise<z.infer<typeof ReservationSummaryToolOutputSchema>> => {
-        const [latestPendingOrActive, reservations] = await Promise.all([
-          Effect.runPromise(
-            args.reservationQueryService.getLatestPendingOrActiveForUser(args.userId),
-          ),
-          Effect.runPromise(
-            args.reservationQueryService.listForUser(
-              args.userId,
-              {},
-              rentalToolPage,
-            ),
-          ),
-        ]);
-
-        return {
-          latestPendingOrActive: Option.isSome(latestPendingOrActive)
-            ? {
-                ...toContractReservation(latestPendingOrActive.value),
-                prepaidDisplay: formatMinorVnd(Number(latestPendingOrActive.value.prepaid.toString())),
-              }
-            : null,
-          reservations: reservations.items.map(reservation => ({
-            ...toContractReservation(reservation),
-            prepaidDisplay: formatMinorVnd(Number(reservation.prepaid.toString())),
-          })),
-        };
-      },
-    }),
-    getReservationDetail: tool({
-      description: "Get one user-owned reservation detail. Prefer current screen context or the latest pending or active reservation before raw ids.",
-      inputSchema: ReservationDetailInputSchema,
-      outputSchema: ReservationDetailToolOutputSchema,
-      execute: async (input): Promise<z.infer<typeof ReservationDetailToolOutputSchema>> => {
-        let reservationId = input.reservationId ?? null;
-
-        if (!reservationId && input.reference === "context") {
-          reservationId = args.context?.reservationId ?? null;
-        }
-
-        if (!reservationId && input.reference === "latestPendingOrActive") {
-          const latest = await Effect.runPromise(
-            args.reservationQueryService.getLatestPendingOrActiveForUser(args.userId),
-          );
-          reservationId = Option.isSome(latest) ? latest.value.id : null;
-        }
-
-        if (!reservationId) {
-          return { reference: input.reference, detail: null };
-        }
-
-        const detail = await Effect.runPromise(
-          args.reservationQueryService.getExpandedDetailById(reservationId),
-        );
-
-        return {
-          reference: input.reference,
-          detail: Option.isSome(detail) && detail.value.user.id === args.userId
-            ? {
-                ...toContractReservationExpanded(detail.value),
-                prepaidDisplay: formatMinorVnd(Number(detail.value.prepaid.toString())),
-              }
-            : null,
-        };
-      },
-    }),
-    getWalletSummary: tool({
-      description: "Get the current user's wallet summary and recent wallet transactions.",
-      inputSchema: z.object({}),
-      outputSchema: WalletSummaryToolOutputSchema,
-      execute: async (): Promise<z.infer<typeof WalletSummaryToolOutputSchema>> => {
-        const walletResult = await Effect.runPromise(
-          args.walletService.getByUserId(args.userId).pipe(Effect.either),
-        );
-
-        if (Either.isLeft(walletResult)) {
-          return {
-            hasWallet: false,
-            wallet: null,
-            recentTransactions: [],
-          };
-        }
-
-        const wallet = walletResult.right;
-        const transactions = await Effect.runPromise(
-          args.walletService.listTransactionsForUser({
-            userId: args.userId,
-            pageReq: {
-              page: 1,
-              pageSize: 5,
-              sortBy: "createdAt",
-              sortDir: "desc",
-            },
-          }),
-        );
-
-        return {
-          hasWallet: true,
-          wallet: {
-            ...toWalletDetail(wallet),
-            balanceDisplay: formatMinorVnd(wallet.balance),
-            availableBalanceDisplay: formatMinorVnd(wallet.balance - wallet.reservedBalance),
-            reservedBalanceDisplay: formatMinorVnd(wallet.reservedBalance),
-          },
-          recentTransactions: transactions.items.map(transaction => ({
-            ...toWalletTransactionDetail(transaction),
-            amountDisplay: formatMinorVnd(transaction.amount),
-            feeDisplay: formatMinorVnd(transaction.fee),
-          })),
-        };
-      },
-    }),
-    getWalletTransactionDetail: tool({
-      description: "Get one wallet transaction detail. Prefer the latest transaction unless a known transaction id is already available from prior results.",
-      inputSchema: WalletTransactionDetailInputSchema,
-      outputSchema: WalletTransactionDetailToolOutputSchema,
-      execute: async (input): Promise<z.infer<typeof WalletTransactionDetailToolOutputSchema>> => {
-        let transactionId = input.transactionId ?? null;
-
-        if (!transactionId && input.reference === "latest") {
-          const transactions = await Effect.runPromise(
-            args.walletService.listTransactionsForUser({
-              userId: args.userId,
-              pageReq: {
-                page: 1,
-                pageSize: 1,
-                sortBy: "createdAt",
-                sortDir: "desc",
-              },
-            }).pipe(Effect.either),
-          );
-
-          if (Either.isRight(transactions)) {
-            transactionId = transactions.right.items[0]?.id ?? null;
-          }
-        }
-
-        if (!transactionId) {
-          return { reference: input.reference, detail: null };
-        }
-
-        const transaction = await Effect.runPromise(
-          args.walletService.getTransactionByIdForUser({
-            userId: args.userId,
-            transactionId,
-          }).pipe(Effect.either),
-        );
-
-        return {
-          reference: input.reference,
-          detail: Either.isRight(transaction) && Option.isSome(transaction.right)
-            ? {
-                ...toWalletTransactionDetail(transaction.right.value),
-                amountDisplay: formatMinorVnd(transaction.right.value.amount),
-                feeDisplay: formatMinorVnd(transaction.right.value.fee),
-              }
-            : null,
-        };
-      },
-    }),
+    ...createCustomerRentalTools(args),
+    ...createCustomerReservationTools(args),
+    ...createCustomerStationTools(args),
+    ...createCustomerBikeTools(args),
+    ...createCustomerWalletTools(args),
   } as const;
 }
 

--- a/apps/server/src/domain/ai/tools/customer-tools.ts
+++ b/apps/server/src/domain/ai/tools/customer-tools.ts
@@ -23,6 +23,12 @@ const returnSlotTools = [
   "getCurrentReturnSlot",
 ] as const satisfies readonly CustomerToolName[];
 
+const returnSlotMutationTools = [
+  "createReturnSlot",
+  "switchReturnSlot",
+  "cancelReturnSlot",
+] as const satisfies readonly CustomerToolName[];
+
 const locationTools = [
   "getNearbyStationsFromLocation",
 ] as const satisfies readonly CustomerToolName[];
@@ -32,11 +38,11 @@ export function getActiveCustomerTools(
 ): CustomerToolName[] {
   switch (screen) {
     case "rental":
-      return ["getCurrentRentalSummary", ...returnSlotTools, "getRentalDetail", ...locationTools, ...stationTools, ...bikeTools];
+      return ["getCurrentRentalSummary", ...returnSlotTools, ...returnSlotMutationTools, "getRentalDetail", ...locationTools, ...stationTools, ...bikeTools];
     case "reservation":
       return ["getReservationSummary", "getReservationDetail", ...locationTools, ...stationTools, ...bikeTools];
     case "station":
-      return [...returnSlotTools, ...locationTools, ...stationTools, ...bikeTools];
+      return [...returnSlotTools, ...returnSlotMutationTools, ...locationTools, ...stationTools, ...bikeTools];
     case "bike":
       return [...bikeTools, ...locationTools, ...stationTools];
     case "wallet":
@@ -45,6 +51,7 @@ export function getActiveCustomerTools(
       return [
         "getCurrentRentalSummary",
         ...returnSlotTools,
+        ...returnSlotMutationTools,
         "getRentalDetail",
         "getReservationSummary",
         "getReservationDetail",

--- a/apps/server/src/domain/ai/tools/customer-wallet-tools.ts
+++ b/apps/server/src/domain/ai/tools/customer-wallet-tools.ts
@@ -10,7 +10,7 @@ import {
 import type { CreateCustomerToolsArgs } from "./customer-tool-helpers";
 
 import {
-
+  formatLocalDateTime,
   formatMinorVnd,
   WalletTransactionDetailInputSchema,
 } from "./customer-tool-helpers";
@@ -57,11 +57,14 @@ export function createCustomerWalletTools(args: CreateCustomerToolsArgs) {
             ...toWalletDetail(wallet),
             balanceDisplay: formatMinorVnd(wallet.balance),
             availableBalanceDisplay: formatMinorVnd(wallet.balance - wallet.reservedBalance),
+            createdAtDisplay: formatLocalDateTime(wallet.createdAt),
             reservedBalanceDisplay: formatMinorVnd(wallet.reservedBalance),
+            updatedAtDisplay: formatLocalDateTime(wallet.updatedAt),
           },
           recentTransactions: transactions.items.map(transaction => ({
             ...toWalletTransactionDetail(transaction),
             amountDisplay: formatMinorVnd(transaction.amount),
+            createdAtDisplay: formatLocalDateTime(transaction.createdAt),
             feeDisplay: formatMinorVnd(transaction.fee),
           })),
         };
@@ -109,6 +112,7 @@ export function createCustomerWalletTools(args: CreateCustomerToolsArgs) {
             ? {
                 ...toWalletTransactionDetail(transaction.right.value),
                 amountDisplay: formatMinorVnd(transaction.right.value.amount),
+                createdAtDisplay: formatLocalDateTime(transaction.right.value.createdAt),
                 feeDisplay: formatMinorVnd(transaction.right.value.fee),
               }
             : null,

--- a/apps/server/src/domain/ai/tools/customer-wallet-tools.ts
+++ b/apps/server/src/domain/ai/tools/customer-wallet-tools.ts
@@ -1,0 +1,119 @@
+import { tool } from "ai";
+import { Effect, Either, Option } from "effect";
+import { z } from "zod";
+
+import {
+  toWalletDetail,
+  toWalletTransactionDetail,
+} from "@/http/presenters/wallets.presenter";
+
+import type { CreateCustomerToolsArgs } from "./customer-tool-helpers";
+
+import {
+
+  formatMinorVnd,
+  WalletTransactionDetailInputSchema,
+} from "./customer-tool-helpers";
+import {
+  WalletSummaryToolOutputSchema,
+  WalletTransactionDetailToolOutputSchema,
+} from "./customer-tool-schemas";
+
+export function createCustomerWalletTools(args: CreateCustomerToolsArgs) {
+  return {
+    getWalletSummary: tool({
+      description: "Get the current user's wallet summary and recent wallet transactions.",
+      inputSchema: z.object({}),
+      outputSchema: WalletSummaryToolOutputSchema,
+      execute: async (): Promise<z.infer<typeof WalletSummaryToolOutputSchema>> => {
+        const walletResult = await Effect.runPromise(
+          args.walletService.getByUserId(args.userId).pipe(Effect.either),
+        );
+
+        if (Either.isLeft(walletResult)) {
+          return {
+            hasWallet: false,
+            wallet: null,
+            recentTransactions: [],
+          };
+        }
+
+        const wallet = walletResult.right;
+        const transactions = await Effect.runPromise(
+          args.walletService.listTransactionsForUser({
+            userId: args.userId,
+            pageReq: {
+              page: 1,
+              pageSize: 5,
+              sortBy: "createdAt",
+              sortDir: "desc",
+            },
+          }),
+        );
+
+        return {
+          hasWallet: true,
+          wallet: {
+            ...toWalletDetail(wallet),
+            balanceDisplay: formatMinorVnd(wallet.balance),
+            availableBalanceDisplay: formatMinorVnd(wallet.balance - wallet.reservedBalance),
+            reservedBalanceDisplay: formatMinorVnd(wallet.reservedBalance),
+          },
+          recentTransactions: transactions.items.map(transaction => ({
+            ...toWalletTransactionDetail(transaction),
+            amountDisplay: formatMinorVnd(transaction.amount),
+            feeDisplay: formatMinorVnd(transaction.fee),
+          })),
+        };
+      },
+    }),
+    getWalletTransactionDetail: tool({
+      description: "Get one wallet transaction detail. Prefer the latest transaction unless a known transaction id is already available from prior results.",
+      inputSchema: WalletTransactionDetailInputSchema,
+      outputSchema: WalletTransactionDetailToolOutputSchema,
+      execute: async (input): Promise<z.infer<typeof WalletTransactionDetailToolOutputSchema>> => {
+        let transactionId = input.transactionId ?? null;
+
+        if (!transactionId && input.reference === "latest") {
+          const transactions = await Effect.runPromise(
+            args.walletService.listTransactionsForUser({
+              userId: args.userId,
+              pageReq: {
+                page: 1,
+                pageSize: 1,
+                sortBy: "createdAt",
+                sortDir: "desc",
+              },
+            }).pipe(Effect.either),
+          );
+
+          if (Either.isRight(transactions)) {
+            transactionId = transactions.right.items[0]?.id ?? null;
+          }
+        }
+
+        if (!transactionId) {
+          return { reference: input.reference, detail: null };
+        }
+
+        const transaction = await Effect.runPromise(
+          args.walletService.getTransactionByIdForUser({
+            userId: args.userId,
+            transactionId,
+          }).pipe(Effect.either),
+        );
+
+        return {
+          reference: input.reference,
+          detail: Either.isRight(transaction) && Option.isSome(transaction.right)
+            ? {
+                ...toWalletTransactionDetail(transaction.right.value),
+                amountDisplay: formatMinorVnd(transaction.right.value.amount),
+                feeDisplay: formatMinorVnd(transaction.right.value.fee),
+              }
+            : null,
+        };
+      },
+    }),
+  } as const;
+}

--- a/apps/server/src/http/shared/features/ai.layers.ts
+++ b/apps/server/src/http/shared/features/ai.layers.ts
@@ -2,14 +2,19 @@ import { Layer } from "effect";
 
 import { AiChatServiceLive } from "@/domain/ai";
 
-import { RentalServiceLayer } from "./rental.layers";
+import { BikeServiceLayer } from "./bike.layers";
+import { RentalCommandServiceLayer, RentalServiceLayer } from "./rental.layers";
 import { ReservationQueryServiceLayer } from "./reservation.layers";
+import { StationQueryServiceLayer } from "./station.layers";
 import { WalletServiceLayer } from "./wallet.layers";
 
 export const AiServiceLayer = AiChatServiceLive.pipe(
   Layer.provide(WalletServiceLayer),
+  Layer.provide(StationQueryServiceLayer),
   Layer.provide(ReservationQueryServiceLayer),
   Layer.provide(RentalServiceLayer),
+  Layer.provide(RentalCommandServiceLayer),
+  Layer.provide(BikeServiceLayer),
 );
 
 export const AiDepsLive = Layer.mergeAll(

--- a/packages/shared/src/contracts/server/ai/schemas.ts
+++ b/packages/shared/src/contracts/server/ai/schemas.ts
@@ -23,6 +23,7 @@ export const AiChatContextSchema = z.object({
   reservationId: z.string().nullable().optional(),
   bikeId: z.string().nullable().optional(),
   stationId: z.string().nullable().optional(),
+  stationName: z.string().nullable().optional(),
   location: AiChatLocationSchema.nullable().optional(),
 }).openapi("AiChatContext");
 

--- a/packages/shared/src/contracts/server/ai/schemas.ts
+++ b/packages/shared/src/contracts/server/ai/schemas.ts
@@ -6,11 +6,16 @@ import {
 } from "../schemas";
 
 export const AiChatScreenSchema = z
-  .enum(["rental", "reservation", "wallet"])
+  .enum(["rental", "reservation", "station", "bike", "wallet"])
   .openapi("AiChatScreen");
 
 export const AiChatMessageSchema = z.object({
 }).catchall(z.unknown()).openapi("AiChatMessage");
+
+export const AiChatLocationSchema = z.object({
+  latitude: z.number(),
+  longitude: z.number(),
+}).openapi("AiChatLocation");
 
 export const AiChatContextSchema = z.object({
   screen: AiChatScreenSchema.nullable().optional(),
@@ -18,6 +23,7 @@ export const AiChatContextSchema = z.object({
   reservationId: z.string().nullable().optional(),
   bikeId: z.string().nullable().optional(),
   stationId: z.string().nullable().optional(),
+  location: AiChatLocationSchema.nullable().optional(),
 }).openapi("AiChatContext");
 
 export const AiChatRequestSchema = z.object({


### PR DESCRIPTION
## Summary
- expand the customer assistant with rental return-slot, station, bike, and nearby-station tools while tightening prompt rules and structured action error handling
- add native approval flow rendering for return-slot mutations on mobile, including isolated action cards and station-name-first confirmation summaries
- refine guest station browsing and assistant context wiring so station-focused flows stay usable without exposing internal ids in customer UI

## Verification
- pnpm build (packages/shared)
- pnpm tsc --noEmit (apps/server)
- pnpm exec tsc --noEmit -p apps/mobile/tsconfig.json