### PR TITLE
refactor(rentals): remove cancelled rental status

### DIFF
--- a/apps/mobile/screen/rental/booking-history/components/booking-card.tsx
+++ b/apps/mobile/screen/rental/booking-history/components/booking-card.tsx
@@ -198,15 +198,6 @@ function getStatusMeta(status: RentalStatus, theme: ReturnType<typeof useTheme>)
         destinationTone: "warning" as const,
         routeAccentColor: theme.statusWarning.val,
       };
-    case "CANCELLED":
-      return {
-        label: "ĐÃ HỦY",
-        tone: "danger" as const,
-        pulseDot: false,
-        withDot: false,
-        destinationTone: "danger" as const,
-        routeAccentColor: theme.statusDanger.val,
-      };
     default:
       return {
         label: status,

--- a/apps/mobile/screen/staff/phone-lookup/staff-phone-lookup-screen.tsx
+++ b/apps/mobile/screen/staff/phone-lookup/staff-phone-lookup-screen.tsx
@@ -20,8 +20,6 @@ function getStatusTone(status: string) {
       return "warning" as const;
     case "COMPLETED":
       return "success" as const;
-    case "CANCELLED":
-      return "danger" as const;
     case "RESERVED":
       return "neutral" as const;
     default:
@@ -35,8 +33,6 @@ function getStatusText(status: string) {
       return "Đang thuê";
     case "COMPLETED":
       return "Hoàn thành";
-    case "CANCELLED":
-      return "Đã hủy";
     case "RESERVED":
       return "Đã đặt trước";
     default:

--- a/apps/server/generated/kysely/types.ts
+++ b/apps/server/generated/kysely/types.ts
@@ -181,8 +181,7 @@ export const HandoverStatus = {
 export type HandoverStatus = (typeof HandoverStatus)[keyof typeof HandoverStatus];
 export const RentalStatus = {
     RENTED: "RENTED",
-    COMPLETED: "COMPLETED",
-    CANCELLED: "CANCELLED"
+    COMPLETED: "COMPLETED"
 } as const;
 export type RentalStatus = (typeof RentalStatus)[keyof typeof RentalStatus];
 export const ReservationStatus = {

--- a/apps/server/prisma/migrations/20260420113000_remove_cancelled_rental_status/migration.sql
+++ b/apps/server/prisma/migrations/20260420113000_remove_cancelled_rental_status/migration.sql
@@ -1,0 +1,30 @@
+DROP INDEX "idx_rentals_active_bike";
+
+DROP INDEX "idx_rentals_active_user";
+
+ALTER TYPE "RentalStatus" RENAME TO "RentalStatus_old";
+
+CREATE TYPE "RentalStatus" AS ENUM ('RENTED', 'COMPLETED');
+
+ALTER TABLE "Rental" ALTER COLUMN "status" DROP DEFAULT;
+
+ALTER TABLE "Rental"
+ALTER COLUMN "status" TYPE "RentalStatus"
+USING (
+  CASE
+    WHEN "status"::text = 'CANCELLED' THEN 'COMPLETED'
+    ELSE "status"::text
+  END::"RentalStatus"
+);
+
+ALTER TABLE "Rental" ALTER COLUMN "status" SET DEFAULT 'RENTED';
+
+DROP TYPE "RentalStatus_old";
+
+CREATE UNIQUE INDEX "idx_rentals_active_bike"
+ON "Rental"("bike_id")
+WHERE "status" = 'RENTED' AND "bike_id" IS NOT NULL;
+
+CREATE UNIQUE INDEX "idx_rentals_active_user"
+ON "Rental"("user_id")
+WHERE "status" = 'RENTED';

--- a/apps/server/prisma/models/rentals.prisma
+++ b/apps/server/prisma/models/rentals.prisma
@@ -1,7 +1,6 @@
 enum RentalStatus {
   RENTED
   COMPLETED
-  CANCELLED
 }
 
 model Rental {

--- a/apps/server/prisma/seed-demo.ts
+++ b/apps/server/prisma/seed-demo.ts
@@ -28,6 +28,7 @@ import {
 import { setBikeNumberSequence } from "../src/domain/bikes/repository/bike.repository.shared";
 import { toPrismaDecimal } from "../src/domain/shared/decimal";
 import logger from "../src/lib/logger";
+import { seedDefaultGlobalCouponRules } from "./seed-coupon-rules";
 import { upsertVietnamBoundary } from "./seed-geo-boundary";
 import { seedDefaultPricingPolicy } from "./seed-pricing-policy";
 import { buildDemoCustomerFullName, buildDemoTechnicianFullName } from "./seed/demo-faker";
@@ -384,28 +385,6 @@ function buildRentals(params: {
     300,
   );
 
-  for (let i = 0; i < 18; i++) {
-    const idx = 400 + i;
-    const user = pick(normalUsers, idx);
-    const bike = pick(bikes, idx);
-    const start = toUtcDate(-2 - (i % 25), 10 + (i % 10), (i * 5) % 60);
-    rentals.push({
-      id: uuidv7(),
-      userId: user.id,
-      bikeId: bike.id,
-      startStationId: bike.stationId ?? pick(stationIds, idx),
-      endStationId: null,
-      createdAt: new Date(start.getTime() - 10 * 60 * 1000),
-      startTime: start,
-      endTime: null,
-      duration: null,
-      totalPrice: null,
-      subscriptionId: null,
-      status: RentalStatus.CANCELLED,
-      updatedAt: new Date(start.getTime() + 5 * 60 * 1000),
-    });
-  }
-
   const rentedUsers = normalUsers.slice(0, 8);
   const rentedBikes = bikes.slice(0, 8);
   for (let i = 0; i < 8; i++) {
@@ -472,6 +451,7 @@ async function main() {
 
     await upsertVietnamBoundary(prisma);
     await seedDefaultPricingPolicy(prisma);
+    await seedDefaultGlobalCouponRules(prisma, { demoMode: true });
     await seedDemoEnvironmentPolicy(prisma);
     await seedStations(prisma);
     await seedRatingReasons(prisma);
@@ -1233,10 +1213,6 @@ async function main() {
           + agencyStatsRentals.filter(r => r.status === RentalStatus.COMPLETED).length,
       },
       "Completed rentals seeded",
-    );
-    logger.info(
-      { cancelled: rentals.filter(r => r.status === RentalStatus.CANCELLED).length },
-      "Cancelled rentals seeded",
     );
     logger.info(
       { pending: reservations.filter(r => r.status === ReservationStatus.PENDING).length },

--- a/apps/server/src/domain/agencies/models.ts
+++ b/apps/server/src/domain/agencies/models.ts
@@ -50,7 +50,6 @@ export type AgencyPickupStats = {
   readonly totalRentals: number;
   readonly activeRentals: number;
   readonly completedRentals: number;
-  readonly cancelledRentals: number;
   readonly totalRevenue: number;
   readonly avgDurationMinutes: number;
 };

--- a/apps/server/src/domain/agencies/repository/agency-stats.repository.ts
+++ b/apps/server/src/domain/agencies/repository/agency-stats.repository.ts
@@ -280,7 +280,6 @@ export function makeAgencyStatsRepository(
             totalRentals,
             activeRentals: pickupCounts.get(RentalStatus.RENTED) ?? 0,
             completedRentals: pickupCounts.get(RentalStatus.COMPLETED) ?? 0,
-            cancelledRentals: pickupCounts.get(RentalStatus.CANCELLED) ?? 0,
             totalRevenue: Number(pickupCompletedAggregate._sum.totalPrice ?? 0),
             avgDurationMinutes: Number(
               pickupCompletedAggregate._avg.duration?.toFixed(2) ?? 0,

--- a/apps/server/src/domain/agencies/services/agency-stats.service.ts
+++ b/apps/server/src/domain/agencies/services/agency-stats.service.ts
@@ -66,7 +66,6 @@ function emptyMetrics(totalCapacity: number, returnSlotLimit: number) {
       totalRentals: 0,
       activeRentals: 0,
       completedRentals: 0,
-      cancelledRentals: 0,
       totalRevenue: 0,
       avgDurationMinutes: 0,
     },

--- a/apps/server/src/domain/environment/services/test/environment-impact-repair.service.int.test.ts
+++ b/apps/server/src/domain/environment/services/test/environment-impact-repair.service.int.test.ts
@@ -35,7 +35,7 @@ describe("environment impact repair jobs integration", () => {
   }
 
   async function createRental(input: {
-    status: "RENTED" | "COMPLETED" | "CANCELLED";
+    status: "RENTED" | "COMPLETED";
     startTime?: Date;
     endTime?: Date | null;
   }) {
@@ -155,9 +155,8 @@ describe("environment impact repair jobs integration", () => {
     expect(outboxCount).toBe(0);
   });
 
-  it("does not enqueue jobs for rented or cancelled rentals", async () => {
+  it("does not enqueue jobs for rented rentals", async () => {
     await createRental({ status: "RENTED", endTime: null });
-    await createRental({ status: "CANCELLED" });
 
     const summary = await runRepair({ limit: 100 });
 

--- a/apps/server/src/domain/ratings/repository/rating.mappers.ts
+++ b/apps/server/src/domain/ratings/repository/rating.mappers.ts
@@ -113,7 +113,7 @@ export function toAdminRatingDetailRow(
   row: AdminRatingBasePayload & {
     rental: {
       id: string;
-      status: "RENTED" | "COMPLETED" | "CANCELLED";
+      status: "RENTED" | "COMPLETED";
       startTime: Date;
       endTime: Date | null;
     };

--- a/apps/server/src/domain/rentals/models.ts
+++ b/apps/server/src/domain/rentals/models.ts
@@ -158,7 +158,6 @@ export type RentalCountsRow = {
 export type RentalStatusCounts = {
   RENTED: number;
   COMPLETED: number;
-  CANCELLED: number;
 };
 
 export type RentalRevenueGroupBy = "DAY" | "MONTH" | "YEAR";
@@ -189,7 +188,6 @@ export type RentalSummaryStats = {
   rentalList: {
     Rented: number;
     Completed: number;
-    Cancelled: number;
   };
   dailyRevenue: RevenueDelta;
   monthlyRevenue: RevenueDelta;

--- a/apps/server/src/domain/rentals/repository/test/rental-analytics.repository.int.test.ts
+++ b/apps/server/src/domain/rentals/repository/test/rental-analytics.repository.int.test.ts
@@ -18,7 +18,7 @@ describe("rentalAnalyticsRepository Integration", () => {
     userId: string;
     bikeId: string;
     stationId: string;
-    status: "RENTED" | "COMPLETED" | "CANCELLED";
+    status: "RENTED" | "COMPLETED";
     startTime: Date;
     endTime?: Date | null;
     totalPrice?: number | null;
@@ -44,7 +44,6 @@ describe("rentalAnalyticsRepository Integration", () => {
     const now = new Date("2026-03-16T10:00:00.000Z");
 
     await createRental({ userId: user.id, bikeId: bike.id, stationId: station.id, status: "RENTED", startTime: now });
-    await createRental({ userId: user.id, bikeId: bike.id, stationId: station.id, status: "CANCELLED", startTime: now });
     await createRental({
       userId: user.id,
       bikeId: bike.id,
@@ -59,7 +58,6 @@ describe("rentalAnalyticsRepository Integration", () => {
     const byStatus = new Map(rows.map(row => [row.status, row.count]));
 
     expect(byStatus.get("RENTED")).toBe(1);
-    expect(byStatus.get("CANCELLED")).toBe(1);
     expect(byStatus.get("COMPLETED")).toBe(1);
   });
 

--- a/apps/server/src/domain/rentals/services/rental-counts.ts
+++ b/apps/server/src/domain/rentals/services/rental-counts.ts
@@ -6,7 +6,6 @@ export function aggregateRentalStatusCounts(
   const counts: RentalStatusCounts = {
     RENTED: 0,
     COMPLETED: 0,
-    CANCELLED: 0,
   };
 
   for (const row of rows) {

--- a/apps/server/src/domain/rentals/services/rental-stats.service.ts
+++ b/apps/server/src/domain/rentals/services/rental-stats.service.ts
@@ -74,7 +74,6 @@ export const RentalStatsServiceLive = Layer.effect(
             rentalList: {
               Rented: counts.RENTED,
               Completed: counts.COMPLETED,
-              Cancelled: counts.CANCELLED,
             },
             dailyRevenue: compareRevenue(dailyCurrent, dailyPrevious),
             monthlyRevenue: compareRevenue(monthlyCurrent, monthlyPrevious),

--- a/apps/server/src/domain/rentals/services/test/rental-counts.test.ts
+++ b/apps/server/src/domain/rentals/services/test/rental-counts.test.ts
@@ -14,21 +14,19 @@ describe("aggregateRentalStatusCounts", () => {
     expect(aggregateRentalStatusCounts(rows)).toEqual({
       RENTED: 2,
       COMPLETED: 5,
-      CANCELLED: 0,
     });
   });
 
   it("overwrites counts per status", () => {
     const rows: RentalCountsRow[] = [
       { status: "RENTED", count: 1 },
+      { status: "COMPLETED", count: 2 },
       { status: "RENTED", count: 3 },
-      { status: "CANCELLED", count: 4 },
     ];
 
     expect(aggregateRentalStatusCounts(rows)).toEqual({
       RENTED: 3,
-      COMPLETED: 0,
-      CANCELLED: 4,
+      COMPLETED: 2,
     });
   });
 });

--- a/apps/server/src/domain/rentals/services/test/return-slot.int.test.ts
+++ b/apps/server/src/domain/rentals/services/test/return-slot.int.test.ts
@@ -402,7 +402,11 @@ describe("return slot integration", () => {
       userId: user.id,
       bikeId: bike.id,
       startStationId: station.id,
-      status: "CANCELLED",
+      status: "COMPLETED",
+      endStationId: station.id,
+      endTime: new Date(Date.now() - 30 * 60 * 1000),
+      duration: 30,
+      totalPrice: "12000",
     });
     const operator = await fixture.factories.user({ role: "STAFF" });
     await fixture.factories.userOrgAssignment({ userId: operator.id, stationId: station.id });

--- a/apps/server/src/domain/stations/repository/test/read/station.read.repository.int.test.ts
+++ b/apps/server/src/domain/stations/repository/test/read/station.read.repository.int.test.ts
@@ -134,17 +134,6 @@ describe("stationReadRepository Integration", () => {
       totalPrice: "5000",
       status: "COMPLETED",
     });
-    await kit.fixture.factories.rental({
-      userId: userB.id,
-      bikeId: bikeB.id,
-      startStationId: stationB.id,
-      startTime: new Date("2026-02-15T09:00:00.000Z"),
-      endTime: new Date("2026-02-15T09:15:00.000Z"),
-      duration: 15,
-      totalPrice: "9000",
-      status: "CANCELLED",
-    });
-
     const result = await Effect.runPromise(repo.getRevenueByStation({ from, to }));
 
     expect(result).toHaveLength(2);

--- a/apps/server/src/http/test/e2e/admin-agencies-stats-routing.e2e.int.test.ts
+++ b/apps/server/src/http/test/e2e/admin-agencies-stats-routing.e2e.int.test.ts
@@ -150,17 +150,6 @@ describe("admin agency stats routing e2e", () => {
       status: "RENTED",
     });
 
-    await fixture.factories.rental({
-      userId: customer.id,
-      bikeId: bookedBike.id,
-      startStationId: station.id,
-      startTime: new Date("2026-03-14T10:00:00.000Z"),
-      endTime: null,
-      duration: null,
-      totalPrice: null,
-      status: "CANCELLED",
-    });
-
     await fixture.prisma.returnConfirmation.create({
       data: {
         rentalId: completedRental.id,
@@ -235,10 +224,9 @@ describe("admin agency stats routing e2e", () => {
     });
     expect(body.currentStation.occupancyRate).toBeCloseTo(33.33, 2);
     expect(body.pickups).toEqual({
-      totalRentals: 3,
+      totalRentals: 2,
       activeRentals: 1,
       completedRentals: 1,
-      cancelledRentals: 1,
       totalRevenue: 32000,
       avgDurationMinutes: 45,
     });

--- a/apps/server/src/http/test/e2e/environment-policies-routing.e2e.int.test.ts
+++ b/apps/server/src/http/test/e2e/environment-policies-routing.e2e.int.test.ts
@@ -153,7 +153,7 @@ describe("environment policies routing e2e", () => {
   async function createRentalForImpact(input: {
     id?: string;
     userId?: string;
-    status?: "RENTED" | "COMPLETED" | "CANCELLED";
+    status?: "RENTED" | "COMPLETED";
     duration?: number | null;
     startTime?: Date;
     endTime?: Date | null;

--- a/apps/server/src/http/test/e2e/rentals-billing-preview-routing.e2e.int.test.ts
+++ b/apps/server/src/http/test/e2e/rentals-billing-preview-routing.e2e.int.test.ts
@@ -24,7 +24,7 @@ describe("rentals billing preview routing e2e", () => {
     readonly startOffsetMs?: number;
     readonly prepaid?: string;
     readonly withSubscription?: boolean;
-    readonly rentalStatus?: "RENTED" | "COMPLETED" | "CANCELLED";
+    readonly rentalStatus?: "RENTED" | "COMPLETED";
   }) {
     const user = await fixture.factories.user({ role: "USER" });
     await fixture.factories.wallet({ userId: user.id, balance: 100_000n });

--- a/apps/server/src/test/factories/types.ts
+++ b/apps/server/src/test/factories/types.ts
@@ -61,7 +61,7 @@ export type RentalOverrides = {
   duration?: number | null;
   totalPrice?: string | null;
   subscriptionId?: string | null;
-  status?: "RENTED" | "COMPLETED" | "CANCELLED";
+  status?: "RENTED" | "COMPLETED";
 };
 
 export type ReservationOverrides = {

--- a/packages/shared/src/contracts/server/agencies/models.ts
+++ b/packages/shared/src/contracts/server/agencies/models.ts
@@ -50,7 +50,6 @@ export const AgencyPickupStatsSchema = z.object({
   totalRentals: z.number(),
   activeRentals: z.number(),
   completedRentals: z.number(),
-  cancelledRentals: z.number(),
   totalRevenue: z.number(),
   avgDurationMinutes: z.number(),
 }).openapi("AgencyPickupStats");

--- a/packages/shared/src/contracts/server/ratings/models.ts
+++ b/packages/shared/src/contracts/server/ratings/models.ts
@@ -34,7 +34,7 @@ export const AdminRatingStationSchema = z.object({
 
 export const AdminRatingRentalSchema = z.object({
   id: z.uuidv7(),
-  status: z.enum(["RENTED", "COMPLETED", "CANCELLED"]),
+  status: z.enum(["RENTED", "COMPLETED"]),
   startTime: z.iso.datetime(),
   endTime: z.iso.datetime().nullable(),
 });

--- a/packages/shared/src/contracts/server/rentals/models.ts
+++ b/packages/shared/src/contracts/server/rentals/models.ts
@@ -10,7 +10,6 @@ import { UserRoleSchema, VerifyStatusSchema } from "../users";
 export const RentalStatusSchema = z.enum([
   "RENTED",
   "COMPLETED",
-  "CANCELLED",
 ]);
 
 export const BikeSwapStatusSchema = z.enum([
@@ -277,7 +276,6 @@ export const DashboardResponseSchema = z.object({
 export const RentalStatusCountsSchema = z.object({
   RENTED: z.number(),
   COMPLETED: z.number(),
-  CANCELLED: z.number(),
 });
 
 export const RentalCountsResponseSchema = RentalStatusCountsSchema;
@@ -293,7 +291,6 @@ export const RentalSummaryStatsSchema = z.object({
   rentalList: z.object({
     Rented: z.number(),
     Completed: z.number(),
-    Cancelled: z.number(),
   }),
   dailyRevenue: RevenueDeltaSchema,
   monthlyRevenue: RevenueDeltaSchema,
@@ -327,11 +324,6 @@ export const UpdateRentalRequestSchema = z.object({
   endTime: z.iso.datetime().optional(),
   status: RentalStatusSchema.optional(),
   totalPrice: z.number().optional(),
-  reason: z.string(),
-});
-
-export const CancelRentalRequestSchema = z.object({
-  bikeStatus: BikeStatusSchema.optional(),
   reason: z.string(),
 });
 
@@ -482,7 +474,6 @@ export type StaffCreateRentalRequest = z.infer<
 export type CardTapRentalRequest = z.infer<typeof CardTapRentalRequestSchema>;
 export type EndRentalRequest = z.infer<typeof EndRentalRequestSchema>;
 export type UpdateRentalRequest = z.infer<typeof UpdateRentalRequestSchema>;
-export type CancelRentalRequest = z.infer<typeof CancelRentalRequestSchema>;
 export type CreateReturnSlotRequest = z.infer<typeof CreateReturnSlotRequestSchema>;
 export type RentalListResponse = z.infer<typeof RentalListResponseSchema>;
 export type AdminRentalsListResponse = z.infer<

--- a/packages/shared/src/contracts/server/routes/rentals/index.ts
+++ b/packages/shared/src/contracts/server/routes/rentals/index.ts
@@ -6,7 +6,6 @@ export {
   agencyApproveBikeSwapRequest,
   agencyRejectBikeSwapRequest,
   cancelMyReturnSlot,
-  cancelRental,
   confirmRentalReturnByOperator,
   createMyReturnSlot,
   createRental,

--- a/packages/shared/src/contracts/server/routes/rentals/mutations.ts
+++ b/packages/shared/src/contracts/server/routes/rentals/mutations.ts
@@ -4,7 +4,6 @@ import { z } from "../../../../zod";
 import {
   BikeSwapRequestErrorCodeSchema,
   BikeSwapRequestErrorResponseSchema,
-  CancelRentalRequestSchema,
   CardTapRentalRequestSchema,
   CreateRentalRequestSchema,
   CreateReturnSlotRequestSchema,
@@ -372,53 +371,6 @@ export const confirmRentalReturnByOperator = createRoute({
 
 // Legacy alias kept so existing generated route consumers do not break immediately.
 export const endRentalByAdmin = confirmRentalReturnByOperator;
-
-export const cancelRental = createRoute({
-  method: "post",
-  path: "/v1/rentals/{rentalId}/cancel",
-  tags: ["Rentals"],
-  request: {
-    params: RentalIdParamSchema,
-    body: {
-      content: {
-        "application/json": {
-          schema: CancelRentalRequestSchema.openapi("CancelRentalRequest"),
-        },
-      },
-    },
-  },
-  responses: {
-    200: {
-      description: "Rental cancelled successfully",
-      content: {
-        "application/json": {
-          schema: RentalDetailSchemaOpenApi,
-        },
-      },
-    },
-    400: {
-      description: "Cannot cancel rental",
-      content: {
-        "application/json": {
-          schema: RentalErrorResponseSchema,
-          examples: {
-            CannotCancelWithStatus: {
-              value: {
-                error: "Cannot cancel rental in this status",
-                details: {
-                  code: RentalErrorCodeSchema.enum
-                    .CANNOT_CANCEL_THIS_RENTAL_WITH_STATUS,
-                  rentalId: "665fd6e36b7e5d53f8f3d2c9",
-                  status: "COMPLETED",
-                },
-              },
-            },
-          },
-        },
-      },
-    },
-  },
-});
 
 export const processCardTapRental = createRoute({
   method: "post",


### PR DESCRIPTION
## Summary
- remove the unsupported `CANCELLED` rental status from Prisma, generated types, and shared/server rental contracts
- stop demo seeding from creating cancelled rentals and include coupon rule seeding in `seed-demo.ts`
- prune server analytics/tests plus mobile rental displays that still assumed cancelled rentals existed

## Validation
- `DATABASE_URL=\"postgresql://mebike:mebike@127.0.0.1:5432/mebike_test_template\" pnpm prisma migrate reset --force`
- `pnpm --dir ../../packages/shared build`
- `pnpm prisma generate`
- `pnpm tsc --noEmit`
- `pnpm vitest run src/domain/rentals/services/test/rental-counts.test.ts --mode test`
- `pnpm vitest run --config vitest.int.config.ts --mode test src/domain/environment/services/test/environment-impact-repair.service.int.test.ts src/domain/rentals/repository/test/rental-analytics.repository.int.test.ts src/domain/stations/repository/test/read/station.read.repository.int.test.ts`