### PR TITLE
feat(server): add integrated dev cli tooling

### DIFF
--- a/apps/mobile/screen/station-detail/components/station-detail-header.tsx
+++ b/apps/mobile/screen/station-detail/components/station-detail-header.tsx
@@ -5,7 +5,6 @@ import type { StationReadSummary } from "@/contracts/server";
 import { IconSymbol } from "@components/IconSymbol";
 import { AppHeroHeader } from "@ui/patterns/app-hero-header";
 import { AppText } from "@ui/primitives/app-text";
-import { StatusBadge } from "@ui/primitives/status-badge";
 
 type StationDetailHeaderProps = {
   onBack: () => void;
@@ -20,7 +19,6 @@ export function StationDetailHeader({
 
   return (
     <AppHeroHeader
-      accessory={<StatusBadge label="HOẠT ĐỘNG" size="compact" tone="overlaySuccess" />}
       onBack={onBack}
       size="default"
       subtitle={(

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -40,11 +40,11 @@
     "ios": "expo run:ios"
   },
   "dependencies": {
-    "@inquirer/prompts": "^7.10.1",
     "@date-fns/tz": "^1.4.1",
     "@faker-js/faker": "^10.4.0",
     "@hono/node-server": "^1.19.3",
     "@hono/zod-openapi": "^1.1.3",
+    "@inquirer/prompts": "^7.10.1",
     "@mapbox/mapbox-sdk": "^0.16.2",
     "@mebike/shared": "workspace:*",
     "@openrouter/ai-sdk-provider": "^2.8.0",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -21,6 +21,8 @@
     "dev:test": "vitest --watch",
     "lint": "eslint .",
     "dev": "tsx --watch src/http/server.ts",
+    "dev:cli": "tsx src/dev-cli/index.ts",
+    "dev:cli:interactive": "tsx src/dev-cli/index.ts interactive",
     "dev:build": "pnpm --dir ../../packages/shared build && tsx --watch src/http/server.ts",
     "worker": "tsx src/worker/index.ts",
     "worker:iot": "tsx src/worker/iot-runtime.ts",
@@ -38,6 +40,7 @@
     "ios": "expo run:ios"
   },
   "dependencies": {
+    "@inquirer/prompts": "^7.10.1",
     "@date-fns/tz": "^1.4.1",
     "@faker-js/faker": "^10.4.0",
     "@hono/node-server": "^1.19.3",
@@ -51,6 +54,7 @@
     "@types/nodemailer": "^7.0.3",
     "ai": "^6.0.168",
     "bcrypt": "^6.0.0",
+    "chalk": "^5.6.2",
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
     "dotenv": "^17.2.3",

--- a/apps/server/src/dev-cli/data.ts
+++ b/apps/server/src/dev-cli/data.ts
@@ -1,0 +1,708 @@
+import type { JobPayload } from "@mebike/shared/contracts/server/jobs";
+
+import { safeParseJobPayload } from "@mebike/shared/contracts/server/jobs";
+
+import type { PrismaClient } from "generated/prisma/client";
+
+import { confirmRentalReturnByStaff, withPrismaClient } from "./runtime";
+
+export const EMAIL_JOB_TYPE = "emails.send";
+
+export type EmailJobStatus = "ALL" | "PENDING" | "SENT" | "FAILED" | "CANCELLED";
+
+export type StationSummaryRow = {
+  id: string;
+  name: string;
+  address: string;
+  stationType: "INTERNAL" | "AGENCY";
+  totalCapacity: number;
+  returnSlotLimit: number;
+  updatedAt: Date;
+  totalBikes: number;
+  availableBikes: number;
+  bookedBikes: number;
+  brokenBikes: number;
+  reservedBikes: number;
+  maintainedBikes: number;
+  unavailableBikes: number;
+};
+
+export type StationBikeRow = {
+  id: string;
+  bikeNumber: string;
+  chipId: string;
+  status: string;
+  updatedAt: Date;
+  activeRentalId: string | null;
+  pendingReservationId: string | null;
+};
+
+export type StationInspection = StationSummaryRow & {
+  bikes: StationBikeRow[];
+};
+
+export type BikeRentalSnapshot = {
+  id: string;
+  status: string;
+  startTime: Date;
+  endTime: Date | null;
+  userId: string;
+  userEmail: string;
+};
+
+export type BikeInspection = {
+  id: string;
+  bikeNumber: string;
+  chipId: string;
+  status: string;
+  stationId: string | null;
+  stationName: string | null;
+  stationAddress: string | null;
+  supplierId: string | null;
+  supplierName: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  activeRentalId: string | null;
+  pendingReservationId: string | null;
+  recentRentals: BikeRentalSnapshot[];
+};
+
+export type ActiveRentalInspectorRow = {
+  id: string;
+  userId: string;
+  userEmail: string;
+  bikeId: string;
+  bikeNumber: string;
+  bikeChipId: string;
+  startStationId: string;
+  startStationName: string;
+  startTime: Date;
+  status: string;
+};
+
+export type PersonaRentalHistoryRow = {
+  id: string;
+  status: string;
+  bikeId: string;
+  bikeNumber: string;
+  bikeChipId: string;
+  startStationId: string;
+  startStationName: string;
+  endStationId: string | null;
+  endStationName: string | null;
+  startTime: Date;
+  endTime: Date | null;
+  durationMinutes: number | null;
+  totalPrice: number | null;
+  updatedAt: Date;
+};
+
+export type PersonaRentalDetail = {
+  id: string;
+  userId: string;
+  userEmail: string;
+  status: string;
+  bikeId: string;
+  bikeNumber: string;
+  bikeChipId: string;
+  bikeStatus: string;
+  startStationId: string;
+  startStationName: string;
+  startStationAddress: string;
+  endStationId: string | null;
+  endStationName: string | null;
+  endStationAddress: string | null;
+  startTime: Date;
+  endTime: Date | null;
+  durationMinutes: number | null;
+  totalPrice: number | null;
+  subscriptionId: string | null;
+  updatedAt: Date;
+  returnConfirmedAt: Date | null;
+  returnConfirmationMethod: string | null;
+  returnHandoverStatus: string | null;
+  returnConfirmedByUserId: string | null;
+  returnConfirmedByUserEmail: string | null;
+  returnConfirmationStationId: string | null;
+  returnConfirmationStationName: string | null;
+  billedTotalAmount: number | null;
+  billedBaseAmount: number | null;
+  billedOvertimeAmount: number | null;
+  billedCouponDiscountAmount: number | null;
+  billedSubscriptionDiscountAmount: number | null;
+  billedDepositForfeited: boolean | null;
+  penaltiesTotalAmount: number | null;
+  penaltiesCount: number;
+};
+
+export type EmailJobRow = {
+  id: string;
+  status: Exclude<EmailJobStatus, "ALL">;
+  attempts: number;
+  dedupeKey: string | null;
+  lastError: string | null;
+  createdAt: Date;
+  runAt: Date;
+  sentAt: Date | null;
+  payload: JobPayload<"emails.send"> | Record<string, unknown>;
+  payloadKind: string;
+  subject: string;
+  to: string;
+  html: string;
+};
+
+type RawEmailJobRow = {
+  id: string;
+  status: Exclude<EmailJobStatus, "ALL">;
+  attempts: number;
+  dedupeKey: string | null;
+  lastError: string | null;
+  createdAt: Date;
+  runAt: Date;
+  sentAt: Date | null;
+  payload: unknown;
+};
+
+async function withClient<T>(_connectionString: string, task: (client: PrismaClient) => Promise<T>) {
+  return withPrismaClient(task);
+}
+
+export async function listStations(args: {
+  connectionString: string;
+  limit?: number;
+  search?: string;
+}) {
+  return withClient(args.connectionString, async (client) => {
+    const search = args.search ?? null;
+    return client.$queryRaw<StationSummaryRow[]>`
+        SELECT
+          s.id,
+          s.name,
+          s.address,
+          s.station_type AS "stationType",
+          s.total_capacity AS "totalCapacity",
+          s.return_slot_limit AS "returnSlotLimit",
+          s.updated_at AS "updatedAt",
+          COUNT(b.id)::int AS "totalBikes",
+          COUNT(*) FILTER (WHERE b.status = 'AVAILABLE')::int AS "availableBikes",
+          COUNT(*) FILTER (WHERE b.status = 'BOOKED')::int AS "bookedBikes",
+          COUNT(*) FILTER (WHERE b.status = 'BROKEN')::int AS "brokenBikes",
+          COUNT(*) FILTER (WHERE b.status = 'RESERVED')::int AS "reservedBikes",
+          COUNT(*) FILTER (WHERE b.status = 'MAINTAINED')::int AS "maintainedBikes",
+          COUNT(*) FILTER (WHERE b.status = 'UNAVAILABLE')::int AS "unavailableBikes"
+        FROM "Station" s
+        LEFT JOIN "Bike" b ON b."stationId" = s.id
+        WHERE (${search}::text IS NULL OR s.id::text = ${search} OR s.name ILIKE '%' || ${search} || '%')
+        GROUP BY s.id
+        ORDER BY s.name ASC
+        LIMIT ${args.limit ?? 25}
+      `;
+  });
+}
+
+export async function getStationInspection(args: {
+  connectionString: string;
+  value: string;
+}) {
+  return withClient(args.connectionString, async (client) => {
+    const stationRows = await client.$queryRaw<StationSummaryRow[]>`
+        SELECT
+          s.id,
+          s.name,
+          s.address,
+          s.station_type AS "stationType",
+          s.total_capacity AS "totalCapacity",
+          s.return_slot_limit AS "returnSlotLimit",
+          s.updated_at AS "updatedAt",
+          COUNT(b.id)::int AS "totalBikes",
+          COUNT(*) FILTER (WHERE b.status = 'AVAILABLE')::int AS "availableBikes",
+          COUNT(*) FILTER (WHERE b.status = 'BOOKED')::int AS "bookedBikes",
+          COUNT(*) FILTER (WHERE b.status = 'BROKEN')::int AS "brokenBikes",
+          COUNT(*) FILTER (WHERE b.status = 'RESERVED')::int AS "reservedBikes",
+          COUNT(*) FILTER (WHERE b.status = 'MAINTAINED')::int AS "maintainedBikes",
+          COUNT(*) FILTER (WHERE b.status = 'UNAVAILABLE')::int AS "unavailableBikes"
+        FROM "Station" s
+        LEFT JOIN "Bike" b ON b."stationId" = s.id
+        WHERE s.id::text = ${args.value} OR s.name ILIKE '%' || ${args.value} || '%'
+        GROUP BY s.id
+        ORDER BY
+          CASE
+            WHEN s.id::text = ${args.value} THEN 0
+            WHEN s.name = ${args.value} THEN 1
+            ELSE 2
+          END,
+          s.updated_at DESC
+        LIMIT 1
+      `;
+
+    const station = stationRows[0] ?? null;
+    if (!station) {
+      return null;
+    }
+
+    const bikes = await client.$queryRaw<StationBikeRow[]>`
+        SELECT
+          b.id,
+          b.bike_number AS "bikeNumber",
+          b.chip_id AS "chipId",
+          b.status,
+          b.updated_at AS "updatedAt",
+          (
+            SELECT r.id
+            FROM "Rental" r
+            WHERE r.bike_id = b.id AND r.status = 'RENTED'
+            ORDER BY r.start_time DESC
+            LIMIT 1
+          ) AS "activeRentalId",
+          (
+            SELECT res.id
+            FROM "Reservation" res
+            WHERE res.bike_id = b.id AND res.status = 'PENDING'
+            ORDER BY res.created_at DESC
+            LIMIT 1
+          ) AS "pendingReservationId"
+        FROM "Bike" b
+        WHERE b."stationId" = ${station.id}::uuid
+        ORDER BY b.bike_number ASC
+      `;
+
+    return {
+      ...station,
+      bikes,
+    } satisfies StationInspection;
+  });
+}
+
+export async function getBikeInspection(args: {
+  connectionString: string;
+  value: string;
+}) {
+  return withClient(args.connectionString, async (client) => {
+    const bikeRows = await client.$queryRaw<Array<Omit<BikeInspection, "recentRentals">>>`
+        SELECT
+          b.id,
+          b.bike_number AS "bikeNumber",
+          b.chip_id AS "chipId",
+          b.status,
+          b."stationId" AS "stationId",
+          s.name AS "stationName",
+          s.address AS "stationAddress",
+          b."supplierId" AS "supplierId",
+          sup.name AS "supplierName",
+          b.created_at AS "createdAt",
+          b.updated_at AS "updatedAt",
+          (
+            SELECT r.id
+            FROM "Rental" r
+            WHERE r.bike_id = b.id AND r.status = 'RENTED'
+            ORDER BY r.start_time DESC
+            LIMIT 1
+          ) AS "activeRentalId",
+          (
+            SELECT res.id
+            FROM "Reservation" res
+            WHERE res.bike_id = b.id AND res.status = 'PENDING'
+            ORDER BY res.created_at DESC
+            LIMIT 1
+          ) AS "pendingReservationId"
+        FROM "Bike" b
+        LEFT JOIN "Station" s ON s.id = b."stationId"
+        LEFT JOIN "Supplier" sup ON sup.id = b."supplierId"
+        WHERE b.id::text = ${args.value} OR b.bike_number ILIKE '%' || ${args.value} || '%' OR b.chip_id ILIKE '%' || ${args.value} || '%'
+        ORDER BY
+          CASE
+            WHEN b.id::text = ${args.value} THEN 0
+            WHEN b.bike_number = ${args.value} THEN 1
+            WHEN b.chip_id = ${args.value} THEN 2
+            ELSE 3
+          END,
+          b.updated_at DESC
+        LIMIT 1
+      `;
+
+    const bike = bikeRows[0] ?? null;
+    if (!bike) {
+      return null;
+    }
+
+    const recentRentals = await client.$queryRaw<BikeRentalSnapshot[]>`
+        SELECT
+          r.id,
+          r.status,
+          r.start_time AS "startTime",
+          r.end_time AS "endTime",
+          u.id AS "userId",
+          u.email AS "userEmail"
+        FROM "Rental" r
+        INNER JOIN users u ON u.id = r.user_id
+        WHERE r.bike_id = ${bike.id}::uuid
+        ORDER BY r.start_time DESC
+        LIMIT 5
+      `;
+
+    return {
+      ...bike,
+      recentRentals,
+    } satisfies BikeInspection;
+  });
+}
+
+export async function listActiveRentals(args: {
+  connectionString: string;
+  limit?: number;
+}) {
+  return withClient(args.connectionString, async (client) => {
+    return client.$queryRaw<ActiveRentalInspectorRow[]>`
+        SELECT
+          r.id,
+          r.user_id AS "userId",
+          u.email AS "userEmail",
+          r.bike_id AS "bikeId",
+          b.bike_number AS "bikeNumber",
+          b.chip_id AS "bikeChipId",
+          r.start_station AS "startStationId",
+          s.name AS "startStationName",
+          r.start_time AS "startTime",
+          r.status
+        FROM "Rental" r
+        INNER JOIN users u ON u.id = r.user_id
+        INNER JOIN "Bike" b ON b.id = r.bike_id
+        INNER JOIN "Station" s ON s.id = r.start_station
+        WHERE r.status = 'RENTED'
+        ORDER BY r.start_time DESC
+        LIMIT ${args.limit ?? 25}
+      `;
+  });
+}
+
+export async function listPersonaRentalHistory(args: {
+  connectionString: string;
+  userId: string;
+  limit?: number;
+  status?: "RENTED" | "COMPLETED" | "CANCELLED";
+}) {
+  return withClient(args.connectionString, async (client) => {
+    const status = args.status ?? null;
+    return client.$queryRaw<PersonaRentalHistoryRow[]>`
+        SELECT
+          r.id,
+          r.status,
+          r.bike_id AS "bikeId",
+          b.bike_number AS "bikeNumber",
+          b.chip_id AS "bikeChipId",
+          r.start_station AS "startStationId",
+          start_station.name AS "startStationName",
+          r.end_station AS "endStationId",
+          end_station.name AS "endStationName",
+          r.start_time AS "startTime",
+          r.end_time AS "endTime",
+          r.duration AS "durationMinutes",
+          CASE WHEN r.total_price IS NULL THEN NULL ELSE r.total_price::float8 END AS "totalPrice",
+          r.updated_at AS "updatedAt"
+        FROM "Rental" r
+        INNER JOIN "Bike" b ON b.id = r.bike_id
+        INNER JOIN "Station" start_station ON start_station.id = r.start_station
+        LEFT JOIN "Station" end_station ON end_station.id = r.end_station
+        WHERE r.user_id = ${args.userId}::uuid
+          AND (${status}::text IS NULL OR r.status = ${status})
+        ORDER BY r.start_time DESC, r.created_at DESC
+        LIMIT ${args.limit ?? 20}
+      `;
+  });
+}
+
+export async function getPersonaRentalDetail(args: {
+  connectionString: string;
+  userId: string;
+  rentalId: string;
+}) {
+  return withClient(args.connectionString, async (client) => {
+    const rows = await client.$queryRaw<PersonaRentalDetail[]>`
+        SELECT
+          r.id,
+          r.user_id AS "userId",
+          u.email AS "userEmail",
+          r.status,
+          r.bike_id AS "bikeId",
+          b.bike_number AS "bikeNumber",
+          b.chip_id AS "bikeChipId",
+          b.status AS "bikeStatus",
+          r.start_station AS "startStationId",
+          start_station.name AS "startStationName",
+          start_station.address AS "startStationAddress",
+          r.end_station AS "endStationId",
+          end_station.name AS "endStationName",
+          end_station.address AS "endStationAddress",
+          r.start_time AS "startTime",
+          r.end_time AS "endTime",
+          r.duration AS "durationMinutes",
+          CASE WHEN r.total_price IS NULL THEN NULL ELSE r.total_price::float8 END AS "totalPrice",
+          r.subscription_id AS "subscriptionId",
+          r.updated_at AS "updatedAt",
+          rc.confirmed_at AS "returnConfirmedAt",
+          rc.confirmation_method AS "returnConfirmationMethod",
+          rc.handover_status AS "returnHandoverStatus",
+          rc.confirmed_by_user_id AS "returnConfirmedByUserId",
+          confirmed_by.email AS "returnConfirmedByUserEmail",
+          rc.station_id AS "returnConfirmationStationId",
+          confirmation_station.name AS "returnConfirmationStationName",
+          CASE WHEN rbr.total_amount IS NULL THEN NULL ELSE rbr.total_amount::float8 END AS "billedTotalAmount",
+          CASE WHEN rbr.base_amount IS NULL THEN NULL ELSE rbr.base_amount::float8 END AS "billedBaseAmount",
+          CASE WHEN rbr.overtime_amount IS NULL THEN NULL ELSE rbr.overtime_amount::float8 END AS "billedOvertimeAmount",
+          CASE WHEN rbr.coupon_discount_amount IS NULL THEN NULL ELSE rbr.coupon_discount_amount::float8 END AS "billedCouponDiscountAmount",
+          CASE WHEN rbr.subscription_discount_amount IS NULL THEN NULL ELSE rbr.subscription_discount_amount::float8 END AS "billedSubscriptionDiscountAmount",
+          rbr.deposit_forfeited AS "billedDepositForfeited",
+          penalties.total_amount AS "penaltiesTotalAmount",
+          penalties.count AS "penaltiesCount"
+        FROM "Rental" r
+        INNER JOIN users u ON u.id = r.user_id
+        INNER JOIN "Bike" b ON b.id = r.bike_id
+        INNER JOIN "Station" start_station ON start_station.id = r.start_station
+        LEFT JOIN "Station" end_station ON end_station.id = r.end_station
+        LEFT JOIN return_confirmations rc ON rc.rental_id = r.id
+        LEFT JOIN users confirmed_by ON confirmed_by.id = rc.confirmed_by_user_id
+        LEFT JOIN "Station" confirmation_station ON confirmation_station.id = rc.station_id
+        LEFT JOIN rental_billing_records rbr ON rbr.rental_id = r.id
+        LEFT JOIN (
+          SELECT
+            rental_id,
+            COUNT(*)::int AS count,
+            COALESCE(SUM(amount)::float8, 0) AS total_amount
+          FROM rental_penalties
+          GROUP BY rental_id
+        ) penalties ON penalties.rental_id = r.id
+        WHERE r.user_id = ${args.userId}::uuid
+          AND r.id = ${args.rentalId}::uuid
+        LIMIT 1
+      `;
+
+    return rows[0] ?? null;
+  });
+}
+
+export async function confirmRentalReturnAsStaff(args: {
+  connectionString: string;
+  rentalId: string;
+  staffUserId: string;
+  stationId: string;
+}) {
+  return confirmRentalReturnByStaff({
+    rentalId: args.rentalId,
+    staffUserId: args.staffUserId,
+    stationId: args.stationId,
+  });
+}
+
+export async function listEmailJobs(args: {
+  connectionString: string;
+  status: EmailJobStatus;
+  limit?: number;
+}) {
+  return withClient(args.connectionString, async (client) => {
+    const rows = await client.$queryRaw<RawEmailJobRow[]>`
+        SELECT
+          id,
+          status,
+          attempts,
+          dedupe_key AS "dedupeKey",
+          last_error AS "lastError",
+          created_at AS "createdAt",
+          run_at AS "runAt",
+          sent_at AS "sentAt",
+          payload
+        FROM job_outbox
+        WHERE type = ${EMAIL_JOB_TYPE}
+          AND (${args.status} = 'ALL' OR status = ${args.status})
+        ORDER BY created_at DESC
+        LIMIT ${args.limit ?? 30}
+      `;
+
+    return rows.map((row) => {
+      const parsed = safeParseJobPayload(EMAIL_JOB_TYPE, row.payload);
+      if (parsed.success) {
+        const summary = summarizePayload(parsed.data);
+        return {
+          ...row,
+          payload: parsed.data,
+          payloadKind: parsed.data.kind,
+          subject: summary.subject,
+          to: parsed.data.to,
+          html: summary.html,
+        } satisfies EmailJobRow;
+      }
+
+      const payload = (row.payload && typeof row.payload === "object")
+        ? row.payload as Record<string, unknown>
+        : {};
+
+      return {
+        ...row,
+        payload,
+        payloadKind: typeof payload.kind === "string" ? payload.kind : "unknown",
+        subject: typeof payload.subject === "string" ? payload.subject : "(invalid payload)",
+        to: typeof payload.to === "string" ? payload.to : "(invalid payload)",
+        html: typeof payload.html === "string" ? payload.html : "",
+      } satisfies EmailJobRow;
+    });
+  });
+}
+
+export async function processOneEmailJob() {
+  const { processEmailOnce } = await import("../worker/commands/process-email-once");
+  return processEmailOnce();
+}
+
+export async function sendSampleEmails(args: { to: string }) {
+  const [{ makeEmailTransporter }, templates] = await Promise.all([
+    import("../lib/email"),
+    import("../lib/email-templates"),
+  ]);
+
+  const email = makeEmailTransporter({ fromName: "MeBike" });
+  await email.transporter.verify();
+
+  const samples = [
+    templates.buildAuthOtpEmail({
+      kind: "auth.verifyOtp",
+      fullName: "An Nguyen",
+      otp: "123456",
+      expiresInMinutes: 10,
+    }),
+    templates.buildAuthOtpEmail({
+      kind: "auth.resetOtp",
+      fullName: "An Nguyen",
+      otp: "654321",
+      expiresInMinutes: 10,
+    }),
+    templates.buildSubscriptionCreatedEmail({
+      fullName: "An Nguyen",
+      packageName: "Goi Thang Thu Nghiem",
+      price: 99000,
+      maxUsages: 30,
+      createdOn: "15/04/2026",
+    }),
+    templates.buildFixedSlotAssignedEmail({
+      fullName: "An Nguyen",
+      stationName: "Tram Ben Thanh",
+      slotDateLabel: "16/04/2026",
+      slotTimeLabel: "09:00",
+    }),
+    templates.buildFixedSlotNoBikeEmail({
+      fullName: "An Nguyen",
+      stationName: "Tram Ben Thanh",
+      slotDateLabel: "16/04/2026",
+      slotTimeLabel: "09:00",
+    }),
+    templates.buildFixedSlotBillingFailedEmail({
+      fullName: "An Nguyen",
+      stationName: "Tram Ben Thanh",
+      slotDateLabel: "16/04/2026",
+      slotTimeLabel: "09:00",
+      reason: "INSUFFICIENT_BALANCE",
+    }),
+    templates.buildReservationConfirmedEmail({
+      fullName: "An Nguyen",
+      stationName: "Tram Nha Hat",
+      bikeId: "MB-102",
+      startTimeLabel: "16/04/2026 08:45",
+      endTimeLabel: "16/04/2026 09:00",
+    }),
+    templates.buildReservationNearExpiryEmail({
+      fullName: "An Nguyen",
+      stationName: "Tram Nha Hat",
+      bikeId: "MB-102",
+      minutesRemaining: 5,
+    }),
+    templates.buildReservationExpiredEmail({
+      fullName: "An Nguyen",
+      stationName: "Tram Nha Hat",
+      bikeId: "MB-102",
+      endTimeLabel: "16/04/2026 09:00",
+    }),
+    templates.buildAgencyApprovedEmail({
+      agencyName: "Agency Demo",
+      loginEmail: "agency.demo@mebike.vn",
+      temporaryPassword: "TempPass!234",
+    }),
+  ];
+
+  const sentSubjects: string[] = [];
+
+  try {
+    for (const [index, sample] of samples.entries()) {
+      await email.transporter.sendMail({
+        from: email.defaultFrom,
+        to: args.to,
+        subject: `[Sample ${index + 1}/${samples.length}] ${sample.subject}`,
+        html: sample.html,
+      });
+      sentSubjects.push(sample.subject);
+    }
+
+    return sentSubjects;
+  }
+  finally {
+    if (typeof email.transporter.close === "function") {
+      email.transporter.close();
+    }
+  }
+}
+
+export async function getEmailJobById(args: {
+  connectionString: string;
+  id: string;
+}) {
+  const jobs = await listEmailJobs({
+    connectionString: args.connectionString,
+    status: "ALL",
+    limit: 100,
+  });
+
+  return jobs.find(job => job.id === args.id) ?? null;
+}
+
+export function formatTimestamp(value: Date | null) {
+  if (!value) {
+    return "-";
+  }
+
+  return new Intl.DateTimeFormat("en-GB", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  }).format(value);
+}
+
+export function stripHtml(html: string) {
+  return html
+    .replace(/<style[\s\S]*?<\/style>/gi, " ")
+    .replace(/<script[\s\S]*?<\/script>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function summarizePayload(payload: JobPayload<"emails.send">) {
+  switch (payload.kind) {
+    case "raw":
+      return {
+        subject: payload.subject,
+        html: payload.html,
+      };
+    case "auth.verifyOtp":
+      return {
+        subject: "Verify OTP",
+        html: `OTP ${payload.otp} for ${payload.fullName}. Expires in ${payload.expiresInMinutes} minutes.`,
+      };
+    case "auth.resetOtp":
+      return {
+        subject: "Reset password OTP",
+        html: `OTP ${payload.otp} for ${payload.fullName}. Expires in ${payload.expiresInMinutes} minutes.`,
+      };
+  }
+}

--- a/apps/server/src/dev-cli/data.ts
+++ b/apps/server/src/dev-cli/data.ts
@@ -499,23 +499,40 @@ export async function listEmailJobs(args: {
   limit?: number;
 }) {
   return withClient(args.connectionString, async (client) => {
-    const rows = await client.$queryRaw<RawEmailJobRow[]>`
-        SELECT
-          id,
-          status,
-          attempts,
-          dedupe_key AS "dedupeKey",
-          last_error AS "lastError",
-          created_at AS "createdAt",
-          run_at AS "runAt",
-          sent_at AS "sentAt",
-          payload
-        FROM job_outbox
-        WHERE type = ${EMAIL_JOB_TYPE}
-          AND (${args.status} = 'ALL' OR status = ${args.status})
-        ORDER BY created_at DESC
-        LIMIT ${args.limit ?? 30}
-      `;
+    const rows = args.status === "ALL"
+      ? await client.$queryRaw<RawEmailJobRow[]>`
+          SELECT
+            id,
+            status,
+            attempts,
+            dedupe_key AS "dedupeKey",
+            last_error AS "lastError",
+            created_at AS "createdAt",
+            run_at AS "runAt",
+            sent_at AS "sentAt",
+            payload
+          FROM job_outbox
+          WHERE type = ${EMAIL_JOB_TYPE}
+          ORDER BY created_at DESC
+          LIMIT ${args.limit ?? 30}
+        `
+      : await client.$queryRaw<RawEmailJobRow[]>`
+          SELECT
+            id,
+            status,
+            attempts,
+            dedupe_key AS "dedupeKey",
+            last_error AS "lastError",
+            created_at AS "createdAt",
+            run_at AS "runAt",
+            sent_at AS "sentAt",
+            payload
+          FROM job_outbox
+          WHERE type = ${EMAIL_JOB_TYPE}
+            AND status = ${args.status}
+          ORDER BY created_at DESC
+          LIMIT ${args.limit ?? 30}
+        `;
 
     return rows.map((row) => {
       const parsed = safeParseJobPayload(EMAIL_JOB_TYPE, row.payload);

--- a/apps/server/src/dev-cli/device.ts
+++ b/apps/server/src/dev-cli/device.ts
@@ -1,0 +1,164 @@
+import type { Buffer } from "node:buffer";
+
+import { execFile } from "node:child_process";
+import { open } from "node:fs/promises";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const PROVISIONING_PREFIX = "CFG ";
+const DEFAULT_BAUD_RATE = 115200;
+const DEFAULT_TIMEOUT_MS = 5000;
+const SERIAL_SETTLE_MS = 250;
+
+export type DeviceConfig = {
+  bikeId: string;
+  wifiSsid: string;
+  wifiPass: string;
+  mqttBrokerIP: string;
+  mqttPort: number;
+  mqttUsername: string;
+  mqttPassword: string;
+};
+
+type ProvisioningResponse = {
+  ok: boolean;
+  type?: string;
+  error?: string;
+  message?: string;
+  requestId?: string;
+  bikeId?: string;
+  wifiSsid?: string;
+  wifiPass?: string;
+  mqttBrokerIP?: string;
+  mqttPort?: number;
+  mqttUsername?: string;
+  mqttPassword?: string;
+};
+
+export async function getDeviceConfig(portPath: string) {
+  const response = await sendProvisioningCommand(portPath, { type: "get-config" });
+  return {
+    bikeId: response.bikeId ?? "",
+    wifiSsid: response.wifiSsid ?? "",
+    wifiPass: response.wifiPass ?? "",
+    mqttBrokerIP: response.mqttBrokerIP ?? "",
+    mqttPort: response.mqttPort ?? 0,
+    mqttUsername: response.mqttUsername ?? "",
+    mqttPassword: response.mqttPassword ?? "",
+  } satisfies DeviceConfig;
+}
+
+export async function setDeviceConfig(portPath: string, updates: Partial<DeviceConfig>) {
+  await sendProvisioningCommand(portPath, {
+    type: "set-config",
+    ...updates,
+  }, 8000);
+}
+
+export async function restartDevice(portPath: string) {
+  await sendProvisioningCommand(portPath, { type: "restart" }, 8000);
+}
+
+async function sendProvisioningCommand(
+  portPath: string,
+  payload: Record<string, string | number | undefined>,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+) {
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= 2; attempt += 1) {
+    const requestId = `${Date.now()}-${Math.random().toString(16).slice(2, 10)}`;
+    const request = `${PROVISIONING_PREFIX}${JSON.stringify({ ...payload, requestId })}\n`;
+
+    await execFileAsync("stty", ["-F", portPath, String(DEFAULT_BAUD_RATE), "raw", "-echo", "-icanon", "min", "0", "time", "5"]);
+
+    const handle = await open(portPath, "r+");
+    const stream = handle.createReadStream({ encoding: "utf8" });
+
+    try {
+      await sleep(SERIAL_SETTLE_MS);
+      const responsePromise = waitForProvisioningResponse(stream, requestId, timeoutMs);
+      await handle.writeFile(request, { encoding: "utf8" });
+      const response = await responsePromise;
+      if (!response.ok) {
+        throw new Error(response.message ?? response.error ?? "device rejected request");
+      }
+      return response;
+    }
+    catch (error) {
+      lastError = error;
+      if (!isTimeoutError(error) || attempt === 2) {
+        throw error;
+      }
+      await sleep(750);
+    }
+    finally {
+      stream.destroy();
+      await handle.close();
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
+
+function waitForProvisioningResponse(stream: NodeJS.ReadableStream, requestId: string, timeoutMs: number) {
+  return new Promise<ProvisioningResponse>((resolve, reject) => {
+    let buffer = "";
+    let cleanup = () => {};
+
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error(`Timed out waiting for device response on serial port for request ${requestId}`));
+    }, timeoutMs);
+
+    const onData = (chunk: string | Buffer) => {
+      buffer += chunk.toString();
+      const lines = buffer.split(/\r?\n/);
+      buffer = lines.pop() ?? "";
+
+      for (const line of lines) {
+        if (!line.startsWith(PROVISIONING_PREFIX)) {
+          continue;
+        }
+
+        let parsed: ProvisioningResponse;
+        try {
+          parsed = JSON.parse(line.slice(PROVISIONING_PREFIX.length)) as ProvisioningResponse;
+        }
+        catch {
+          continue;
+        }
+
+        if (parsed.requestId !== requestId) {
+          continue;
+        }
+
+        cleanup();
+        resolve(parsed);
+        return;
+      }
+    };
+
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+
+    cleanup = () => {
+      clearTimeout(timeout);
+      stream.off("data", onData);
+      stream.off("error", onError);
+    };
+
+    stream.on("data", onData);
+    stream.on("error", onError);
+  });
+}
+
+function isTimeoutError(error: unknown) {
+  return error instanceof Error && error.message.includes("Timed out waiting for device response");
+}
+
+function sleep(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/apps/server/src/dev-cli/env-bootstrap.ts
+++ b/apps/server/src/dev-cli/env-bootstrap.ts
@@ -1,0 +1,9 @@
+import dotenv from "dotenv";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const filePath = fileURLToPath(import.meta.url);
+const serverRoot = path.resolve(path.dirname(filePath), "../..");
+
+dotenv.config({ path: path.join(serverRoot, ".env") });
+dotenv.config({ path: path.join(serverRoot, ".env.local"), override: true });

--- a/apps/server/src/dev-cli/index.ts
+++ b/apps/server/src/dev-cli/index.ts
@@ -1,0 +1,553 @@
+import chalk from "chalk";
+import dotenv from "dotenv";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+import {
+  formatTimestamp,
+  getBikeInspection,
+  getEmailJobById,
+  getPersonaRentalDetail,
+  getStationInspection,
+  listEmailJobs,
+  listPersonaRentalHistory,
+  listStations,
+  processOneEmailJob,
+  sendSampleEmails,
+  stripHtml,
+} from "./data";
+import {
+  getDeviceConfig,
+  restartDevice,
+  setDeviceConfig,
+} from "./device";
+import { runInteractiveCli } from "./interactive";
+import { writeError, writeLine } from "./output";
+import { printPersona } from "./persona-output";
+import {
+  clearCurrentPersona,
+  listSeededPersonas,
+  readCurrentPersona,
+  resolvePersona,
+  writeCurrentPersona,
+} from "./personas";
+import { disposeCliRuntimes } from "./runtime";
+import { updateUserCardBinding } from "./user-card";
+
+const filePath = fileURLToPath(import.meta.url);
+const serverRoot = path.resolve(path.dirname(filePath), "../..");
+const repoRoot = path.resolve(serverRoot, "../..");
+const serverEnvPath = path.join(serverRoot, ".env");
+const serverLocalEnvPath = path.join(serverRoot, ".env.local");
+
+dotenv.config({ path: serverEnvPath });
+dotenv.config({ path: serverLocalEnvPath, override: true });
+
+const [command = "list", ...args] = process.argv.slice(2);
+
+try {
+  switch (command) {
+    case "help":
+    case "--help":
+    case "-h": {
+      printHelp();
+      break;
+    }
+    case "interactive": {
+      const connectionString = requireConnectionString();
+      await runInteractiveCli({ connectionString, repoRoot });
+      break;
+    }
+    case "persona": {
+      const connectionString = requireConnectionString();
+      await handlePersonaCommand(connectionString, args, repoRoot);
+      break;
+    }
+    case "device": {
+      await handleDeviceCommand(args);
+      break;
+    }
+    case "user-card": {
+      const connectionString = requireConnectionString();
+      await handleUserCardCommand(connectionString, args);
+      break;
+    }
+    case "list": {
+      const connectionString = requireConnectionString();
+      if (args.includes("--interactive")) {
+        await runInteractiveCli({ connectionString, repoRoot });
+        break;
+      }
+
+      const status = normalizeStatus(args[0]);
+      const jobs = await listEmailJobs({ connectionString, status, limit: 20 });
+      writeLine(chalk.cyan(`Email jobs (${status})`));
+      if (jobs.length === 0) {
+        writeLine(chalk.yellow("No email jobs found."));
+        break;
+      }
+
+      for (const job of jobs) {
+        writeLine(
+          [
+            colorStatus(job.status).padEnd(19),
+            chalk.white(job.id),
+            chalk.gray(job.payloadKind),
+            chalk.green(job.to),
+            chalk.white(job.subject),
+          ].join("  "),
+        );
+      }
+      break;
+    }
+    case "stations": {
+      const connectionString = requireConnectionString();
+      const search = args[0];
+      const stations = await listStations({ connectionString, search, limit: 30 });
+      writeLine(chalk.cyan(`Stations${search ? ` matching ${search}` : ""}`));
+      if (stations.length === 0) {
+        writeLine(chalk.yellow("No stations found."));
+        break;
+      }
+
+      for (const station of stations) {
+        writeLine(`${chalk.white(station.name)}  ${chalk.gray(station.id)}  bikes ${station.totalBikes}/${station.totalCapacity}  available ${station.availableBikes}  booked ${station.bookedBikes}  reserved ${station.reservedBikes}`);
+      }
+      break;
+    }
+    case "station": {
+      const connectionString = requireConnectionString();
+      const value = args[0];
+      if (!value) {
+        throw new Error("Need station id or name: pnpm dev:cli station <station-id|name>");
+      }
+
+      const station = await getStationInspection({ connectionString, value });
+      if (!station) {
+        throw new Error(`Station not found: ${value}`);
+      }
+
+      writeLine(chalk.cyan(`Station ${station.name}`));
+      writeLine(`${chalk.gray("id")}: ${station.id}`);
+      writeLine(`${chalk.gray("type")}: ${station.stationType}`);
+      writeLine(`${chalk.gray("address")}: ${station.address}`);
+      writeLine(`${chalk.gray("capacity")}: ${station.totalBikes}/${station.totalCapacity}`);
+      writeLine(`${chalk.gray("returnSlots")}: ${station.returnSlotLimit}`);
+      writeLine(`${chalk.gray("bikes")}: available ${station.availableBikes}, booked ${station.bookedBikes}, reserved ${station.reservedBikes}, broken ${station.brokenBikes}, maintained ${station.maintainedBikes}, unavailable ${station.unavailableBikes}`);
+      for (const bike of station.bikes) {
+        writeLine(`- ${bike.bikeNumber} ${bike.status} ${bike.id} ${bike.chipId}`);
+      }
+      break;
+    }
+    case "bike": {
+      const connectionString = requireConnectionString();
+      const value = args[0];
+      if (!value) {
+        throw new Error("Need bike id, bike number, or chip id: pnpm dev:cli bike <value>");
+      }
+
+      const bike = await getBikeInspection({ connectionString, value });
+      if (!bike) {
+        throw new Error(`Bike not found: ${value}`);
+      }
+
+      writeLine(chalk.cyan(`Bike ${bike.bikeNumber}`));
+      writeLine(`${chalk.gray("id")}: ${bike.id}`);
+      writeLine(`${chalk.gray("chip")}: ${bike.chipId}`);
+      writeLine(`${chalk.gray("status")}: ${bike.status}`);
+      writeLine(`${chalk.gray("station")}: ${bike.stationName ?? "-"}`);
+      writeLine(`${chalk.gray("supplier")}: ${bike.supplierName ?? "-"}`);
+      writeLine(`${chalk.gray("activeRental")}: ${bike.activeRentalId ?? "-"}`);
+      writeLine(`${chalk.gray("pendingReservation")}: ${bike.pendingReservationId ?? "-"}`);
+      writeLine(`${chalk.gray("updated")}: ${formatTimestamp(bike.updatedAt)}`);
+      for (const rental of bike.recentRentals) {
+        writeLine(`- rental ${rental.id} ${rental.status} ${formatTimestamp(rental.startTime)} ${rental.userEmail}`);
+      }
+      break;
+    }
+    case "rentals": {
+      const connectionString = requireConnectionString();
+      await handleRentalHistoryCommand(connectionString, args, repoRoot);
+      break;
+    }
+    case "rental": {
+      const connectionString = requireConnectionString();
+      await handleRentalDetailCommand(connectionString, args, repoRoot);
+      break;
+    }
+    case "show": {
+      const connectionString = requireConnectionString();
+      const id = args[0];
+      if (!id) {
+        throw new Error("Need job id: pnpm dev:cli show <job-id>");
+      }
+      const job = await getEmailJobById({ connectionString, id });
+      if (!job) {
+        throw new Error(`Email job not found: ${id}`);
+      }
+
+      writeLine(chalk.cyan(`Email job ${job.id}`));
+      writeLine(`${chalk.gray("status")}: ${colorStatus(job.status)}`);
+      writeLine(`${chalk.gray("kind")}: ${job.payloadKind}`);
+      writeLine(`${chalk.gray("to")}: ${job.to}`);
+      writeLine(`${chalk.gray("subject")}: ${job.subject}`);
+      writeLine(`${chalk.gray("attempts")}: ${String(job.attempts)}`);
+      writeLine(`${chalk.gray("created")}: ${formatTimestamp(job.createdAt)}`);
+      writeLine(`${chalk.gray("runAt")}: ${formatTimestamp(job.runAt)}`);
+      writeLine(`${chalk.gray("sentAt")}: ${formatTimestamp(job.sentAt)}`);
+      writeLine(`${chalk.gray("dedupe")}: ${job.dedupeKey ?? "-"}`);
+      writeLine(`${chalk.gray("lastError")}: ${job.lastError ?? "-"}`);
+      writeLine(chalk.magenta("preview"));
+      writeLine(stripHtml(job.html) || "(empty)");
+      break;
+    }
+    case "process-once": {
+      requireConnectionString();
+      const result = await processOneEmailJob();
+      if (result.status === "empty") {
+        writeLine(chalk.yellow("No pending email job."));
+      }
+      else {
+        writeLine(chalk.green(`Processed email job ${result.jobId}.`));
+      }
+      break;
+    }
+    case "send-samples": {
+      requireConnectionString();
+      const to = args[0];
+      if (!to) {
+        throw new Error("Need target email: pnpm dev:cli send-samples <email>");
+      }
+
+      const subjects = await sendSampleEmails({ to });
+      writeLine(chalk.cyan(`Sent ${subjects.length} sample emails to ${to}`));
+      for (const subject of subjects) {
+        writeLine(`- ${subject}`);
+      }
+      break;
+    }
+    default:
+      throw new Error(`Unknown command: ${command}`);
+  }
+}
+catch (error) {
+  writeError(chalk.red(error instanceof Error ? error.message : String(error)));
+  printHelp();
+  process.exitCode = 1;
+}
+finally {
+  await disposeCliRuntimes();
+}
+
+function requireConnectionString() {
+  const connectionString = process.env.DATABASE_URL ?? process.env.TEST_DATABASE_URL;
+  if (!connectionString) {
+    throw new Error("Missing DATABASE_URL or TEST_DATABASE_URL. Load server env first.");
+  }
+
+  return connectionString;
+}
+
+function normalizeStatus(input?: string) {
+  switch (input?.toUpperCase()) {
+    case undefined:
+    case "ALL":
+      return "ALL" as const;
+    case "PENDING":
+    case "SENT":
+    case "FAILED":
+    case "CANCELLED":
+      return input.toUpperCase() as "PENDING" | "SENT" | "FAILED" | "CANCELLED";
+    default:
+      throw new Error(`Unknown status filter: ${input}`);
+  }
+}
+
+function colorStatus(status: string) {
+  switch (status) {
+    case "PENDING":
+      return chalk.yellow(status);
+    case "SENT":
+      return chalk.green(status);
+    case "FAILED":
+      return chalk.red(status);
+    case "CANCELLED":
+      return chalk.gray(status);
+    default:
+      return chalk.white(status);
+  }
+}
+
+function printHelp() {
+  writeLine(chalk.cyan("Usage"));
+  writeLine("  pnpm dev:cli persona list");
+  writeLine("  pnpm dev:cli persona current");
+  writeLine("  pnpm dev:cli persona use <handle|email>");
+  writeLine("  pnpm dev:cli persona clear");
+  writeLine("  pnpm dev:cli device config get [--port /dev/ttyUSB0]");
+  writeLine("  pnpm dev:cli device config set --bike-id <id> [--wifi-ssid <ssid>] [--wifi-pass <pass>] [--mqtt-broker-ip <ip>] [--mqtt-port <port>] [--mqtt-username <user>] [--mqtt-password <pass>] [--port /dev/ttyUSB0]");
+  writeLine("  pnpm dev:cli device restart [--port /dev/ttyUSB0]");
+  writeLine("  pnpm dev:cli user-card <user-id|email|handle> <card-uid>");
+  writeLine("  pnpm dev:cli user-card <user-id|email|handle> --clear");
+  writeLine("  pnpm dev:cli list [ALL|PENDING|SENT|FAILED|CANCELLED]");
+  writeLine("  pnpm dev:cli list --interactive");
+  writeLine("  pnpm dev:cli stations [search]");
+  writeLine("  pnpm dev:cli station <station-id|name>");
+  writeLine("  pnpm dev:cli bike <bike-id|bike-number|chip-id>");
+  writeLine("  pnpm dev:cli rentals [RENTED|COMPLETED|CANCELLED]");
+  writeLine("  pnpm dev:cli rental <rental-id>");
+  writeLine("  pnpm dev:cli show <job-id>");
+  writeLine("  pnpm dev:cli process-once");
+  writeLine("  pnpm dev:cli send-samples <email>");
+  writeLine("  pnpm dev:cli interactive");
+}
+
+async function handleUserCardCommand(connectionString: string, args: string[]) {
+  const [target, cardUid] = args;
+  if (!target || !cardUid) {
+    throw new Error("Need target user and card uid: pnpm dev:cli user-card <user-id|email|handle> <card-uid|--clear>");
+  }
+
+  const nextCardUid = cardUid === "--clear" ? null : cardUid;
+  const updated = await updateUserCardBinding({
+    connectionString,
+    target,
+    cardUid: nextCardUid,
+  });
+
+  writeLine(chalk.cyan(`Updated card binding for ${updated.fullName}`));
+  writeLine(`${chalk.gray("id")}: ${updated.id}`);
+  writeLine(`${chalk.gray("email")}: ${updated.email}`);
+  writeLine(`${chalk.gray("handle")}: ${updated.handle}`);
+  writeLine(`${chalk.gray("nfcCardUid")}: ${updated.nfcCardUid ?? "-"}`);
+}
+
+async function handleDeviceCommand(args: string[]) {
+  const [subcommand, maybeAction, ...rest] = args;
+
+  if (subcommand === "restart") {
+    const flags = parseFlags([maybeAction, ...rest].filter(Boolean) as string[]);
+    const portPath = flags.port ?? "/dev/ttyUSB0";
+    await restartDevice(portPath);
+    writeLine(chalk.green(`Restart command sent to ${portPath}.`));
+    return;
+  }
+
+  const action = maybeAction;
+  const flags = parseFlags(rest);
+  const portPath = flags.port ?? "/dev/ttyUSB0";
+
+  if (subcommand === "config" && action === "get") {
+    const config = await getDeviceConfig(portPath);
+    writeLine(chalk.cyan(`Device config from ${portPath}`));
+    writeLine(`${chalk.gray("bikeId")}: ${config.bikeId}`);
+    writeLine(`${chalk.gray("wifiSsid")}: ${config.wifiSsid}`);
+    writeLine(`${chalk.gray("wifiPass")}: ${config.wifiPass || "-"}`);
+    writeLine(`${chalk.gray("mqttBrokerIP")}: ${config.mqttBrokerIP}`);
+    writeLine(`${chalk.gray("mqttPort")}: ${String(config.mqttPort)}`);
+    writeLine(`${chalk.gray("mqttUsername")}: ${config.mqttUsername || "-"}`);
+    writeLine(`${chalk.gray("mqttPassword")}: ${config.mqttPassword || "-"}`);
+    return;
+  }
+
+  if (subcommand === "config" && action === "set") {
+    const updates = {
+      bikeId: flags["bike-id"],
+      wifiSsid: flags["wifi-ssid"],
+      wifiPass: flags["wifi-pass"],
+      mqttBrokerIP: flags["mqtt-broker-ip"],
+      mqttPort: flags["mqtt-port"] ? Number(flags["mqtt-port"]) : undefined,
+      mqttUsername: flags["mqtt-username"],
+      mqttPassword: flags["mqtt-password"],
+    };
+
+    if (Object.values(updates).every(value => value === undefined)) {
+      throw new Error("Need at least one config field to update.");
+    }
+    if (updates.mqttPort !== undefined && Number.isNaN(updates.mqttPort)) {
+      throw new Error(`Invalid --mqtt-port value: ${flags["mqtt-port"]}`);
+    }
+
+    await setDeviceConfig(portPath, updates);
+    writeLine(chalk.green(`Saved config to ${portPath}. Device is restarting.`));
+    return;
+  }
+
+  throw new Error(`Unknown device command: ${[subcommand, action].filter(Boolean).join(" ")}`);
+}
+
+async function handlePersonaCommand(connectionString: string, args: string[], repoRoot: string) {
+  const [subcommand = "current", value] = args;
+
+  switch (subcommand) {
+    case "list": {
+      const personas = await listSeededPersonas(connectionString);
+      const currentPersonaEmail = await readCurrentPersona(repoRoot);
+      if (personas.length === 0) {
+        writeLine(chalk.yellow("No seeded personas found."));
+        return;
+      }
+
+      for (const persona of personas) {
+        printPersona(persona, currentPersonaEmail);
+      }
+      return;
+    }
+    case "current": {
+      const currentPersonaEmail = await readCurrentPersona(repoRoot);
+      if (!currentPersonaEmail) {
+        writeLine(chalk.yellow("No current persona selected."));
+        return;
+      }
+
+      const persona = await resolvePersona(connectionString, currentPersonaEmail);
+      if (!persona) {
+        writeLine(chalk.red(`Current persona not found in database: ${currentPersonaEmail}`));
+        return;
+      }
+
+      printPersona(persona, currentPersonaEmail);
+      return;
+    }
+    case "use": {
+      if (!value) {
+        throw new Error("Need persona handle or email: pnpm dev:cli persona use <handle|email>");
+      }
+
+      const persona = await resolvePersona(connectionString, value);
+      if (!persona) {
+        throw new Error(`Seeded persona not found: ${value}`);
+      }
+
+      await writeCurrentPersona(repoRoot, persona);
+      writeLine(chalk.green(`Current persona set to ${persona.handle}.`));
+      printPersona(persona, persona.email);
+      return;
+    }
+    case "clear": {
+      await clearCurrentPersona(repoRoot);
+      writeLine(chalk.yellow("Cleared current persona."));
+      return;
+    }
+    default:
+      throw new Error(`Unknown persona command: ${subcommand}`);
+  }
+}
+
+async function handleRentalHistoryCommand(connectionString: string, args: string[], repoRoot: string) {
+  const persona = await requireCurrentPersona(connectionString, repoRoot);
+  const status = normalizeRentalStatus(args[0]);
+  const rentals = await listPersonaRentalHistory({
+    connectionString,
+    userId: persona.id,
+    status,
+    limit: 20,
+  });
+
+  writeLine(chalk.cyan(`Rental history for ${persona.handle}${status ? ` (${status})` : ""}`));
+  if (rentals.length === 0) {
+    writeLine(chalk.yellow("No rentals found."));
+    return;
+  }
+
+  for (const rental of rentals) {
+    writeLine(
+      `${chalk.white(rental.id)} ${rental.status.padEnd(10)} ${rental.bikeNumber.padEnd(8)} ${formatTimestamp(rental.startTime)} -> ${formatTimestamp(rental.endTime)} ${chalk.gray(`${rental.startStationName} -> ${rental.endStationName ?? "-"}`)}`,
+    );
+  }
+}
+
+async function handleRentalDetailCommand(connectionString: string, args: string[], repoRoot: string) {
+  const rentalId = args[0];
+  if (!rentalId) {
+    throw new Error("Need rental id: pnpm dev:cli rental <rental-id>");
+  }
+
+  const persona = await requireCurrentPersona(connectionString, repoRoot);
+  const rental = await getPersonaRentalDetail({
+    connectionString,
+    userId: persona.id,
+    rentalId,
+  });
+
+  if (!rental) {
+    throw new Error(`Rental not found for current persona: ${rentalId}`);
+  }
+
+  writeLine(chalk.cyan(`Rental ${rental.id}`));
+  writeLine(`${chalk.gray("user")}: ${rental.userEmail}`);
+  writeLine(`${chalk.gray("status")}: ${rental.status}`);
+  writeLine(`${chalk.gray("bike")}: ${rental.bikeNumber} ${chalk.gray(`(${rental.bikeId})`)}`);
+  writeLine(`${chalk.gray("chip")}: ${rental.bikeChipId}`);
+  writeLine(`${chalk.gray("bikeStatus")}: ${rental.bikeStatus}`);
+  writeLine(`${chalk.gray("startStation")}: ${rental.startStationName} ${chalk.gray(`(${rental.startStationId})`)}`);
+  writeLine(`${chalk.gray("endStation")}: ${rental.endStationName ?? "-"} ${rental.endStationId ? chalk.gray(`(${rental.endStationId})`) : ""}`.trimEnd());
+  writeLine(`${chalk.gray("startTime")}: ${formatTimestamp(rental.startTime)}`);
+  writeLine(`${chalk.gray("endTime")}: ${formatTimestamp(rental.endTime)}`);
+  writeLine(`${chalk.gray("duration")}: ${rental.durationMinutes ?? "-"}`);
+  writeLine(`${chalk.gray("totalPrice")}: ${rental.totalPrice ?? "-"}`);
+  writeLine(`${chalk.gray("subscriptionId")}: ${rental.subscriptionId ?? "-"}`);
+  writeLine(`${chalk.gray("updated")}: ${formatTimestamp(rental.updatedAt)}`);
+  writeLine(`${chalk.gray("returnConfirmedAt")}: ${formatTimestamp(rental.returnConfirmedAt)}`);
+  writeLine(`${chalk.gray("returnMethod")}: ${rental.returnConfirmationMethod ?? "-"}`);
+  writeLine(`${chalk.gray("handoverStatus")}: ${rental.returnHandoverStatus ?? "-"}`);
+  writeLine(`${chalk.gray("confirmedBy")}: ${rental.returnConfirmedByUserEmail ?? rental.returnConfirmedByUserId ?? "-"}`);
+  writeLine(`${chalk.gray("returnStation")}: ${rental.returnConfirmationStationName ?? rental.returnConfirmationStationId ?? "-"}`);
+  writeLine(`${chalk.gray("billedTotal")}: ${rental.billedTotalAmount ?? "-"}`);
+  writeLine(`${chalk.gray("billedBase")}: ${rental.billedBaseAmount ?? "-"}`);
+  writeLine(`${chalk.gray("billedOvertime")}: ${rental.billedOvertimeAmount ?? "-"}`);
+  writeLine(`${chalk.gray("couponDiscount")}: ${rental.billedCouponDiscountAmount ?? "-"}`);
+  writeLine(`${chalk.gray("subscriptionDiscount")}: ${rental.billedSubscriptionDiscountAmount ?? "-"}`);
+  writeLine(`${chalk.gray("depositForfeited")}: ${rental.billedDepositForfeited ?? "-"}`);
+  writeLine(`${chalk.gray("penalties")}: ${rental.penaltiesCount} item(s), total ${rental.penaltiesTotalAmount ?? 0}`);
+}
+
+async function requireCurrentPersona(connectionString: string, repoRoot: string) {
+  const currentPersonaEmail = await readCurrentPersona(repoRoot);
+  if (!currentPersonaEmail) {
+    throw new Error("No current persona selected. Use: pnpm dev:cli persona use <handle|email>");
+  }
+
+  const persona = await resolvePersona(connectionString, currentPersonaEmail);
+  if (!persona) {
+    throw new Error(`Current persona not found in database: ${currentPersonaEmail}`);
+  }
+
+  return persona;
+}
+
+function normalizeRentalStatus(input?: string) {
+  switch (input?.toUpperCase()) {
+    case undefined:
+      return undefined;
+    case "RENTED":
+    case "COMPLETED":
+    case "CANCELLED":
+      return input.toUpperCase() as "RENTED" | "COMPLETED" | "CANCELLED";
+    default:
+      throw new Error(`Unknown rental status filter: ${input}`);
+  }
+}
+
+function parseFlags(args: string[]) {
+  const flags: Record<string, string> = {};
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (!arg.startsWith("--")) {
+      throw new Error(`Unexpected argument: ${arg}`);
+    }
+
+    const key = arg.slice(2);
+    const value = args[index + 1];
+    if (!value || value.startsWith("--")) {
+      throw new Error(`Missing value for --${key}`);
+    }
+
+    flags[key] = value;
+    index += 1;
+  }
+
+  return flags;
+}

--- a/apps/server/src/dev-cli/interactive.ts
+++ b/apps/server/src/dev-cli/interactive.ts
@@ -1,0 +1,726 @@
+import { confirm, input, select } from "@inquirer/prompts";
+import chalk from "chalk";
+import process from "node:process";
+import { emitKeypressEvents } from "node:readline";
+
+import type { EmailJobStatus } from "./data";
+
+import {
+  confirmRentalReturnAsStaff,
+  formatTimestamp,
+  getBikeInspection,
+  getEmailJobById,
+  getPersonaRentalDetail,
+  getStationInspection,
+  listActiveRentals,
+  listEmailJobs,
+  listPersonaRentalHistory,
+  listStations,
+  processOneEmailJob,
+  sendSampleEmails,
+  stripHtml,
+} from "./data";
+import { getDeviceConfig, restartDevice, setDeviceConfig } from "./device";
+import { writeError, writeLine } from "./output";
+import { printPersona } from "./persona-output";
+import {
+  clearCurrentPersona,
+  listSeededPersonas,
+  readCurrentPersona,
+  resolvePersona,
+  writeCurrentPersona,
+} from "./personas";
+import { updateUserCardBinding } from "./user-card";
+
+const STATUS_OPTIONS: EmailJobStatus[] = ["ALL", "PENDING", "SENT", "FAILED", "CANCELLED"];
+const DEFAULT_DEVICE_PORT = "/dev/ttyUSB0";
+
+export async function runInteractiveCli(args: {
+  connectionString: string;
+  repoRoot: string;
+}) {
+  let status: EmailJobStatus = "ALL";
+  let currentPersonaEmail = await readCurrentPersona(args.repoRoot);
+
+  while (true) {
+    const currentPersona = currentPersonaEmail
+      ? await resolvePersona(args.connectionString, currentPersonaEmail)
+      : null;
+
+    writeLine("");
+    writeLine(chalk.cyan(`Dev CLI interactive mode (filter: ${status})`));
+    writeLine(chalk.gray(`Current persona: ${currentPersonaEmail ?? "none"}`));
+
+    const action = await select<string>({
+      message: "Choose action",
+      choices: [
+        { name: "Choose seeded persona", value: "persona" },
+        ...(currentPersona ? [{ name: "My rental history", value: "my-rentals" }] : []),
+        { name: "Bind user NFC card", value: "user-card" },
+        ...(currentPersona?.role === "STAFF"
+          ? [{ name: "End rental as staff", value: "staff-end-rental" }]
+          : []),
+        { name: "Device config", value: "device-config" },
+        { name: "Browse recent email jobs", value: "browse" },
+        { name: "Browse stations", value: "stations" },
+        { name: "Inspect bike", value: "bike" },
+        { name: "Change status filter", value: "filter" },
+        { name: "Show job by id", value: "show" },
+        { name: "Process one queued email", value: "process" },
+        { name: "Send sample emails", value: "samples" },
+        { name: "Quit", value: "quit" },
+      ],
+    });
+
+    switch (action) {
+      case "persona": {
+        currentPersonaEmail = await choosePersona(args.connectionString, args.repoRoot, currentPersonaEmail);
+        break;
+      }
+      case "my-rentals":
+        await browsePersonaRentals(args.connectionString, currentPersona);
+        break;
+      case "user-card":
+        await bindUserCardInteractive(args.connectionString);
+        break;
+      case "staff-end-rental":
+        await endRentalAsStaffInteractive(args.connectionString, currentPersona);
+        break;
+      case "device-config":
+        await runInteractiveAction(deviceConfigInteractive);
+        break;
+      case "browse":
+        await browseJobs(args.connectionString, status);
+        break;
+      case "stations":
+        await browseStations(args.connectionString);
+        break;
+      case "bike": {
+        const value = await input({ message: "Bike id, bike number, or chip id" });
+        if (value) {
+          await inspectBike(args.connectionString, value);
+        }
+        break;
+      }
+      case "filter":
+        status = await select({
+          message: "Choose status filter",
+          choices: STATUS_OPTIONS.map(value => ({ name: value, value })),
+        });
+        break;
+      case "show": {
+        const id = await input({ message: "Job id" });
+        if (id) {
+          await showJob(args.connectionString, id);
+        }
+        break;
+      }
+      case "process": {
+        const result = await processOneEmailJob();
+        if (result.status === "empty") {
+          writeLine(chalk.yellow("No pending email job."));
+        }
+        else {
+          writeLine(chalk.green(`Processed email job ${result.jobId}.`));
+        }
+        break;
+      }
+      case "samples": {
+        const to = await input({ message: "Target email" });
+        if (to) {
+          const subjects = await sendSampleEmails({ to });
+          writeLine(chalk.green(`Sent ${subjects.length} sample emails to ${to}`));
+        }
+        break;
+      }
+      case "quit":
+        return;
+    }
+  }
+}
+
+async function runInteractiveAction(action: () => Promise<void>) {
+  try {
+    await action();
+  }
+  catch (error) {
+    writeError(chalk.red(error instanceof Error ? error.message : String(error)));
+  }
+}
+
+async function deviceConfigInteractive() {
+  const portPath = await input({
+    message: "Serial port",
+    default: DEFAULT_DEVICE_PORT,
+  });
+
+  if (!portPath) {
+    return;
+  }
+
+  while (true) {
+    const action = await select<string>({
+      message: `Device config (${portPath})`,
+      choices: [
+        { name: "Read current config", value: "read" },
+        { name: "Update config", value: "update" },
+        { name: "Restart device", value: "restart" },
+        { name: "Back", value: "back" },
+      ],
+    });
+
+    if (action === "back") {
+      return;
+    }
+
+    if (action === "read") {
+      await showDeviceConfig(portPath);
+      continue;
+    }
+
+    if (action === "update") {
+      await updateDeviceConfigInteractive(portPath);
+      continue;
+    }
+
+    if (action === "restart") {
+      const confirmed = await confirm({
+        message: `Restart device on ${portPath}?`,
+        default: true,
+      });
+      if (!confirmed) {
+        continue;
+      }
+
+      await restartDevice(portPath);
+      writeLine(chalk.green(`Restart command sent to ${portPath}.`));
+    }
+  }
+}
+
+async function showDeviceConfig(portPath: string) {
+  const config = await getDeviceConfig(portPath);
+  writeLine("");
+  writeLine(chalk.cyan(`Device config from ${portPath}`));
+  writeLine(`${chalk.gray("bikeId")}: ${config.bikeId}`);
+  writeLine(`${chalk.gray("wifiSsid")}: ${config.wifiSsid}`);
+  writeLine(`${chalk.gray("wifiPass")}: ${config.wifiPass || "-"}`);
+  writeLine(`${chalk.gray("mqttBrokerIP")}: ${config.mqttBrokerIP}`);
+  writeLine(`${chalk.gray("mqttPort")}: ${String(config.mqttPort)}`);
+  writeLine(`${chalk.gray("mqttUsername")}: ${config.mqttUsername || "-"}`);
+  writeLine(`${chalk.gray("mqttPassword")}: ${config.mqttPassword || "-"}`);
+}
+
+async function updateDeviceConfigInteractive(portPath: string) {
+  const currentConfig = await getDeviceConfig(portPath);
+
+  const bikeId = await input({ message: "Bike ID", default: currentConfig.bikeId });
+  const wifiSsid = await input({ message: "Wi-Fi SSID", default: currentConfig.wifiSsid });
+  const wifiPass = await input({ message: "Wi-Fi password", default: currentConfig.wifiPass });
+  const mqttBrokerIP = await input({ message: "MQTT broker IP", default: currentConfig.mqttBrokerIP });
+  const mqttPortValue = await input({ message: "MQTT port", default: String(currentConfig.mqttPort) });
+  const mqttUsername = await input({ message: "MQTT username", default: currentConfig.mqttUsername });
+  const mqttPassword = await input({ message: "MQTT password", default: currentConfig.mqttPassword });
+
+  const mqttPort = Number(mqttPortValue);
+  if (!Number.isInteger(mqttPort) || mqttPort <= 0) {
+    throw new Error(`Invalid MQTT port: ${mqttPortValue}`);
+  }
+
+  writeLine("");
+  writeLine(chalk.cyan(`New device config for ${portPath}`));
+  writeLine(`${chalk.gray("bikeId")}: ${bikeId}`);
+  writeLine(`${chalk.gray("wifiSsid")}: ${wifiSsid}`);
+  writeLine(`${chalk.gray("wifiPass")}: ${wifiPass || "-"}`);
+  writeLine(`${chalk.gray("mqttBrokerIP")}: ${mqttBrokerIP}`);
+  writeLine(`${chalk.gray("mqttPort")}: ${String(mqttPort)}`);
+  writeLine(`${chalk.gray("mqttUsername")}: ${mqttUsername || "-"}`);
+  writeLine(`${chalk.gray("mqttPassword")}: ${mqttPassword || "-"}`);
+
+  const confirmed = await confirm({
+    message: `Save this config to ${portPath} and restart device?`,
+    default: true,
+  });
+  if (!confirmed) {
+    return;
+  }
+
+  await setDeviceConfig(portPath, {
+    bikeId,
+    wifiSsid,
+    wifiPass,
+    mqttBrokerIP,
+    mqttPort,
+    mqttUsername,
+    mqttPassword,
+  });
+
+  writeLine(chalk.green(`Saved config to ${portPath}. Device is restarting.`));
+}
+
+async function choosePersona(connectionString: string, repoRoot: string, currentPersonaEmail: string | null) {
+  const personas = await listSeededPersonas(connectionString);
+  if (personas.length === 0) {
+    writeLine(chalk.yellow("No seeded personas found."));
+    return currentPersonaEmail;
+  }
+
+  const selected = await select<string>({
+    message: "Choose seeded persona",
+    choices: [
+      ...personas.map(persona => ({
+        name: `${persona.handle.padEnd(12)} ${persona.role.padEnd(10)} ${persona.email}`,
+        value: persona.email,
+      })),
+      { name: "Clear current persona", value: "__clear" },
+      { name: "Back", value: "__back" },
+    ],
+    pageSize: 14,
+  });
+
+  if (selected === "__back") {
+    return currentPersonaEmail;
+  }
+
+  if (selected === "__clear") {
+    await clearCurrentPersona(repoRoot);
+    writeLine(chalk.yellow("Cleared current persona."));
+    return null;
+  }
+
+  const persona = personas.find(item => item.email === selected)!;
+  await writeCurrentPersona(repoRoot, persona);
+  writeLine(chalk.green(`Current persona set to ${persona.handle} (${persona.email}).`));
+  printPersona(persona, persona.email);
+  return persona.email;
+}
+
+async function bindUserCardInteractive(connectionString: string) {
+  const personas = await listSeededPersonas(connectionString);
+  if (personas.length === 0) {
+    writeLine(chalk.yellow("No seeded personas found."));
+    return;
+  }
+
+  const selected = await select<string>({
+    message: "Choose user to bind card",
+    choices: [
+      ...personas.map(persona => ({
+        name: `${persona.handle.padEnd(12)} ${persona.role.padEnd(10)} ${persona.email} ${chalk.gray(persona.nfcCardUid ?? "")}`.trim(),
+        value: persona.email,
+      })),
+      { name: "Back", value: "__back" },
+    ],
+    pageSize: 14,
+  });
+
+  if (selected === "__back") {
+    return;
+  }
+
+  const cardUid = await input({
+    message: "Card UID (type --clear to remove current binding)",
+    default: "",
+  });
+
+  if (!cardUid) {
+    return;
+  }
+
+  const updated = await updateUserCardBinding({
+    connectionString,
+    target: selected,
+    cardUid: cardUid === "--clear" ? null : cardUid,
+  });
+
+  writeLine(chalk.green(`Updated card binding for ${updated.fullName}`));
+  writeLine(`${chalk.gray("email")}: ${updated.email}`);
+  writeLine(`${chalk.gray("handle")}: ${updated.handle}`);
+  writeLine(`${chalk.gray("nfcCardUid")}: ${updated.nfcCardUid ?? "-"}`);
+}
+
+async function endRentalAsStaffInteractive(
+  connectionString: string,
+  currentPersona: Awaited<ReturnType<typeof resolvePersona>>,
+) {
+  if (!currentPersona || currentPersona.role !== "STAFF") {
+    writeLine(chalk.yellow("Current persona is not a staff user."));
+    return;
+  }
+
+  if (!currentPersona.stationId) {
+    writeLine(chalk.yellow("Current staff persona has no station assignment."));
+    return;
+  }
+
+  const rentals = await listActiveRentals({ connectionString, limit: 20 });
+  if (rentals.length === 0) {
+    writeLine(chalk.yellow("No active rentals found."));
+    return;
+  }
+
+  const selectedRentalId = await select<string>({
+    message: `Choose rental to end at station ${currentPersona.stationId}`,
+    choices: [
+      ...rentals.map(rental => ({
+        name: `${rental.bikeNumber.padEnd(8)} ${rental.userEmail.padEnd(28)} ${formatTimestamp(rental.startTime)} ${rental.id}`,
+        value: rental.id,
+      })),
+      { name: "Back", value: "__back" },
+    ],
+    pageSize: 14,
+  });
+
+  if (selectedRentalId === "__back") {
+    return;
+  }
+
+  const chosenRental = rentals.find(rental => rental.id === selectedRentalId);
+  if (!chosenRental) {
+    writeLine(chalk.red(`Rental not found in selection: ${selectedRentalId}`));
+    return;
+  }
+
+  const confirmed = await confirm({
+    message: `End rental ${chosenRental.id} for ${chosenRental.userEmail}?`,
+    default: true,
+  });
+
+  if (!confirmed) {
+    return;
+  }
+
+  const completedRental = await confirmRentalReturnAsStaff({
+    connectionString,
+    rentalId: chosenRental.id,
+    staffUserId: currentPersona.id,
+    stationId: currentPersona.stationId,
+  });
+
+  writeLine(chalk.green(`Completed rental ${completedRental.id}`));
+  writeLine(`${chalk.gray("bikeId")}: ${completedRental.bikeId}`);
+  writeLine(`${chalk.gray("userId")}: ${completedRental.userId}`);
+  writeLine(`${chalk.gray("status")}: ${completedRental.status}`);
+  writeLine(`${chalk.gray("endTime")}: ${formatTimestamp(completedRental.endTime ?? null)}`);
+}
+
+async function browsePersonaRentals(
+  connectionString: string,
+  currentPersona: Awaited<ReturnType<typeof resolvePersona>>,
+) {
+  if (!currentPersona) {
+    writeLine(chalk.yellow("Choose a persona first."));
+    return;
+  }
+
+  const status = await select<"ALL" | "RENTED" | "COMPLETED" | "CANCELLED" | "__back">({
+    message: "Choose rental status",
+    choices: [
+      { name: "All", value: "ALL" },
+      { name: "Rented", value: "RENTED" },
+      { name: "Completed", value: "COMPLETED" },
+      { name: "Cancelled", value: "CANCELLED" },
+      { name: "Back", value: "__back" },
+    ],
+  });
+
+  if (status === "__back") {
+    return;
+  }
+
+  const rentals = await listPersonaRentalHistory({
+    connectionString,
+    userId: currentPersona.id,
+    status: status === "ALL" ? undefined : status,
+    limit: 20,
+  });
+
+  if (rentals.length === 0) {
+    writeLine(chalk.yellow("No rentals found for current persona."));
+    return;
+  }
+
+  const selectedRentalId = await select<string>({
+    message: `Choose rental for ${currentPersona.handle}`,
+    choices: [
+      ...rentals.map(rental => ({
+        name: `${rental.status.padEnd(10)} ${rental.bikeNumber.padEnd(8)} ${formatTimestamp(rental.startTime)} ${rental.id}`,
+        value: rental.id,
+      })),
+      { name: "Back", value: "__back" },
+    ],
+    pageSize: 14,
+  });
+
+  if (selectedRentalId === "__back") {
+    return;
+  }
+
+  await inspectPersonaRental(connectionString, currentPersona.id, selectedRentalId);
+}
+
+async function inspectPersonaRental(connectionString: string, userId: string, rentalId: string) {
+  while (true) {
+    const rental = await getPersonaRentalDetail({ connectionString, userId, rentalId });
+    if (!rental) {
+      writeLine(chalk.red(`Rental not found: ${rentalId}`));
+      return;
+    }
+
+    writeLine("");
+    writeLine(chalk.cyan(`Rental ${rental.id}`));
+    writeLine(`${chalk.gray("status")}: ${rental.status}`);
+    writeLine(`${chalk.gray("bike")}: ${rental.bikeNumber} ${chalk.gray(`(${rental.bikeId})`)}`);
+    writeLine(`${chalk.gray("chip")}: ${rental.bikeChipId}`);
+    writeLine(`${chalk.gray("bikeStatus")}: ${rental.bikeStatus}`);
+    writeLine(`${chalk.gray("startStation")}: ${rental.startStationName} ${chalk.gray(`(${rental.startStationAddress})`)}`);
+    writeLine(`${chalk.gray("endStation")}: ${rental.endStationName ?? "-"} ${rental.endStationAddress ? chalk.gray(`(${rental.endStationAddress})`) : ""}`.trimEnd());
+    writeLine(`${chalk.gray("startTime")}: ${formatTimestamp(rental.startTime)}`);
+    writeLine(`${chalk.gray("endTime")}: ${formatTimestamp(rental.endTime)}`);
+    writeLine(`${chalk.gray("duration")}: ${rental.durationMinutes ?? "-"}`);
+    writeLine(`${chalk.gray("totalPrice")}: ${rental.totalPrice ?? "-"}`);
+    writeLine(`${chalk.gray("updated")}: ${formatTimestamp(rental.updatedAt)}`);
+    writeLine(`${chalk.gray("returnConfirmedAt")}: ${formatTimestamp(rental.returnConfirmedAt)}`);
+    writeLine(`${chalk.gray("returnMethod")}: ${rental.returnConfirmationMethod ?? "-"}`);
+    writeLine(`${chalk.gray("handoverStatus")}: ${rental.returnHandoverStatus ?? "-"}`);
+    writeLine(`${chalk.gray("confirmedBy")}: ${rental.returnConfirmedByUserEmail ?? rental.returnConfirmedByUserId ?? "-"}`);
+    writeLine(`${chalk.gray("returnStation")}: ${rental.returnConfirmationStationName ?? rental.returnConfirmationStationId ?? "-"}`);
+    writeLine(`${chalk.gray("billedTotal")}: ${rental.billedTotalAmount ?? "-"}`);
+    writeLine(`${chalk.gray("billedBase")}: ${rental.billedBaseAmount ?? "-"}`);
+    writeLine(`${chalk.gray("billedOvertime")}: ${rental.billedOvertimeAmount ?? "-"}`);
+    writeLine(`${chalk.gray("couponDiscount")}: ${rental.billedCouponDiscountAmount ?? "-"}`);
+    writeLine(`${chalk.gray("subscriptionDiscount")}: ${rental.billedSubscriptionDiscountAmount ?? "-"}`);
+    writeLine(`${chalk.gray("depositForfeited")}: ${rental.billedDepositForfeited ?? "-"}`);
+    writeLine(`${chalk.gray("penalties")}: ${rental.penaltiesCount} item(s), total ${rental.penaltiesTotalAmount ?? 0}`);
+
+    writeLine(chalk.gray("Press r to refresh, b/Enter/q to go back."));
+    const action = await readDetailAction({ allowInspectBike: false });
+    if (action === "refresh") {
+      continue;
+    }
+    return;
+  }
+}
+
+async function browseJobs(connectionString: string, status: EmailJobStatus) {
+  const jobs = await listEmailJobs({ connectionString, status, limit: 20 });
+  if (jobs.length === 0) {
+    writeLine(chalk.yellow("No email jobs found."));
+    return;
+  }
+
+  const selectedId = await select<string>({
+    message: "Select email job",
+    choices: [
+      ...jobs.map(job => ({
+        name: `${job.status.padEnd(9)} ${job.payloadKind.padEnd(16)} ${job.to} ${job.subject}`,
+        value: job.id,
+      })),
+      { name: "Back", value: "__back" },
+    ],
+    pageSize: 12,
+  });
+
+  if (selectedId !== "__back") {
+    await showJob(connectionString, selectedId);
+  }
+}
+
+async function showJob(connectionString: string, id: string) {
+  const job = await getEmailJobById({ connectionString, id });
+  if (!job) {
+    writeLine(chalk.red(`Email job not found: ${id}`));
+    return;
+  }
+
+  writeLine("");
+  writeLine(chalk.cyan(`Email job ${job.id}`));
+  writeLine(`${chalk.gray("status")}: ${job.status}`);
+  writeLine(`${chalk.gray("kind")}: ${job.payloadKind}`);
+  writeLine(`${chalk.gray("to")}: ${job.to}`);
+  writeLine(`${chalk.gray("subject")}: ${job.subject}`);
+  writeLine(`${chalk.gray("attempts")}: ${String(job.attempts)}`);
+  writeLine(`${chalk.gray("created")}: ${formatTimestamp(job.createdAt)}`);
+  writeLine(`${chalk.gray("runAt")}: ${formatTimestamp(job.runAt)}`);
+  writeLine(`${chalk.gray("sentAt")}: ${formatTimestamp(job.sentAt)}`);
+  writeLine(`${chalk.gray("dedupe")}: ${job.dedupeKey ?? "-"}`);
+  writeLine(`${chalk.gray("lastError")}: ${job.lastError ?? "-"}`);
+  writeLine(chalk.magenta("preview"));
+  writeLine(stripHtml(job.html) || "(empty)");
+
+  await confirm({ message: "Back to menu", default: true });
+}
+
+async function browseStations(connectionString: string) {
+  const search = await input({ message: "Search station name or id (blank for recent)", default: "" });
+  const stations = await listStations({
+    connectionString,
+    limit: 20,
+    search: search.trim() || undefined,
+  });
+
+  if (stations.length === 0) {
+    writeLine(chalk.yellow("No stations found."));
+    return;
+  }
+
+  const selected = await select<string>({
+    message: "Select station",
+    choices: [
+      ...stations.map(station => ({
+        name: `${station.name.padEnd(24)} bikes ${String(station.totalBikes).padStart(2)}  available ${String(station.availableBikes).padStart(2)}  ${station.id}`,
+        value: station.id,
+      })),
+      { name: "Back", value: "__back" },
+    ],
+    pageSize: 14,
+  });
+
+  if (selected !== "__back") {
+    await inspectStation(connectionString, selected);
+  }
+}
+
+async function inspectStation(connectionString: string, value: string) {
+  while (true) {
+    const station = await getStationInspection({ connectionString, value });
+    if (!station) {
+      writeLine(chalk.red(`Station not found: ${value}`));
+      return;
+    }
+
+    writeLine("");
+    writeLine(chalk.cyan(`Station ${station.name}`));
+    writeLine(`${chalk.gray("id")}: ${station.id}`);
+    writeLine(`${chalk.gray("type")}: ${station.stationType}`);
+    writeLine(`${chalk.gray("address")}: ${station.address}`);
+    writeLine(`${chalk.gray("capacity")}: ${station.totalBikes}/${station.totalCapacity} bikes`);
+    writeLine(`${chalk.gray("returnSlots")}: ${station.returnSlotLimit}`);
+    writeLine(`${chalk.gray("status")}: available ${station.availableBikes}, booked ${station.bookedBikes}, reserved ${station.reservedBikes}, broken ${station.brokenBikes}, maintained ${station.maintainedBikes}, unavailable ${station.unavailableBikes}`);
+    writeLine(`${chalk.gray("updated")}: ${formatTimestamp(station.updatedAt)}`);
+    writeLine(chalk.magenta("bikes in station"));
+    if (station.bikes.length === 0) {
+      writeLine(chalk.yellow("  No bikes in this station."));
+    }
+    else {
+      for (const bike of station.bikes) {
+        const activity = [
+          bike.activeRentalId ? chalk.green("active-rental") : null,
+          bike.pendingReservationId ? chalk.yellow("pending-reservation") : null,
+        ].filter(Boolean).join(", ");
+        writeLine(`  ${chalk.white(bike.bikeNumber.padEnd(8))} ${chalk.gray(bike.id)} ${bike.status.padEnd(11)} ${bike.chipId}${activity ? ` ${chalk.gray(`(${activity})`)}` : ""}`);
+      }
+    }
+
+    writeLine(chalk.gray("Press r to refresh, i to inspect a bike, b/Enter/q to go back."));
+    const action = await readDetailAction({ allowInspectBike: station.bikes.length > 0 });
+    if (action === "refresh") {
+      continue;
+    }
+    if (action === "inspect-bike") {
+      const bikeId = await select<string>({
+        message: "Select bike",
+        choices: [
+          ...station.bikes.map(bike => ({
+            name: `${bike.bikeNumber} ${bike.status} ${bike.id}`,
+            value: bike.id,
+          })),
+          { name: "Back", value: "__back" },
+        ],
+        pageSize: 14,
+      });
+
+      if (bikeId !== "__back") {
+        await inspectBike(connectionString, bikeId);
+      }
+      continue;
+    }
+
+    return;
+  }
+}
+
+async function inspectBike(connectionString: string, value: string) {
+  while (true) {
+    const bike = await getBikeInspection({ connectionString, value });
+    if (!bike) {
+      writeLine(chalk.red(`Bike not found: ${value}`));
+      return;
+    }
+
+    writeLine("");
+    writeLine(chalk.cyan(`Bike ${bike.bikeNumber}`));
+    writeLine(`${chalk.gray("id")}: ${bike.id}`);
+    writeLine(`${chalk.gray("chip")}: ${bike.chipId}`);
+    writeLine(`${chalk.gray("status")}: ${bike.status}`);
+    writeLine(`${chalk.gray("station")}: ${bike.stationName ?? "-"} ${bike.stationAddress ? `(${bike.stationAddress})` : ""}`);
+    writeLine(`${chalk.gray("supplier")}: ${bike.supplierName ?? "-"}`);
+    writeLine(`${chalk.gray("activeRental")}: ${bike.activeRentalId ?? "-"}`);
+    writeLine(`${chalk.gray("pendingReservation")}: ${bike.pendingReservationId ?? "-"}`);
+    writeLine(`${chalk.gray("created")}: ${formatTimestamp(bike.createdAt)}`);
+    writeLine(`${chalk.gray("updated")}: ${formatTimestamp(bike.updatedAt)}`);
+    writeLine(chalk.magenta("recent rentals"));
+    if (bike.recentRentals.length === 0) {
+      writeLine(chalk.yellow("  No rentals found."));
+    }
+    else {
+      for (const rental of bike.recentRentals) {
+        writeLine(`  ${chalk.white(rental.id)} ${rental.status.padEnd(10)} ${formatTimestamp(rental.startTime)} -> ${formatTimestamp(rental.endTime)} ${chalk.gray(rental.userEmail)}`);
+      }
+    }
+
+    writeLine(chalk.gray("Press r to refresh, b/Enter/q to go back."));
+    const action = await readDetailAction({ allowInspectBike: false });
+    if (action === "refresh") {
+      continue;
+    }
+    return;
+  }
+}
+
+async function readDetailAction(args: { allowInspectBike: boolean }) {
+  if (!process.stdin.isTTY || typeof process.stdin.setRawMode !== "function") {
+    return "back" as const;
+  }
+
+  return new Promise<"refresh" | "back" | "inspect-bike">((resolve) => {
+    const stdin = process.stdin;
+    const previousRawMode = stdin.isRaw;
+    emitKeypressEvents(stdin);
+    stdin.setRawMode(true);
+    stdin.resume();
+    let cleanup = () => {};
+
+    function onKeypress(_value: string, key: { ctrl?: boolean; name?: string }) {
+      if (key.ctrl && key.name === "c") {
+        cleanup();
+        process.exit(130);
+      }
+
+      if (key.name === "r") {
+        cleanup();
+        resolve("refresh");
+        return;
+      }
+
+      if (args.allowInspectBike && key.name === "i") {
+        cleanup();
+        resolve("inspect-bike");
+        return;
+      }
+
+      if (key.name === "return" || key.name === "escape" || key.name === "b" || key.name === "q") {
+        cleanup();
+        resolve("back");
+      }
+    }
+
+    cleanup = () => {
+      stdin.off("keypress", onKeypress);
+      stdin.setRawMode(Boolean(previousRawMode));
+      stdin.pause();
+    };
+
+    stdin.on("keypress", onKeypress);
+  });
+}

--- a/apps/server/src/dev-cli/output.ts
+++ b/apps/server/src/dev-cli/output.ts
@@ -1,0 +1,9 @@
+import process from "node:process";
+
+export function writeLine(value: string) {
+  process.stdout.write(`${value}\n`);
+}
+
+export function writeError(value: string) {
+  process.stderr.write(`${value}\n`);
+}

--- a/apps/server/src/dev-cli/persona-output.ts
+++ b/apps/server/src/dev-cli/persona-output.ts
@@ -1,0 +1,18 @@
+import chalk from "chalk";
+
+import type { PersonaRecord } from "./personas";
+
+import { writeLine } from "./output";
+
+export function printPersona(persona: PersonaRecord, currentEmail?: string | null) {
+  const currentMark = currentEmail === persona.email ? chalk.green("* current") : "";
+  writeLine(
+    [
+      chalk.cyan(persona.handle.padEnd(12)),
+      chalk.white(persona.email.padEnd(24)),
+      chalk.yellow(persona.role.padEnd(10)),
+      persona.fullName,
+      currentMark,
+    ].filter(Boolean).join("  "),
+  );
+}

--- a/apps/server/src/dev-cli/personas.ts
+++ b/apps/server/src/dev-cli/personas.ts
@@ -1,0 +1,166 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+import { withPrismaClient } from "./runtime";
+
+export type PersonaRecord = {
+  id: string;
+  fullName: string;
+  email: string;
+  role: string;
+  handle: string;
+  nfcCardUid?: string | null;
+  stationId?: string | null;
+  agencyId?: string | null;
+};
+
+type PersonaState = {
+  currentPersonaEmail: string;
+};
+
+const STATE_FILE_NAME = ".mebike-dev-cli.json";
+
+const personaSelect = {
+  id: true,
+  fullName: true,
+  email: true,
+  role: true,
+  nfcCardUid: true,
+  orgAssignment: {
+    select: {
+      stationId: true,
+      agencyId: true,
+    },
+  },
+} as const;
+
+const roleRank: Record<string, number> = {
+  ADMIN: 0,
+  MANAGER: 1,
+  STAFF: 2,
+  AGENCY: 3,
+  TECHNICIAN: 4,
+};
+
+function toPersonaRecord(row: {
+  id: string;
+  fullName: string;
+  email: string;
+  role: string;
+  nfcCardUid: string | null;
+  orgAssignment: {
+    stationId: string | null;
+    agencyId: string | null;
+  } | null;
+}): PersonaRecord {
+  return {
+    id: row.id,
+    fullName: row.fullName,
+    email: row.email,
+    role: row.role,
+    handle: row.email.replace(/@mebike\.local$/u, ""),
+    nfcCardUid: row.nfcCardUid,
+    stationId: row.orgAssignment?.stationId ?? null,
+    agencyId: row.orgAssignment?.agencyId ?? null,
+  } satisfies PersonaRecord;
+}
+
+export async function listSeededPersonas(connectionString: string) {
+  void connectionString;
+  const rows = await withPrismaClient(client =>
+    client.user.findMany({
+      where: {
+        email: { endsWith: "@mebike.local" },
+      },
+      select: personaSelect,
+    }),
+  );
+
+  return rows
+    .map(toPersonaRecord)
+    .sort((left, right) => {
+      const rankDiff = (roleRank[left.role] ?? 99) - (roleRank[right.role] ?? 99);
+      return rankDiff !== 0 ? rankDiff : left.email.localeCompare(right.email);
+    });
+}
+
+export async function resolvePersona(connectionString: string, value: string) {
+  const personas = await listSeededPersonas(connectionString);
+  return personas.find(persona => persona.email === value || persona.handle === value) ?? null;
+}
+
+export async function resolveUserCardTarget(connectionString: string, value: string) {
+  void connectionString;
+  const handleEmail = value.includes("@") ? value : `${value}@mebike.local`;
+  const rows = await withPrismaClient(client =>
+    client.user.findMany({
+      where: {
+        OR: [
+          { id: value },
+          { email: value },
+          { email: handleEmail },
+        ],
+      },
+      select: personaSelect,
+      take: 5,
+    }),
+  );
+
+  return rows
+    .map(toPersonaRecord)
+    .sort((left, right) => {
+      const leftRank = left.id === value ? 0 : left.email === value ? 1 : 2;
+      const rightRank = right.id === value ? 0 : right.email === value ? 1 : 2;
+      return leftRank - rightRank;
+    })[0] ?? null;
+}
+
+export async function readCurrentPersona(repoRoot: string) {
+  const state = await readStateFile(repoRoot);
+  return state?.currentPersonaEmail ?? null;
+}
+
+export async function writeCurrentPersona(repoRoot: string, persona: PersonaRecord) {
+  const statePath = getStateFilePath(repoRoot);
+  const nextState: PersonaState = {
+    currentPersonaEmail: persona.email,
+  };
+
+  await fs.writeFile(statePath, JSON.stringify(nextState, null, 2), "utf8");
+}
+
+export async function clearCurrentPersona(repoRoot: string) {
+  const statePath = getStateFilePath(repoRoot);
+  try {
+    await fs.unlink(statePath);
+  }
+  catch (error) {
+    if (!isMissingFileError(error)) {
+      throw error;
+    }
+  }
+}
+
+function getStateFilePath(repoRoot: string) {
+  return path.join(repoRoot, STATE_FILE_NAME);
+}
+
+async function readStateFile(repoRoot: string) {
+  const statePath = getStateFilePath(repoRoot);
+
+  try {
+    const raw = await fs.readFile(statePath, "utf8");
+    return JSON.parse(raw) as PersonaState;
+  }
+  catch (error) {
+    if (isMissingFileError(error)) {
+      return null;
+    }
+
+    throw error;
+  }
+}
+
+function isMissingFileError(error: unknown) {
+  return error instanceof Error && "code" in error && error.code === "ENOENT";
+}

--- a/apps/server/src/dev-cli/runtime.ts
+++ b/apps/server/src/dev-cli/runtime.ts
@@ -1,0 +1,72 @@
+import { Effect, ManagedRuntime, Option } from "effect";
+
+import "./env-bootstrap";
+
+import type { PrismaClient } from "generated/prisma/client";
+
+import { RentalCommandServiceTag } from "../domain/rentals";
+import { UserCommandServiceTag } from "../domain/users";
+import {
+  PrismaLive,
+  RentalCommandServiceLayer,
+  UserCommandServiceLayer,
+} from "../http/shared/providers";
+import { Prisma } from "../infrastructure/prisma";
+
+const rentalCommandRuntime = ManagedRuntime.make(RentalCommandServiceLayer);
+const prismaRuntime = ManagedRuntime.make(PrismaLive);
+const userCommandRuntime = ManagedRuntime.make(UserCommandServiceLayer);
+
+export async function disposeCliRuntimes() {
+  await Promise.allSettled([
+    rentalCommandRuntime.dispose(),
+    prismaRuntime.dispose(),
+    userCommandRuntime.dispose(),
+  ]);
+}
+
+export async function confirmRentalReturnByStaff(args: {
+  rentalId: string;
+  staffUserId: string;
+  stationId: string;
+}) {
+  return rentalCommandRuntime.runPromise(
+    Effect.flatMap(RentalCommandServiceTag, rentalCommandService =>
+      rentalCommandService.confirmReturnByOperator({
+        rentalId: args.rentalId,
+        stationId: args.stationId,
+        confirmedByUserId: args.staffUserId,
+        operatorRole: "STAFF",
+        operatorStationId: args.stationId,
+        confirmationMethod: "MANUAL",
+        confirmedAt: new Date(),
+      })),
+  );
+}
+
+export async function updateUserCardUid(args: {
+  userId: string;
+  nfcCardUid: string | null;
+}) {
+  const updated = await userCommandRuntime.runPromise(
+    Effect.flatMap(UserCommandServiceTag, userCommandService =>
+      userCommandService.updateAdminById(args.userId, {
+        nfcCardUid: args.nfcCardUid,
+      })),
+  );
+
+  if (Option.isNone(updated)) {
+    throw new Error(`Failed to update user card uid: ${args.userId}`);
+  }
+
+  return updated.value;
+}
+
+export async function withPrismaClient<T>(
+  task: (client: PrismaClient) => Promise<T>,
+) {
+  return prismaRuntime.runPromise(
+    Effect.flatMap(Prisma, prisma =>
+      Effect.promise(() => task(prisma.client))),
+  );
+}

--- a/apps/server/src/dev-cli/user-card.ts
+++ b/apps/server/src/dev-cli/user-card.ts
@@ -1,0 +1,23 @@
+import { resolveUserCardTarget } from "./personas";
+import { updateUserCardUid } from "./runtime";
+
+export async function updateUserCardBinding(args: {
+  connectionString: string;
+  target: string;
+  cardUid: string | null;
+}) {
+  const user = await resolveUserCardTarget(args.connectionString, args.target);
+  if (!user) {
+    throw new Error(`User not found: ${args.target}`);
+  }
+
+  const updated = await updateUserCardUid({
+    userId: user.id,
+    nfcCardUid: args.cardUid,
+  });
+
+  return {
+    ...user,
+    nfcCardUid: updated.nfcCardUid,
+  };
+}

--- a/apps/server/src/worker/commands/process-email-once.ts
+++ b/apps/server/src/worker/commands/process-email-once.ts
@@ -1,4 +1,6 @@
+import { resolve } from "node:path";
 import process from "node:process";
+import { fileURLToPath } from "node:url";
 
 import { makeJobBackend } from "@/infrastructure/jobs/backend";
 import { JobTypes } from "@/infrastructure/jobs/job-types";
@@ -9,7 +11,11 @@ import logger from "@/lib/logger";
 import { handleEmailJob } from "../email-worker";
 import { attachJobRuntimeLogging, WorkerLog } from "../worker-logging";
 
-async function main() {
+export type ProcessEmailOnceResult
+  = | { readonly status: "empty" }
+    | { readonly status: "processed"; readonly jobId: string };
+
+export async function processEmailOnce(): Promise<ProcessEmailOnceResult> {
   const { runtime } = makeJobBackend();
   attachJobRuntimeLogging(runtime);
   await runtime.start();
@@ -30,7 +36,7 @@ async function main() {
     if (typeof email.transporter.close === "function") {
       email.transporter.close();
     }
-    return;
+    return { status: "empty" };
   }
 
   try {
@@ -38,6 +44,7 @@ async function main() {
     await handleEmailJob(job, email);
     await runtime.complete(JobTypes.EmailSend, job.id);
     WorkerLog.completedOnce(JobTypes.EmailSend, job.id);
+    return { status: "processed", jobId: job.id };
   }
   catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -53,7 +60,11 @@ async function main() {
   }
 }
 
-main().catch((err) => {
-  logger.error({ err }, "process-email-once failed");
-  process.exit(1);
-});
+const isMain = fileURLToPath(import.meta.url) === resolve(process.argv[1] ?? "");
+
+if (isMain) {
+  processEmailOnce().catch((err) => {
+    logger.error({ err }, "process-email-once failed");
+    process.exit(1);
+  });
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   "main": "index.js",
   "scripts": {
     "dev": "turbo run dev --parallel",
+    "dev:cli": "pnpm --dir apps/server dev:cli",
+    "dev:cli:interactive": "pnpm --dir apps/server dev:cli:interactive",
     "openapi:generate": "pnpm --filter iot-service openapi:generate",
     "orval": "orval --config orval.config.ts --tsconfig packages/shared/tsconfig.json",
     "client:generate": "pnpm openapi:generate && pnpm orval",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -599,6 +599,9 @@ importers:
       '@hono/zod-openapi':
         specifier: ^1.1.3
         version: 1.2.0(hono@4.12.9)(zod@4.3.5)
+      '@inquirer/prompts':
+        specifier: ^7.10.1
+        version: 7.10.1(@types/node@24.10.7)
       '@mapbox/mapbox-sdk':
         specifier: ^0.16.2
         version: 0.16.2
@@ -626,6 +629,9 @@ importers:
       bcrypt:
         specifier: ^6.0.0
         version: 6.0.0
+      chalk:
+        specifier: ^5.6.2
+        version: 5.6.2
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
@@ -2608,6 +2614,140 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
+
+  '@inquirer/ansi@1.0.2':
+    resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==}
+    engines: {node: '>=18'}
+
+  '@inquirer/checkbox@4.3.2':
+    resolution: {integrity: sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/confirm@5.1.21':
+    resolution: {integrity: sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@10.3.2':
+    resolution: {integrity: sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/editor@4.2.23':
+    resolution: {integrity: sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/expand@4.0.23':
+    resolution: {integrity: sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/external-editor@1.0.3':
+    resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@1.0.15':
+    resolution: {integrity: sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==}
+    engines: {node: '>=18'}
+
+  '@inquirer/input@4.3.1':
+    resolution: {integrity: sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/number@3.0.23':
+    resolution: {integrity: sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/password@4.0.23':
+    resolution: {integrity: sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/prompts@7.10.1':
+    resolution: {integrity: sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/rawlist@4.1.11':
+    resolution: {integrity: sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/search@3.2.2':
+    resolution: {integrity: sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/select@4.4.2':
+    resolution: {integrity: sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/type@3.0.10':
+    resolution: {integrity: sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   '@ioredis/commands@1.4.0':
     resolution: {integrity: sha512-aFT2yemJJo+TZCmieA7qnYGQooOS7QfNmYrzGtsYd3g9j5iDP8AimYYAesf79ohjbLG12XxC4nG5DyEnC88AsQ==}
@@ -6194,6 +6334,10 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
   change-case@5.4.4:
     resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
 
@@ -6203,6 +6347,9 @@ packages:
 
   character-entities@2.0.2:
     resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  chardet@2.1.1:
+    resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
 
   cheap-ruler@4.0.0:
     resolution: {integrity: sha512-0BJa8f4t141BYKQyn9NSQt1PguFQXMXwZiA5shfoaBYHAb2fFk2RAX+tiWMoQU+Agtzt3mdt0JtuyshAXqZ+Vw==}
@@ -6264,6 +6411,10 @@ packages:
   cli-spinners@2.9.2:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
     engines: {node: '>=6'}
+
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
@@ -7533,7 +7684,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: '>=3.0.2'
+      picomatch: '>=4.0.4'
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -9332,6 +9483,10 @@ packages:
 
   murmurhash-js@1.0.0:
     resolution: {integrity: sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==}
+
+  mute-stream@2.0.0:
+    resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
 
   mylas@2.1.14:
     resolution: {integrity: sha512-BzQguy9W9NJgoVn2mRWzbFrFWWztGCcng2QI9+41frfk+Athwgx3qhqhvStz7ExeUUu7Kzw427sNzHpEZNINog==}
@@ -11964,6 +12119,10 @@ packages:
     resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
     engines: {node: '>=12.20'}
 
+  yoctocolors-cjs@2.1.3:
+    resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
+    engines: {node: '>=18'}
+
   z-schema@5.0.5:
     resolution: {integrity: sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==}
     engines: {node: '>=8.0.0'}
@@ -14496,6 +14655,131 @@ snapshots:
 
   '@img/sharp-win32-x64@0.34.5':
     optional: true
+
+  '@inquirer/ansi@1.0.2': {}
+
+  '@inquirer/checkbox@4.3.2(@types/node@24.10.7)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@24.10.7)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@24.10.7)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.10.7
+
+  '@inquirer/confirm@5.1.21(@types/node@24.10.7)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.10.7)
+      '@inquirer/type': 3.0.10(@types/node@24.10.7)
+    optionalDependencies:
+      '@types/node': 24.10.7
+
+  '@inquirer/core@10.3.2(@types/node@24.10.7)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@24.10.7)
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.10.7
+
+  '@inquirer/editor@4.2.23(@types/node@24.10.7)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.10.7)
+      '@inquirer/external-editor': 1.0.3(@types/node@24.10.7)
+      '@inquirer/type': 3.0.10(@types/node@24.10.7)
+    optionalDependencies:
+      '@types/node': 24.10.7
+
+  '@inquirer/expand@4.0.23(@types/node@24.10.7)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.10.7)
+      '@inquirer/type': 3.0.10(@types/node@24.10.7)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.10.7
+
+  '@inquirer/external-editor@1.0.3(@types/node@24.10.7)':
+    dependencies:
+      chardet: 2.1.1
+      iconv-lite: 0.7.2
+    optionalDependencies:
+      '@types/node': 24.10.7
+
+  '@inquirer/figures@1.0.15': {}
+
+  '@inquirer/input@4.3.1(@types/node@24.10.7)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.10.7)
+      '@inquirer/type': 3.0.10(@types/node@24.10.7)
+    optionalDependencies:
+      '@types/node': 24.10.7
+
+  '@inquirer/number@3.0.23(@types/node@24.10.7)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.10.7)
+      '@inquirer/type': 3.0.10(@types/node@24.10.7)
+    optionalDependencies:
+      '@types/node': 24.10.7
+
+  '@inquirer/password@4.0.23(@types/node@24.10.7)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@24.10.7)
+      '@inquirer/type': 3.0.10(@types/node@24.10.7)
+    optionalDependencies:
+      '@types/node': 24.10.7
+
+  '@inquirer/prompts@7.10.1(@types/node@24.10.7)':
+    dependencies:
+      '@inquirer/checkbox': 4.3.2(@types/node@24.10.7)
+      '@inquirer/confirm': 5.1.21(@types/node@24.10.7)
+      '@inquirer/editor': 4.2.23(@types/node@24.10.7)
+      '@inquirer/expand': 4.0.23(@types/node@24.10.7)
+      '@inquirer/input': 4.3.1(@types/node@24.10.7)
+      '@inquirer/number': 3.0.23(@types/node@24.10.7)
+      '@inquirer/password': 4.0.23(@types/node@24.10.7)
+      '@inquirer/rawlist': 4.1.11(@types/node@24.10.7)
+      '@inquirer/search': 3.2.2(@types/node@24.10.7)
+      '@inquirer/select': 4.4.2(@types/node@24.10.7)
+    optionalDependencies:
+      '@types/node': 24.10.7
+
+  '@inquirer/rawlist@4.1.11(@types/node@24.10.7)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.10.7)
+      '@inquirer/type': 3.0.10(@types/node@24.10.7)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.10.7
+
+  '@inquirer/search@3.2.2(@types/node@24.10.7)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.10.7)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@24.10.7)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.10.7
+
+  '@inquirer/select@4.4.2(@types/node@24.10.7)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@24.10.7)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@24.10.7)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.10.7
+
+  '@inquirer/type@3.0.10(@types/node@24.10.7)':
+    optionalDependencies:
+      '@types/node': 24.10.7
 
   '@ioredis/commands@1.4.0': {}
 
@@ -20058,11 +20342,15 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  chalk@5.6.2: {}
+
   change-case@5.4.4: {}
 
   char-regex@1.0.2: {}
 
   character-entities@2.0.2: {}
+
+  chardet@2.1.1: {}
 
   cheap-ruler@4.0.0: {}
 
@@ -20140,6 +20428,8 @@ snapshots:
       restore-cursor: 2.0.0
 
   cli-spinners@2.9.2: {}
+
+  cli-width@4.1.0: {}
 
   client-only@0.0.1: {}
 
@@ -24166,6 +24456,8 @@ snapshots:
 
   murmurhash-js@1.0.0: {}
 
+  mute-stream@2.0.0: {}
+
   mylas@2.1.14: {}
 
   mysql2@3.15.3:
@@ -27159,6 +27451,8 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yocto-queue@1.2.2: {}
+
+  yoctocolors-cjs@2.1.3: {}
 
   z-schema@5.0.5:
     dependencies:


### PR DESCRIPTION
## Summary
- add first-party MeBike dev CLI tooling inside `apps/server` and wire it to Prisma plus existing rental/user services instead of the separate ad-hoc CLI project
- expose CLI workflows for personas, station and bike inspection, email job browsing/processing, sample emails, NFC card binding, and service-backed rental return handling
- remove the station detail header status badge in mobile to free more space for long station titles

## Verification
- pnpm dev:cli --help
- pnpm dev:cli
- pnpm tsc --noEmit