### PR TITLE
feat(mobile): add metro journey screen

### DIFF
--- a/apps/mobile/components/IconSymbol.tsx
+++ b/apps/mobile/components/IconSymbol.tsx
@@ -2,6 +2,7 @@
 
 import type { ColorValue, StyleProp, ViewStyle } from "react-native";
 
+import { iconSizes } from "@theme/metrics";
 import {
   ArrowDown,
   ArrowLeft,
@@ -47,6 +48,7 @@ import {
   Star,
   Tag,
   Timer,
+  TrainFront,
   TriangleAlert,
   User,
   Wallet,
@@ -55,8 +57,6 @@ import {
   X,
 } from "lucide-react-native";
 import React from "react";
-
-import { iconSizes } from "@theme/metrics";
 
 type LucideIconComponent = typeof ArrowLeft;
 
@@ -118,6 +118,7 @@ const ICONS = {
   "station": { outline: { icon: Building2 } },
   "tag": { outline: { icon: Tag } },
   "timer": { outline: { icon: Timer } },
+  "train": { outline: { icon: TrainFront } },
   "tools": { outline: { icon: Wrench } },
   "wallet": { outline: { icon: Wallet } },
   "warning": { outline: { icon: TriangleAlert }, filled: { icon: TriangleAlert, fill: true } },

--- a/apps/mobile/navigation/root-navigator.tsx
+++ b/apps/mobile/navigation/root-navigator.tsx
@@ -1,8 +1,7 @@
-import { createStackNavigator } from "@react-navigation/stack";
-import React from "react";
-
 import { LoadingScreen } from "@components/LoadingScreen";
 import { useAuthNext } from "@providers/auth-provider-next";
+import { createStackNavigator } from "@react-navigation/stack";
+import React from "react";
 
 import type { RootStackParamList } from "../types/navigation";
 
@@ -20,6 +19,7 @@ import {
   ForgotPasswordScreen,
   IntroScreen,
   LoginScreen,
+  MetroJourneyScreen,
   MyWalletScreen,
   QRScannerScreen,
   RegisterScreen,
@@ -67,6 +67,11 @@ function RootNavigator() {
         <Stack.Screen
           name="BikeDetail"
           component={BikeDetailScreen}
+          options={{ headerShown: false, gestureEnabled: false }}
+        />
+        <Stack.Screen
+          name="MetroJourney"
+          component={MetroJourneyScreen}
           options={{ headerShown: false, gestureEnabled: false }}
         />
         <Stack.Screen
@@ -198,6 +203,11 @@ function RootNavigator() {
       <Stack.Screen
         name="MyWallet"
         component={MyWalletScreen}
+        options={{ headerShown: false, gestureEnabled: false }}
+      />
+      <Stack.Screen
+        name="MetroJourney"
+        component={MetroJourneyScreen}
         options={{ headerShown: false, gestureEnabled: false }}
       />
       <Stack.Screen

--- a/apps/mobile/screen/account/profile/hooks/use-profile.ts
+++ b/apps/mobile/screen/account/profile/hooks/use-profile.ts
@@ -114,6 +114,10 @@ export function useProfile() {
     navigation.navigate("EnvironmentImpact" as never);
   };
 
+  const handleMetroJourney = () => {
+    navigation.navigate("MetroJourney" as never);
+  };
+
   const handleNotifications = () => {
     Alert.alert("Sắp ra mắt", "Quản lý thông báo sẽ sớm được cập nhật.");
   };
@@ -137,6 +141,7 @@ export function useProfile() {
     handleReservations,
     handleSubscriptions,
     handleEnvironmentImpact,
+    handleMetroJourney,
     handleNotifications,
     handleResendOtp,
     handleVerifyEmail,

--- a/apps/mobile/screen/account/profile/index.tsx
+++ b/apps/mobile/screen/account/profile/index.tsx
@@ -73,6 +73,7 @@ function ProfileScreen() {
     handleReservations,
     handleSubscriptions,
     handleEnvironmentImpact,
+    handleMetroJourney,
     handleNotifications,
     handleVerifyEmail,
   } = useProfile();
@@ -141,6 +142,14 @@ function ProfileScreen() {
       onPress: handleChangePassword,
     },
     {
+      icon: "map",
+      title: "Hành trình Metro",
+      subtitle: "Xem tàu đang chạy và lịch các ga theo tuyến",
+      iconColor: theme.actionPrimary.val,
+      iconBackground: theme.surfaceAccent.val,
+      onPress: handleMetroJourney,
+    },
+    {
       icon: "bell",
       title: "Thông báo",
       subtitle: "Tùy chỉnh nhắc nhở và cập nhật",
@@ -150,8 +159,10 @@ function ProfileScreen() {
     },
   ], [
     handleChangePassword,
+    handleMetroJourney,
     handleNotifications,
     handleUpdateProfile,
+    theme.actionPrimary.val,
     theme.statusSuccess.val,
     theme.statusWarning.val,
     theme.actionSecondary.val,

--- a/apps/mobile/screen/index.ts
+++ b/apps/mobile/screen/index.ts
@@ -14,6 +14,7 @@ export { default as FixedSlotDetailScreen } from "./fixed-slot-detail-screen";
 export { default as FixedSlotEditorScreen } from "./fixed-slot-editor-screen";
 export { default as FixedSlotTemplatesScreen } from "./fixed-slot-templates";
 export { default as IntroScreen } from "./Intro";
+export { default as MetroJourneyScreen } from "./metro/metro-journey-screen";
 export { default as MyWalletScreen } from "./my-wallet";
 export { default as QRScannerScreen } from "./QRScannerScreen";
 export { default as BikeDetailScreen } from "./rental/bike-detail/bike-detail-screen";

--- a/apps/mobile/screen/metro/hooks/use-metro-journey-screen.ts
+++ b/apps/mobile/screen/metro/hooks/use-metro-journey-screen.ts
@@ -1,0 +1,84 @@
+import type { MetroDirectionId } from "@services/metro";
+
+import { useIsFocused, useNavigation } from "@react-navigation/native";
+import { useGetStationListQuery } from "@hooks/query/stations/use-get-station-list-query";
+import { metroDirectionOptions, metroService } from "@services/metro";
+import { useQuery } from "@tanstack/react-query";
+import { useCallback, useMemo, useState } from "react";
+
+import type { MetroJourneyNavigationProp } from "@/types/navigation";
+
+const metroJourneyQueryKey = "metro-journey";
+const metroJourneyPollIntervalMs = 15_000;
+
+function presentMetroError(error: unknown) {
+  if (error instanceof Error && error.message.length > 0) {
+    return error.message;
+  }
+
+  return "Không thể tải dữ liệu Metro lúc này. Vui lòng thử lại sau.";
+}
+
+export function useMetroJourneyScreen() {
+  const navigation = useNavigation<MetroJourneyNavigationProp>();
+  const isFocused = useIsFocused();
+  const [directionId, setDirectionId] = useState<MetroDirectionId>(1);
+  const { data: stations = [] } = useGetStationListQuery();
+
+  const journeyQuery = useQuery({
+    queryKey: [metroJourneyQueryKey, directionId],
+    queryFn: () => metroService.getJourney(directionId),
+    refetchInterval: isFocused ? metroJourneyPollIntervalMs : false,
+    staleTime: 10_000,
+  });
+
+  const activeDirection = useMemo(
+    () => metroDirectionOptions.find(option => option.directionId === directionId) ?? metroDirectionOptions[0],
+    [directionId],
+  );
+
+  const stationIdByName = useMemo(
+    () => new Map(stations.map(station => [station.name, station.id])),
+    [stations],
+  );
+
+  const goBack = useCallback(() => {
+    navigation.goBack();
+  }, [navigation]);
+
+  const onRefresh = useCallback(async () => {
+    await journeyQuery.refetch();
+  }, [journeyQuery]);
+
+  const openStationDetail = useCallback((stationName: string) => {
+    const stationId = stationIdByName.get(stationName);
+
+    if (!stationId) {
+      return;
+    }
+
+    navigation.navigate("StationDetail", { stationId });
+  }, [navigation, stationIdByName]);
+
+  return {
+    data: journeyQuery.data ?? null,
+    directionId,
+    directionOptions: metroDirectionOptions,
+    activeDirection,
+    isInitialLoading: journeyQuery.isLoading && !journeyQuery.data,
+    isRefreshing: journeyQuery.isRefetching && !journeyQuery.isLoading,
+    initialError: journeyQuery.isError && !journeyQuery.data
+      ? presentMetroError(journeyQuery.error)
+      : null,
+    refreshError: journeyQuery.isError && journeyQuery.data
+      ? presentMetroError(journeyQuery.error)
+      : null,
+    canOpenStationDetail: stationIdByName.size > 0,
+    actions: {
+      goBack,
+      onRefresh,
+      openStationDetail,
+      setDirection: setDirectionId,
+    },
+  };
+}

--- a/apps/mobile/screen/metro/metro-journey-screen.tsx
+++ b/apps/mobile/screen/metro/metro-journey-screen.tsx
@@ -6,25 +6,24 @@ import { AppButton } from "@ui/primitives/app-button";
 import { AppCard } from "@ui/primitives/app-card";
 import { AppText } from "@ui/primitives/app-text";
 import { Screen } from "@ui/primitives/screen";
-import { LinearGradient } from "expo-linear-gradient";
 import { ActivityIndicator, Pressable, RefreshControl, ScrollView, StatusBar } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTheme, View, XStack, YStack } from "tamagui";
 
 import { useMetroJourneyScreen } from "./hooks/use-metro-journey-screen";
 
+const routeCanvasColor = "#EEF0FA";
+const routeRailColor = "#4B6BFB";
 const routeRailWidth = 8;
 const routeStationMarkerSize = 18;
 const routeTrainMarkerSize = 28;
-const routeTrainAuraSize = routeTrainMarkerSize + 10;
-const routeRowHalfHeight = 32;
-const routeSegmentMinHeight = 78;
-const routePixelsPerKm = 54;
-const routeRailLeftInset = 54;
-const routeRowRightInset = 26;
-const routeGradientColors = ["rgba(59,130,246,0.12)", "rgba(168,85,247,0.08)", "rgba(255,255,255,0)"] as const;
-const routeRailColor = "#5B6EF5";
-const routeTrainAuraColor = "rgba(59, 130, 246, 0.18)";
+const routeRowHalfHeight = 36;
+const routeSegmentMinHeight = 82;
+const routePixelsPerKm = 56;
+const routeDistanceColumnWidth = 54;
+const routeRailLeftInset = 62;
+const routeContentGap = 24;
+const routeInfoWidth = 28;
 const routeRailCenterX = routeRailLeftInset + (routeRailWidth / 2);
 
 function formatDistanceLabel(label: string | null, distanceKm: number | null) {
@@ -37,6 +36,11 @@ function formatDistanceLabel(label: string | null, distanceKm: number | null) {
   }
 
   return `${distanceKm.toFixed(1)} km`;
+}
+
+function splitDistanceLabel(label: string) {
+  const [value = "", unit = ""] = label.split(" ");
+  return { unit, value };
 }
 
 function buildSegmentHeights(stations: MetroJourneyStation[]) {
@@ -58,14 +62,42 @@ function buildStationCenterPositions(segmentHeights: number[]) {
   return centerPositions;
 }
 
-function isVehicleNearStation(station: MetroJourneyStation, vehicles: MetroVehicle[]) {
-  return vehicles.some(vehicle => Math.abs(vehicle.percent - station.progress) <= 0.045);
+function HeaderActionButton({
+  icon,
+  onPress,
+  loading = false,
+}: {
+  icon: "arrow-left" | "refresh";
+  loading?: boolean;
+  onPress: () => void;
+}) {
+  const theme = useTheme();
+
+  return (
+    <Pressable onPress={onPress} style={({ pressed }) => ({ opacity: pressed ? 0.88 : 1 })}>
+      <XStack
+        alignItems="center"
+        backgroundColor="$surfaceDefault"
+        borderColor="$borderSubtle"
+        borderRadius="$round"
+        borderWidth={borderWidths.subtle}
+        height={44}
+        justifyContent="center"
+        style={elevations.whisper}
+        width={44}
+      >
+        {loading
+          ? <ActivityIndicator color={theme.textSecondary.val} size="small" />
+          : <IconSymbol color={theme.textSecondary.val} name={icon} size="md" />}
+      </XStack>
+    </Pressable>
+  );
 }
 
 function DirectionToggle({
   activeDirectionId,
-  options,
   onSelect,
+  options,
 }: {
   activeDirectionId: MetroDirectionId;
   onSelect: (directionId: MetroDirectionId) => void;
@@ -77,7 +109,7 @@ function DirectionToggle({
       borderColor="$borderSubtle"
       borderRadius="$round"
       borderWidth={borderWidths.subtle}
-      gap="$2"
+      gap="$1"
       padding="$1.5"
     >
       {options.map((option) => {
@@ -94,22 +126,23 @@ function DirectionToggle({
             })}
           >
             {() => (
-              <YStack
+              <XStack
                 alignItems="center"
                 backgroundColor={active ? "$surfaceDefault" : "transparent"}
                 borderRadius="$round"
+                justifyContent="center"
+                minHeight={52}
                 paddingHorizontal="$4"
-                paddingVertical="$3"
                 shadowColor="$shadowColor"
-                shadowOffset={{ width: 0, height: 8 }}
-                shadowOpacity={active ? 0.06 : 0}
-                shadowRadius={active ? 12 : 0}
+                shadowOffset={{ width: 0, height: 4 }}
+                shadowOpacity={active ? 0.08 : 0}
+                shadowRadius={active ? 10 : 0}
                 elevation={active ? 2 : 0}
               >
-                <AppText tone={active ? "brand" : "subtle"} variant="tabLabel">
+                <AppText tone={active ? "brand" : "muted"} variant="tabLabel">
                   {option.label}
                 </AppText>
-              </YStack>
+              </XStack>
             )}
           </Pressable>
         );
@@ -121,48 +154,35 @@ function DirectionToggle({
 function MetroJourneyHeader({
   activeDirectionId,
   activeTrainCount,
+  isRefreshing,
   lastUpdatedLabel,
   onBack,
+  onRefresh,
   onSelectDirection,
   options,
 }: {
   activeDirectionId: MetroDirectionId;
   activeTrainCount: number;
+  isRefreshing: boolean;
   lastUpdatedLabel?: string;
   onBack: () => void;
+  onRefresh: () => void;
   onSelectDirection: (directionId: MetroDirectionId) => void;
   options: MetroDirectionOption[];
 }) {
   const insets = useSafeAreaInsets();
-  const theme = useTheme();
 
   return (
     <YStack
       backgroundColor="$surfaceDefault"
-      borderBottomColor="$borderSubtle"
       borderBottomLeftRadius={radii.xxl}
       borderBottomRightRadius={radii.xxl}
-      borderBottomWidth={borderWidths.subtle}
       paddingTop={insets.top + 12}
       paddingHorizontal="$5"
       paddingBottom="$5"
     >
       <XStack alignItems="center" justifyContent="space-between">
-        <Pressable onPress={onBack} style={({ pressed }) => ({ opacity: pressed ? 0.88 : 1 })}>
-          <XStack
-            alignItems="center"
-            backgroundColor="$surfaceMuted"
-            borderColor="$borderSubtle"
-            borderRadius="$round"
-            borderWidth={borderWidths.subtle}
-            height={44}
-            justifyContent="center"
-            style={elevations.whisper}
-            width={44}
-          >
-            <IconSymbol color={theme.textPrimary.val} name="arrow-left" size="md" />
-          </XStack>
-        </Pressable>
+        <HeaderActionButton icon="arrow-left" onPress={onBack} />
 
         <YStack alignItems="center" flex={1} gap="$1" paddingHorizontal="$4">
           <AppText align="center" variant="xlTitle">
@@ -173,24 +193,20 @@ function MetroJourneyHeader({
           </AppText>
         </YStack>
 
-        <View width={44} />
+        <HeaderActionButton icon="refresh" loading={isRefreshing} onPress={onRefresh} />
       </XStack>
 
-      <XStack alignItems="center" justifyContent="space-between" paddingTop="$4">
-        <AppText tone="muted" variant="bodySmall">
+      <XStack alignItems="center" justifyContent="space-between" paddingTop="$5">
+        <AppText tone="muted" variant="subhead">
           {activeTrainCount > 0 ? `${activeTrainCount} tàu đang hoạt động` : "Đang chờ dữ liệu tàu"}
         </AppText>
 
-        {lastUpdatedLabel
-          ? (
-              <XStack alignItems="center" gap="$2">
-                <IconSymbol color={theme.textSecondary.val} name="refresh" size="caption" />
-                <AppText tone="subtle" variant="caption">
-                  {lastUpdatedLabel}
-                </AppText>
-              </XStack>
-            )
-          : null}
+        <XStack alignItems="center" gap="$2">
+          <IconSymbol color="$textSecondary" name="refresh" size="caption" />
+          <AppText tone="muted" variant="caption">
+            {lastUpdatedLabel ?? "--:--"}
+          </AppText>
+        </XStack>
       </XStack>
 
       <YStack paddingTop="$4">
@@ -218,7 +234,7 @@ function MetroJourneyState({
   const theme = useTheme();
 
   return (
-    <YStack flex={1} justifyContent="center" padding="$5">
+    <YStack backgroundColor={routeCanvasColor} flex={1} justifyContent="center" padding="$5">
       <AppCard alignItems="center" borderRadius="$6" gap="$4" padding="$6">
         <YStack
           alignItems="center"
@@ -255,15 +271,15 @@ function MetroJourneyState({
 }
 
 function MetroJourneyRoute({
-  stations,
-  vehicles,
   canOpenStationDetail,
   onOpenStationDetail,
+  stations,
+  vehicles,
 }: {
-  stations: MetroJourneyStation[];
-  vehicles: MetroVehicle[];
   canOpenStationDetail: boolean;
   onOpenStationDetail: (stationName: string) => void;
+  stations: MetroJourneyStation[];
+  vehicles: MetroVehicle[];
 }) {
   const theme = useTheme();
   const segmentHeights = buildSegmentHeights(stations);
@@ -272,149 +288,133 @@ function MetroJourneyRoute({
   const canvasHeight = stationCenterPositions.at(-1)! + routeRowHalfHeight;
 
   return (
-    <YStack>
-      <View height={canvasHeight} position="relative">
-        <LinearGradient
-          colors={[...routeGradientColors]}
-          end={{ x: 1, y: 1 }}
-          start={{ x: 0, y: 0 }}
-          style={{ bottom: 0, left: 0, position: "absolute", right: 0, top: 0 }}
-        />
+    <View backgroundColor={routeCanvasColor} height={canvasHeight} position="relative">
+      <View
+        backgroundColor={routeRailColor}
+        borderRadius={radii.round}
+        height={totalRouteHeight}
+        left={routeRailLeftInset}
+        position="absolute"
+        top={stationCenterPositions[0]}
+        width={routeRailWidth}
+      />
 
-        <View
-          backgroundColor="rgba(91, 110, 245, 0.14)"
-          borderRadius={radii.round}
-          height={totalRouteHeight}
-          left={routeRailLeftInset - 5}
-          position="absolute"
-          top={stationCenterPositions[0]}
-          width={routeRailWidth + 10}
-        />
-        <View
-          backgroundColor={routeRailColor}
-          borderRadius={radii.round}
-          height={totalRouteHeight}
-          left={routeRailLeftInset}
-          position="absolute"
-          top={stationCenterPositions[0]}
-          width={routeRailWidth}
-        />
+      {segmentHeights.map((segmentHeight, index) => {
+        const station = stations[index + 1];
+        const top = stationCenterPositions[index] + (segmentHeight / 2) - 16;
+        const { unit, value } = splitDistanceLabel(
+          formatDistanceLabel(station.distanceFromPreviousLabel, station.distanceFromPreviousKm),
+        );
 
-        {segmentHeights.map((segmentHeight, index) => {
-          const station = stations[index + 1];
-          const top = stationCenterPositions[index] + (segmentHeight / 2) - 10;
+        return (
+          <YStack
+            key={`distance-${station.stopId}`}
+            alignItems="flex-end"
+            left={0}
+            position="absolute"
+            top={top}
+            width={routeDistanceColumnWidth}
+          >
+            <AppText align="right" tone="subtle" variant="subhead">
+              {value}
+            </AppText>
+            <AppText align="right" tone="subtle" variant="subhead">
+              {unit}
+            </AppText>
+          </YStack>
+        );
+      })}
 
-          return (
-            <YStack
-              key={`distance-${station.stopId}`}
-              left={0}
-              position="absolute"
-              top={top}
-              width={42}
-            >
-              <AppText align="right" tone="subtle" variant="bodySmall">
-                {formatDistanceLabel(station.distanceFromPreviousLabel, station.distanceFromPreviousKm)}
-              </AppText>
-            </YStack>
-          );
-        })}
+      {vehicles.map((vehicle, index) => {
+        const markerTop = stationCenterPositions[0] + (vehicle.percent * totalRouteHeight);
 
-        {vehicles.map((vehicle, index) => {
-          const markerTop = stationCenterPositions[0] + (vehicle.percent * totalRouteHeight);
-
-          return (
-            <View
-              key={`vehicle-${vehicle.coordinate[0]}-${vehicle.coordinate[1]}-${index}`}
-              left={routeRailCenterX - (routeTrainAuraSize / 2)}
-              position="absolute"
-              top={markerTop - (routeTrainAuraSize / 2)}
+        return (
+          <View
+            key={`vehicle-${vehicle.coordinate[0]}-${vehicle.coordinate[1]}-${index}`}
+            left={routeRailCenterX - (routeTrainMarkerSize / 2)}
+            pointerEvents="none"
+            position="absolute"
+            top={markerTop - (routeTrainMarkerSize / 2)}
+          >
+            <XStack
+              alignItems="center"
+              justifyContent="center"
+              width={routeTrainMarkerSize}
             >
               <XStack
                 alignItems="center"
-                backgroundColor={routeTrainAuraColor}
-                borderRadius="$round"
-                height={routeTrainAuraSize}
-                justifyContent="center"
-                width={routeTrainAuraSize}
-              >
-                <XStack
-                  alignItems="center"
-                  backgroundColor="$actionPrimary"
-                  borderColor="$surfaceDefault"
-                  borderRadius="$round"
-                  borderWidth={2}
-                  height={routeTrainMarkerSize}
-                  justifyContent="center"
-                  shadowColor="$shadowColor"
-                  shadowOffset={{ width: 0, height: 8 }}
-                  shadowOpacity={0.18}
-                  shadowRadius={16}
-                  width={routeTrainMarkerSize}
-                >
-                  <IconSymbol
-                    color={theme.onActionPrimary.val}
-                    name="train"
-                    size="sm"
-                    style={{ transform: [{ translateX: 0.5 }] }}
-                  />
-                </XStack>
-              </XStack>
-            </View>
-          );
-        })}
-
-        {stations.map((station, index) => {
-          const centerY = stationCenterPositions[index];
-          const rowTop = centerY - routeRowHalfHeight;
-          const hasNearbyVehicle = isVehicleNearStation(station, vehicles);
-
-          return (
-            <Pressable
-              key={station.stopId}
-              disabled={!canOpenStationDetail}
-              onPress={() => {
-                onOpenStationDetail(station.internalStationName);
-              }}
-              style={({ pressed }) => ({
-                left: 0,
-                opacity: pressed && canOpenStationDetail ? 0.9 : 1,
-                position: "absolute",
-                right: 0,
-                top: rowTop,
-              })}
-            >
-              <View
-                backgroundColor="$surfaceDefault"
-                borderColor={hasNearbyVehicle ? "$actionPrimary" : "$surfaceDefault"}
+                backgroundColor={routeRailColor}
+                borderColor="$surfaceDefault"
                 borderRadius="$round"
                 borderWidth={2}
-                height={routeStationMarkerSize}
-                left={routeRailLeftInset - ((routeStationMarkerSize - routeRailWidth) / 2)}
-                position="absolute"
-                top={routeRowHalfHeight - (routeStationMarkerSize / 2)}
-                width={routeStationMarkerSize}
-              />
-
-              <XStack alignItems="center" minHeight={routeRowHalfHeight * 2} paddingRight="$3">
-                <View width={routeRailLeftInset + routeStationMarkerSize + 18} />
-
-                <YStack flex={1} gap="$1" minWidth={0} paddingRight="$3">
-                  <XStack alignItems="center" gap="$2">
-                    <AppText tone={hasNearbyVehicle ? "brand" : "default"} variant="cardTitle">
-                      {station.name}
-                    </AppText>
-                  </XStack>
-                </YStack>
-
-                <XStack alignItems="center" justifyContent="center" width={routeRowRightInset}>
-                  <IconSymbol color={theme.textSecondary.val} name="info" size="sm" />
-                </XStack>
+                height={routeTrainMarkerSize}
+                justifyContent="center"
+                shadowColor="$shadowColor"
+                shadowOffset={{ width: 0, height: 6 }}
+                shadowOpacity={0.18}
+                shadowRadius={12}
+                width={routeTrainMarkerSize}
+              >
+                <IconSymbol
+                  color={theme.onActionPrimary.val}
+                  name="train"
+                  size="sm"
+                  style={{ transform: [{ translateX: 0.5 }] }}
+                />
               </XStack>
-            </Pressable>
-          );
-        })}
-      </View>
-    </YStack>
+            </XStack>
+          </View>
+        );
+      })}
+
+      {stations.map((station, index) => {
+        const centerY = stationCenterPositions[index];
+        const rowTop = centerY - routeRowHalfHeight;
+
+        return (
+          <Pressable
+            key={station.stopId}
+            disabled={!canOpenStationDetail}
+            onPress={() => {
+              onOpenStationDetail(station.internalStationName);
+            }}
+            style={({ pressed }) => ({
+              left: 0,
+              opacity: pressed && canOpenStationDetail ? 0.88 : 1,
+              position: "absolute",
+              right: 0,
+              top: rowTop,
+            })}
+          >
+            <View
+              backgroundColor="$surfaceDefault"
+              borderColor={routeRailColor}
+              borderRadius="$round"
+              borderWidth={4}
+              height={routeStationMarkerSize}
+              left={routeRailCenterX - (routeStationMarkerSize / 2)}
+              position="absolute"
+              top={routeRowHalfHeight - (routeStationMarkerSize / 2)}
+              width={routeStationMarkerSize}
+            />
+
+            <XStack alignItems="center" minHeight={routeRowHalfHeight * 2} paddingRight="$2">
+              <View width={routeRailLeftInset + routeStationMarkerSize + routeContentGap} />
+
+              <YStack flex={1} minWidth={0} paddingRight="$3">
+                <AppText variant="cardTitle">
+                  {station.name}
+                </AppText>
+              </YStack>
+
+              <XStack alignItems="center" justifyContent="center" width={routeInfoWidth}>
+                <IconSymbol color={theme.textSecondary.val} name="info" size="input" />
+              </XStack>
+            </XStack>
+          </Pressable>
+        );
+      })}
+    </View>
   );
 }
 
@@ -424,12 +424,16 @@ export default function MetroJourneyScreen() {
 
   if (vm.isInitialLoading) {
     return (
-      <Screen tone="subtle">
+      <Screen backgroundColor="$surfaceDefault">
         <StatusBar backgroundColor={theme.surfaceDefault.val} barStyle="dark-content" />
         <MetroJourneyHeader
           activeDirectionId={vm.directionId}
           activeTrainCount={0}
+          isRefreshing={false}
           onBack={vm.actions.goBack}
+          onRefresh={() => {
+            void vm.actions.onRefresh();
+          }}
           onSelectDirection={vm.actions.setDirection}
           options={vm.directionOptions}
         />
@@ -444,12 +448,16 @@ export default function MetroJourneyScreen() {
 
   if (vm.initialError || !vm.data) {
     return (
-      <Screen tone="subtle">
+      <Screen backgroundColor="$surfaceDefault">
         <StatusBar backgroundColor={theme.surfaceDefault.val} barStyle="dark-content" />
         <MetroJourneyHeader
           activeDirectionId={vm.directionId}
           activeTrainCount={0}
+          isRefreshing={vm.isRefreshing}
           onBack={vm.actions.goBack}
+          onRefresh={() => {
+            void vm.actions.onRefresh();
+          }}
           onSelectDirection={vm.actions.setDirection}
           options={vm.directionOptions}
         />
@@ -466,7 +474,7 @@ export default function MetroJourneyScreen() {
   }
 
   return (
-    <Screen tone="subtle">
+    <Screen backgroundColor="$surfaceDefault">
       <StatusBar backgroundColor={theme.surfaceDefault.val} barStyle="dark-content" />
 
       <ScrollView
@@ -482,37 +490,41 @@ export default function MetroJourneyScreen() {
         )}
         showsVerticalScrollIndicator={false}
       >
-        <YStack paddingBottom="$7">
-          <MetroJourneyHeader
-            activeDirectionId={vm.directionId}
-            activeTrainCount={vm.data.activeTrainCount}
-            lastUpdatedLabel={vm.data.lastUpdatedLabel}
-            onBack={vm.actions.goBack}
-            onSelectDirection={vm.actions.setDirection}
-            options={vm.directionOptions}
+        <MetroJourneyHeader
+          activeDirectionId={vm.directionId}
+          activeTrainCount={vm.data.activeTrainCount}
+          isRefreshing={vm.isRefreshing}
+          lastUpdatedLabel={vm.data.lastUpdatedLabel}
+          onBack={vm.actions.goBack}
+          onRefresh={() => {
+            void vm.actions.onRefresh();
+          }}
+          onSelectDirection={vm.actions.setDirection}
+          options={vm.directionOptions}
+        />
+
+        <YStack backgroundColor={routeCanvasColor} paddingBottom="$7">
+          <XStack alignItems="center" justifyContent="space-between" paddingHorizontal="$5" paddingTop="$5" paddingBottom="$4">
+            <AppText tone="muted" variant="subhead">
+              {vm.data.directionLabel}
+            </AppText>
+            <AppText tone="muted" variant="subhead">
+              {vm.data.stations.length}
+              {" "}
+              ga
+            </AppText>
+          </XStack>
+
+          <MetroJourneyRoute
+            canOpenStationDetail={vm.canOpenStationDetail}
+            onOpenStationDetail={vm.actions.openStationDetail}
+            stations={vm.data.stations}
+            vehicles={vm.data.vehicles}
           />
 
-          <YStack gap="$4" paddingHorizontal="$5" paddingTop="$5">
-            <XStack alignItems="center" justifyContent="space-between" paddingRight="$1">
-              <AppText tone="subtle" variant="bodySmall">
-                {vm.data.directionLabel}
-              </AppText>
-              <AppText tone="subtle" variant="bodySmall">
-                {vm.data.stations.length}
-                {" "}
-                ga
-              </AppText>
-            </XStack>
-
-            <MetroJourneyRoute
-              canOpenStationDetail={vm.canOpenStationDetail}
-              onOpenStationDetail={vm.actions.openStationDetail}
-              stations={vm.data.stations}
-              vehicles={vm.data.vehicles}
-            />
-
-            {vm.refreshError
-              ? (
+          {vm.refreshError
+            ? (
+                <YStack paddingHorizontal="$5" paddingTop="$4">
                   <AppCard tone="warning">
                     <AppText variant="cardTitle">
                       Đang hiển thị dữ liệu lần gần nhất
@@ -521,9 +533,9 @@ export default function MetroJourneyScreen() {
                       {vm.refreshError}
                     </AppText>
                   </AppCard>
-                )
-              : null}
-          </YStack>
+                </YStack>
+              )
+            : null}
         </YStack>
       </ScrollView>
     </Screen>

--- a/apps/mobile/screen/metro/metro-journey-screen.tsx
+++ b/apps/mobile/screen/metro/metro-journey-screen.tsx
@@ -1,0 +1,531 @@
+import type { MetroDirectionId, MetroDirectionOption, MetroJourneyStation, MetroVehicle } from "@services/metro";
+
+import { IconSymbol } from "@components/IconSymbol";
+import { borderWidths, elevations, radii } from "@theme/metrics";
+import { AppButton } from "@ui/primitives/app-button";
+import { AppCard } from "@ui/primitives/app-card";
+import { AppText } from "@ui/primitives/app-text";
+import { Screen } from "@ui/primitives/screen";
+import { LinearGradient } from "expo-linear-gradient";
+import { ActivityIndicator, Pressable, RefreshControl, ScrollView, StatusBar } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useTheme, View, XStack, YStack } from "tamagui";
+
+import { useMetroJourneyScreen } from "./hooks/use-metro-journey-screen";
+
+const routeRailWidth = 8;
+const routeStationMarkerSize = 18;
+const routeTrainMarkerSize = 28;
+const routeTrainAuraSize = routeTrainMarkerSize + 10;
+const routeRowHalfHeight = 32;
+const routeSegmentMinHeight = 78;
+const routePixelsPerKm = 54;
+const routeRailLeftInset = 54;
+const routeRowRightInset = 26;
+const routeGradientColors = ["rgba(59,130,246,0.12)", "rgba(168,85,247,0.08)", "rgba(255,255,255,0)"] as const;
+const routeRailColor = "#5B6EF5";
+const routeTrainAuraColor = "rgba(59, 130, 246, 0.18)";
+const routeRailCenterX = routeRailLeftInset + (routeRailWidth / 2);
+
+function formatDistanceLabel(label: string | null, distanceKm: number | null) {
+  if (label) {
+    return label;
+  }
+
+  if (distanceKm === null) {
+    return "";
+  }
+
+  return `${distanceKm.toFixed(1)} km`;
+}
+
+function buildSegmentHeights(stations: MetroJourneyStation[]) {
+  return stations.slice(1).map((station) => {
+    const distanceKm = station.distanceFromPreviousKm ?? 0;
+    return Math.max(routeSegmentMinHeight, Math.round(distanceKm * routePixelsPerKm));
+  });
+}
+
+function buildStationCenterPositions(segmentHeights: number[]) {
+  const centerPositions = [routeRowHalfHeight];
+  let current = routeRowHalfHeight;
+
+  for (const height of segmentHeights) {
+    current += height;
+    centerPositions.push(current);
+  }
+
+  return centerPositions;
+}
+
+function isVehicleNearStation(station: MetroJourneyStation, vehicles: MetroVehicle[]) {
+  return vehicles.some(vehicle => Math.abs(vehicle.percent - station.progress) <= 0.045);
+}
+
+function DirectionToggle({
+  activeDirectionId,
+  options,
+  onSelect,
+}: {
+  activeDirectionId: MetroDirectionId;
+  onSelect: (directionId: MetroDirectionId) => void;
+  options: MetroDirectionOption[];
+}) {
+  return (
+    <XStack
+      backgroundColor="$surfaceMuted"
+      borderColor="$borderSubtle"
+      borderRadius="$round"
+      borderWidth={borderWidths.subtle}
+      gap="$2"
+      padding="$1.5"
+    >
+      {options.map((option) => {
+        const active = option.directionId === activeDirectionId;
+
+        return (
+          <Pressable
+            key={option.directionId}
+            onPress={() => onSelect(option.directionId)}
+            style={({ pressed }) => ({
+              flex: 1,
+              opacity: pressed ? 0.98 : 1,
+              transform: [{ scale: pressed ? 0.992 : 1 }],
+            })}
+          >
+            {() => (
+              <YStack
+                alignItems="center"
+                backgroundColor={active ? "$surfaceDefault" : "transparent"}
+                borderRadius="$round"
+                paddingHorizontal="$4"
+                paddingVertical="$3"
+                shadowColor="$shadowColor"
+                shadowOffset={{ width: 0, height: 8 }}
+                shadowOpacity={active ? 0.06 : 0}
+                shadowRadius={active ? 12 : 0}
+                elevation={active ? 2 : 0}
+              >
+                <AppText tone={active ? "brand" : "subtle"} variant="tabLabel">
+                  {option.label}
+                </AppText>
+              </YStack>
+            )}
+          </Pressable>
+        );
+      })}
+    </XStack>
+  );
+}
+
+function MetroJourneyHeader({
+  activeDirectionId,
+  activeTrainCount,
+  lastUpdatedLabel,
+  onBack,
+  onSelectDirection,
+  options,
+}: {
+  activeDirectionId: MetroDirectionId;
+  activeTrainCount: number;
+  lastUpdatedLabel?: string;
+  onBack: () => void;
+  onSelectDirection: (directionId: MetroDirectionId) => void;
+  options: MetroDirectionOption[];
+}) {
+  const insets = useSafeAreaInsets();
+  const theme = useTheme();
+
+  return (
+    <YStack
+      backgroundColor="$surfaceDefault"
+      borderBottomColor="$borderSubtle"
+      borderBottomLeftRadius={radii.xxl}
+      borderBottomRightRadius={radii.xxl}
+      borderBottomWidth={borderWidths.subtle}
+      paddingTop={insets.top + 12}
+      paddingHorizontal="$5"
+      paddingBottom="$5"
+    >
+      <XStack alignItems="center" justifyContent="space-between">
+        <Pressable onPress={onBack} style={({ pressed }) => ({ opacity: pressed ? 0.88 : 1 })}>
+          <XStack
+            alignItems="center"
+            backgroundColor="$surfaceMuted"
+            borderColor="$borderSubtle"
+            borderRadius="$round"
+            borderWidth={borderWidths.subtle}
+            height={44}
+            justifyContent="center"
+            style={elevations.whisper}
+            width={44}
+          >
+            <IconSymbol color={theme.textPrimary.val} name="arrow-left" size="md" />
+          </XStack>
+        </Pressable>
+
+        <YStack alignItems="center" flex={1} gap="$1" paddingHorizontal="$4">
+          <AppText align="center" variant="xlTitle">
+            Hành trình Metro
+          </AppText>
+          <AppText align="center" tone="muted" variant="bodySmall">
+            Tuyến metro số 1 Bến Thành - Suối Tiên
+          </AppText>
+        </YStack>
+
+        <View width={44} />
+      </XStack>
+
+      <XStack alignItems="center" justifyContent="space-between" paddingTop="$4">
+        <AppText tone="muted" variant="bodySmall">
+          {activeTrainCount > 0 ? `${activeTrainCount} tàu đang hoạt động` : "Đang chờ dữ liệu tàu"}
+        </AppText>
+
+        {lastUpdatedLabel
+          ? (
+              <XStack alignItems="center" gap="$2">
+                <IconSymbol color={theme.textSecondary.val} name="refresh" size="caption" />
+                <AppText tone="subtle" variant="caption">
+                  {lastUpdatedLabel}
+                </AppText>
+              </XStack>
+            )
+          : null}
+      </XStack>
+
+      <YStack paddingTop="$4">
+        <DirectionToggle
+          activeDirectionId={activeDirectionId}
+          onSelect={onSelectDirection}
+          options={options}
+        />
+      </YStack>
+    </YStack>
+  );
+}
+
+function MetroJourneyState({
+  description,
+  mode,
+  onRetry,
+  title,
+}: {
+  description: string;
+  mode: "error" | "loading";
+  onRetry?: () => void;
+  title: string;
+}) {
+  const theme = useTheme();
+
+  return (
+    <YStack flex={1} justifyContent="center" padding="$5">
+      <AppCard alignItems="center" borderRadius="$6" gap="$4" padding="$6">
+        <YStack
+          alignItems="center"
+          backgroundColor="$surfaceAccent"
+          borderRadius="$round"
+          height={68}
+          justifyContent="center"
+          width={68}
+        >
+          {mode === "loading"
+            ? <ActivityIndicator color={theme.actionPrimary.val} size="large" />
+            : <IconSymbol color={theme.actionPrimary.val} name="warning" size="chip" />}
+        </YStack>
+
+        <YStack alignItems="center" gap="$2">
+          <AppText align="center" variant="headline">
+            {title}
+          </AppText>
+          <AppText align="center" tone="muted" variant="bodySmall">
+            {description}
+          </AppText>
+        </YStack>
+
+        {mode === "error" && onRetry
+          ? (
+              <AppButton onPress={onRetry} width="100%">
+                Thử lại
+              </AppButton>
+            )
+          : null}
+      </AppCard>
+    </YStack>
+  );
+}
+
+function MetroJourneyRoute({
+  stations,
+  vehicles,
+  canOpenStationDetail,
+  onOpenStationDetail,
+}: {
+  stations: MetroJourneyStation[];
+  vehicles: MetroVehicle[];
+  canOpenStationDetail: boolean;
+  onOpenStationDetail: (stationName: string) => void;
+}) {
+  const theme = useTheme();
+  const segmentHeights = buildSegmentHeights(stations);
+  const stationCenterPositions = buildStationCenterPositions(segmentHeights);
+  const totalRouteHeight = stationCenterPositions.at(-1)! - stationCenterPositions[0]!;
+  const canvasHeight = stationCenterPositions.at(-1)! + routeRowHalfHeight;
+
+  return (
+    <YStack>
+      <View height={canvasHeight} position="relative">
+        <LinearGradient
+          colors={[...routeGradientColors]}
+          end={{ x: 1, y: 1 }}
+          start={{ x: 0, y: 0 }}
+          style={{ bottom: 0, left: 0, position: "absolute", right: 0, top: 0 }}
+        />
+
+        <View
+          backgroundColor="rgba(91, 110, 245, 0.14)"
+          borderRadius={radii.round}
+          height={totalRouteHeight}
+          left={routeRailLeftInset - 5}
+          position="absolute"
+          top={stationCenterPositions[0]}
+          width={routeRailWidth + 10}
+        />
+        <View
+          backgroundColor={routeRailColor}
+          borderRadius={radii.round}
+          height={totalRouteHeight}
+          left={routeRailLeftInset}
+          position="absolute"
+          top={stationCenterPositions[0]}
+          width={routeRailWidth}
+        />
+
+        {segmentHeights.map((segmentHeight, index) => {
+          const station = stations[index + 1];
+          const top = stationCenterPositions[index] + (segmentHeight / 2) - 10;
+
+          return (
+            <YStack
+              key={`distance-${station.stopId}`}
+              left={0}
+              position="absolute"
+              top={top}
+              width={42}
+            >
+              <AppText align="right" tone="subtle" variant="bodySmall">
+                {formatDistanceLabel(station.distanceFromPreviousLabel, station.distanceFromPreviousKm)}
+              </AppText>
+            </YStack>
+          );
+        })}
+
+        {vehicles.map((vehicle, index) => {
+          const markerTop = stationCenterPositions[0] + (vehicle.percent * totalRouteHeight);
+
+          return (
+            <View
+              key={`vehicle-${vehicle.coordinate[0]}-${vehicle.coordinate[1]}-${index}`}
+              left={routeRailCenterX - (routeTrainAuraSize / 2)}
+              position="absolute"
+              top={markerTop - (routeTrainAuraSize / 2)}
+            >
+              <XStack
+                alignItems="center"
+                backgroundColor={routeTrainAuraColor}
+                borderRadius="$round"
+                height={routeTrainAuraSize}
+                justifyContent="center"
+                width={routeTrainAuraSize}
+              >
+                <XStack
+                  alignItems="center"
+                  backgroundColor="$actionPrimary"
+                  borderColor="$surfaceDefault"
+                  borderRadius="$round"
+                  borderWidth={2}
+                  height={routeTrainMarkerSize}
+                  justifyContent="center"
+                  shadowColor="$shadowColor"
+                  shadowOffset={{ width: 0, height: 8 }}
+                  shadowOpacity={0.18}
+                  shadowRadius={16}
+                  width={routeTrainMarkerSize}
+                >
+                  <IconSymbol
+                    color={theme.onActionPrimary.val}
+                    name="train"
+                    size="sm"
+                    style={{ transform: [{ translateX: 0.5 }] }}
+                  />
+                </XStack>
+              </XStack>
+            </View>
+          );
+        })}
+
+        {stations.map((station, index) => {
+          const centerY = stationCenterPositions[index];
+          const rowTop = centerY - routeRowHalfHeight;
+          const hasNearbyVehicle = isVehicleNearStation(station, vehicles);
+
+          return (
+            <Pressable
+              key={station.stopId}
+              disabled={!canOpenStationDetail}
+              onPress={() => {
+                onOpenStationDetail(station.internalStationName);
+              }}
+              style={({ pressed }) => ({
+                left: 0,
+                opacity: pressed && canOpenStationDetail ? 0.9 : 1,
+                position: "absolute",
+                right: 0,
+                top: rowTop,
+              })}
+            >
+              <View
+                backgroundColor="$surfaceDefault"
+                borderColor={hasNearbyVehicle ? "$actionPrimary" : "$surfaceDefault"}
+                borderRadius="$round"
+                borderWidth={2}
+                height={routeStationMarkerSize}
+                left={routeRailLeftInset - ((routeStationMarkerSize - routeRailWidth) / 2)}
+                position="absolute"
+                top={routeRowHalfHeight - (routeStationMarkerSize / 2)}
+                width={routeStationMarkerSize}
+              />
+
+              <XStack alignItems="center" minHeight={routeRowHalfHeight * 2} paddingRight="$3">
+                <View width={routeRailLeftInset + routeStationMarkerSize + 18} />
+
+                <YStack flex={1} gap="$1" minWidth={0} paddingRight="$3">
+                  <XStack alignItems="center" gap="$2">
+                    <AppText tone={hasNearbyVehicle ? "brand" : "default"} variant="cardTitle">
+                      {station.name}
+                    </AppText>
+                  </XStack>
+                </YStack>
+
+                <XStack alignItems="center" justifyContent="center" width={routeRowRightInset}>
+                  <IconSymbol color={theme.textSecondary.val} name="info" size="sm" />
+                </XStack>
+              </XStack>
+            </Pressable>
+          );
+        })}
+      </View>
+    </YStack>
+  );
+}
+
+export default function MetroJourneyScreen() {
+  const theme = useTheme();
+  const vm = useMetroJourneyScreen();
+
+  if (vm.isInitialLoading) {
+    return (
+      <Screen tone="subtle">
+        <StatusBar backgroundColor={theme.surfaceDefault.val} barStyle="dark-content" />
+        <MetroJourneyHeader
+          activeDirectionId={vm.directionId}
+          activeTrainCount={0}
+          onBack={vm.actions.goBack}
+          onSelectDirection={vm.actions.setDirection}
+          options={vm.directionOptions}
+        />
+        <MetroJourneyState
+          description="Đang tải tuyến, các ga và vị trí tàu theo thời gian thực."
+          mode="loading"
+          title="Đang tải hành trình"
+        />
+      </Screen>
+    );
+  }
+
+  if (vm.initialError || !vm.data) {
+    return (
+      <Screen tone="subtle">
+        <StatusBar backgroundColor={theme.surfaceDefault.val} barStyle="dark-content" />
+        <MetroJourneyHeader
+          activeDirectionId={vm.directionId}
+          activeTrainCount={0}
+          onBack={vm.actions.goBack}
+          onSelectDirection={vm.actions.setDirection}
+          options={vm.directionOptions}
+        />
+        <MetroJourneyState
+          description={vm.initialError ?? "Không thể tải dữ liệu Metro lúc này."}
+          mode="error"
+          onRetry={() => {
+            void vm.actions.onRefresh();
+          }}
+          title="Không thể tải hành trình"
+        />
+      </Screen>
+    );
+  }
+
+  return (
+    <Screen tone="subtle">
+      <StatusBar backgroundColor={theme.surfaceDefault.val} barStyle="dark-content" />
+
+      <ScrollView
+        refreshControl={(
+          <RefreshControl
+            colors={[theme.actionPrimary.val]}
+            onRefresh={() => {
+              void vm.actions.onRefresh();
+            }}
+            refreshing={vm.isRefreshing}
+            tintColor={theme.actionPrimary.val}
+          />
+        )}
+        showsVerticalScrollIndicator={false}
+      >
+        <YStack paddingBottom="$7">
+          <MetroJourneyHeader
+            activeDirectionId={vm.directionId}
+            activeTrainCount={vm.data.activeTrainCount}
+            lastUpdatedLabel={vm.data.lastUpdatedLabel}
+            onBack={vm.actions.goBack}
+            onSelectDirection={vm.actions.setDirection}
+            options={vm.directionOptions}
+          />
+
+          <YStack gap="$4" paddingHorizontal="$5" paddingTop="$5">
+            <XStack alignItems="center" justifyContent="space-between" paddingRight="$1">
+              <AppText tone="subtle" variant="bodySmall">
+                {vm.data.directionLabel}
+              </AppText>
+              <AppText tone="subtle" variant="bodySmall">
+                {vm.data.stations.length}
+                {" "}
+                ga
+              </AppText>
+            </XStack>
+
+            <MetroJourneyRoute
+              canOpenStationDetail={vm.canOpenStationDetail}
+              onOpenStationDetail={vm.actions.openStationDetail}
+              stations={vm.data.stations}
+              vehicles={vm.data.vehicles}
+            />
+
+            {vm.refreshError
+              ? (
+                  <AppCard tone="warning">
+                    <AppText variant="cardTitle">
+                      Đang hiển thị dữ liệu lần gần nhất
+                    </AppText>
+                    <AppText tone="muted" variant="bodySmall">
+                      {vm.refreshError}
+                    </AppText>
+                  </AppCard>
+                )
+              : null}
+          </YStack>
+        </YStack>
+      </ScrollView>
+    </Screen>
+  );
+}

--- a/apps/mobile/services/metro/index.ts
+++ b/apps/mobile/services/metro/index.ts
@@ -1,0 +1,8 @@
+export { metroDirectionOptions, metroService } from "./metro.service";
+export type {
+  MetroDirectionId,
+  MetroDirectionOption,
+  MetroJourneyData,
+  MetroJourneyStation,
+  MetroVehicle,
+} from "./metro.service";

--- a/apps/mobile/services/metro/metro.service.ts
+++ b/apps/mobile/services/metro/metro.service.ts
@@ -1,0 +1,242 @@
+import ky from "ky";
+
+const METRO_API_BASE_URL = "https://api.metrohcm.ttgt.vn";
+const METRO_ROUTE_ID = 384;
+const DEFAULT_ERROR_MESSAGE = "Không thể tải dữ liệu Metro lúc này. Vui lòng thử lại sau.";
+
+const metroKy = ky.create({
+  prefixUrl: METRO_API_BASE_URL,
+  retry: { limit: 0 },
+  timeout: 15000,
+});
+
+const forwardStationOrder = [7003, 7004, 7005, 7006, 7007, 7008, 7009, 7010, 7011, 7012, 7013, 7016, 7014, 7015] as const;
+
+const metroStationsById: Record<number, { code: string; name: string }> = {
+  7003: { code: "BTN", name: "Ga Bến Thành" },
+  7004: { code: "OPH", name: "Ga Nhà hát Thành phố" },
+  7005: { code: "BSN", name: "Ga Ba Son" },
+  7006: { code: "VTP", name: "Ga Văn Thánh" },
+  7007: { code: "TCN", name: "Ga Tân Cảng" },
+  7008: { code: "TDN", name: "Ga Thảo Điền" },
+  7009: { code: "ANP", name: "Ga An Phú" },
+  7010: { code: "RCC", name: "Ga Rạch Chiếc" },
+  7011: { code: "PCL", name: "Ga Phước Long" },
+  7012: { code: "BTT", name: "Ga Bình Thái" },
+  7013: { code: "TDC", name: "Ga Thủ Đức" },
+  7014: { code: "NUS", name: "Ga Đại học Quốc Gia" },
+  7015: { code: "STT", name: "Ga Bến xe Suối Tiên" },
+  7016: { code: "HTP", name: "Ga Khu Công nghệ Cao" },
+};
+
+const internalStationNameById: Record<number, string> = {
+  7003: "Ga Bến Thành",
+  7004: "Ga Nhà hát Thành phố",
+  7005: "Ga Ba Son",
+  7006: "Ga Công viên Văn Thánh",
+  7007: "Ga Tân Cảng",
+  7008: "Ga Thảo Điền",
+  7009: "Ga An Phú",
+  7010: "Ga Rạch Chiếc",
+  7011: "Ga Phước Long",
+  7012: "Ga Bình Thái",
+  7013: "Ga Thủ Đức",
+  7014: "Ga Đại học Quốc gia",
+  7015: "Ga Bến xe Suối Tiên",
+  7016: "Ga Khu Công nghệ cao",
+};
+
+type MetroVehiclesResponse = {
+  vehicles?: Array<{
+    angle?: number;
+    coordinate?: [number, number];
+    percent?: number;
+  }>;
+};
+
+type MetroRouteInfoResponse = {
+  distances?: string[];
+};
+
+type MetroScheduledTripsResponse = Record<string, string[]>;
+
+export type MetroDirectionId = 1 | 2;
+
+export type MetroDirectionOption = {
+  directionId: MetroDirectionId;
+  label: string;
+  destination: string;
+};
+
+export type MetroVehicle = {
+  angle: number;
+  coordinate: [number, number];
+  percent: number;
+};
+
+export type MetroJourneyStation = {
+  code: string;
+  distanceFromPreviousKm: number | null;
+  distanceFromPreviousLabel: string | null;
+  internalStationName: string;
+  name: string;
+  progress: number;
+  stopId: number;
+  upcomingTimes: string[];
+};
+
+export type MetroJourneyData = {
+  activeTrainCount: number;
+  directionId: MetroDirectionId;
+  directionLabel: string;
+  lastUpdatedLabel: string;
+  stations: MetroJourneyStation[];
+  subtitle: string;
+  totalDistanceKm: number;
+  vehicles: MetroVehicle[];
+};
+
+export const metroDirectionOptions: MetroDirectionOption[] = [
+  { destination: "Suối Tiên", directionId: 1, label: "Hướng Suối Tiên" },
+  { destination: "Bến Thành", directionId: 2, label: "Hướng Bến Thành" },
+];
+
+function clampPercent(value: number) {
+  return Math.max(0, Math.min(1, value));
+}
+
+function getCurrentMetroTimeLabel() {
+  return new Intl.DateTimeFormat("en-GB", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    timeZone: "Asia/Ho_Chi_Minh",
+  }).format(new Date());
+}
+
+function getOrderedStationIds(directionId: MetroDirectionId) {
+  return directionId === 1
+    ? [...forwardStationOrder]
+    : [...forwardStationOrder].reverse();
+}
+
+function parseDistanceKm(value: string) {
+  const match = value.match(/[\d.]+/);
+  return match ? Number.parseFloat(match[0]) : 0;
+}
+
+function resolveUpcomingTimes(times: string[], nowLabel: string) {
+  if (times.length === 0) {
+    return [];
+  }
+
+  const nextIndex = times.findIndex(time => time >= nowLabel);
+  const startIndex = nextIndex === -1 ? 0 : nextIndex;
+  const upcomingTimes = times.slice(startIndex, startIndex + 3);
+
+  if (upcomingTimes.length === 3) {
+    return upcomingTimes;
+  }
+
+  return [...upcomingTimes, ...times.slice(0, 3 - upcomingTimes.length)];
+}
+
+function buildStations(
+  directionId: MetroDirectionId,
+  scheduledTrips: MetroScheduledTripsResponse,
+  distanceLabels: string[],
+) {
+  const orderedStationIds = getOrderedStationIds(directionId);
+  const distanceValues = distanceLabels.map(parseDistanceKm);
+  const totalDistanceKm = distanceValues.reduce((sum, value) => sum + value, 0);
+  const nowLabel = getCurrentMetroTimeLabel();
+  let accumulatedDistance = 0;
+
+  const stations = orderedStationIds.map((stopId, index) => {
+    if (index > 0) {
+      accumulatedDistance += distanceValues[index - 1] ?? 0;
+    }
+
+    const stationMeta = metroStationsById[stopId];
+    const progress = totalDistanceKm > 0
+      ? accumulatedDistance / totalDistanceKm
+      : (orderedStationIds.length === 1 ? 0 : index / (orderedStationIds.length - 1));
+
+    return {
+      code: stationMeta.code,
+      distanceFromPreviousKm: index === 0 ? null : distanceValues[index - 1] ?? null,
+      distanceFromPreviousLabel: index === 0 ? null : distanceLabels[index - 1] ?? null,
+      internalStationName: internalStationNameById[stopId] ?? stationMeta.name,
+      name: stationMeta.name,
+      progress,
+      stopId,
+      upcomingTimes: resolveUpcomingTimes(scheduledTrips[String(stopId)] ?? [], nowLabel),
+    } satisfies MetroJourneyStation;
+  });
+
+  return { stations, totalDistanceKm };
+}
+
+function buildVehicles(response: MetroVehiclesResponse): MetroVehicle[] {
+  return (response.vehicles ?? [])
+    .filter((vehicle) => {
+      if (!Array.isArray(vehicle.coordinate) || vehicle.coordinate.length !== 2) {
+        return false;
+      }
+
+      return typeof vehicle.coordinate[0] === "number"
+        && typeof vehicle.coordinate[1] === "number"
+        && typeof vehicle.percent === "number"
+        && typeof vehicle.angle === "number";
+    })
+    .map(vehicle => ({
+      angle: vehicle.angle ?? 0,
+      coordinate: [vehicle.coordinate?.[0] ?? 0, vehicle.coordinate?.[1] ?? 0] as [number, number],
+      percent: clampPercent(vehicle.percent ?? 0),
+    }))
+    .sort((left, right) => right.percent - left.percent);
+}
+
+async function fetchMetroJson<T>(path: string, directionId: MetroDirectionId): Promise<T> {
+  return metroKy.get(path, {
+    searchParams: {
+      routeId: String(METRO_ROUTE_ID),
+      varId: String(directionId),
+    },
+  }).json<T>();
+}
+
+function buildDirectionLabel(directionId: MetroDirectionId) {
+  return metroDirectionOptions.find(option => option.directionId === directionId)?.label
+    ?? "Hành trình Metro";
+}
+
+export const metroService = {
+  async getJourney(directionId: MetroDirectionId): Promise<MetroJourneyData> {
+    try {
+      const [vehiclesResponse, routeInfoResponse, scheduledTripsResponse] = await Promise.all([
+        fetchMetroJson<MetroVehiclesResponse>("transit/vehicles", directionId),
+        fetchMetroJson<MetroRouteInfoResponse>("transit/route_info", directionId),
+        fetchMetroJson<MetroScheduledTripsResponse>("transit/scheduled_trips", directionId),
+      ]);
+
+      const distanceLabels = routeInfoResponse.distances ?? [];
+      const { stations, totalDistanceKm } = buildStations(directionId, scheduledTripsResponse, distanceLabels);
+      const vehicles = buildVehicles(vehiclesResponse);
+
+      return {
+        activeTrainCount: vehicles.length,
+        directionId,
+        directionLabel: buildDirectionLabel(directionId),
+        lastUpdatedLabel: getCurrentMetroTimeLabel(),
+        stations,
+        subtitle: "Tuyến metro số 1 Bến Thành - Suối Tiên",
+        totalDistanceKm,
+        vehicles,
+      };
+    }
+    catch {
+      throw new Error(DEFAULT_ERROR_MESSAGE);
+    }
+  },
+};

--- a/apps/mobile/types/navigation.ts
+++ b/apps/mobile/types/navigation.ts
@@ -58,6 +58,7 @@ export type RootStackParamList = {
   "ResetPasswordForm": { resetToken: string };
   "UpdateProfile": undefined;
   "MyWallet": undefined;
+  "MetroJourney": undefined;
   "Ví": undefined;
   "Subscriptions": undefined;
   "Xe": undefined;
@@ -182,6 +183,10 @@ export type UpdateProfileNavigationProp = StackNavigationProp<
 export type MyWalletNavigationProp = StackNavigationProp<
   RootStackParamList,
   "MyWallet"
+>;
+export type MetroJourneyNavigationProp = StackNavigationProp<
+  RootStackParamList,
+  "MetroJourney"
 >;
 export type SubscriptionsNavigationProp = StackNavigationProp<
   RootStackParamList,


### PR DESCRIPTION
## Summary
- add a Metro journey screen in mobile backed by the public metro route, vehicle, and route info endpoints with live polling
- connect Metro stations to existing station detail navigation and expose the screen from the profile menu
- refine the journey layout to match the transit-style timeline UI more closely with cleaner spacing and marker treatment