### PR TITLE
feat(server): support cross-platform device CLI serial ports

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -75,6 +75,7 @@
     "prisma-kysely": "^2.2.1",
     "react": "19.1.0",
     "react-native": "0.81.5",
+    "serialport": "^13.0.0",
     "sharp": "^0.34.5",
     "stripe": "^20.1.0",
     "tsx": "^4.20.5",

--- a/apps/server/src/dev-cli/data.ts
+++ b/apps/server/src/dev-cli/data.ts
@@ -30,7 +30,6 @@ export type StationSummaryRow = {
 export type StationBikeRow = {
   id: string;
   bikeNumber: string;
-  chipId: string;
   status: string;
   updatedAt: Date;
   activeRentalId: string | null;
@@ -53,7 +52,6 @@ export type BikeRentalSnapshot = {
 export type BikeInspection = {
   id: string;
   bikeNumber: string;
-  chipId: string;
   status: string;
   stationId: string | null;
   stationName: string | null;
@@ -73,7 +71,6 @@ export type ActiveRentalInspectorRow = {
   userEmail: string;
   bikeId: string;
   bikeNumber: string;
-  bikeChipId: string;
   startStationId: string;
   startStationName: string;
   startTime: Date;
@@ -85,7 +82,6 @@ export type PersonaRentalHistoryRow = {
   status: string;
   bikeId: string;
   bikeNumber: string;
-  bikeChipId: string;
   startStationId: string;
   startStationName: string;
   endStationId: string | null;
@@ -104,7 +100,6 @@ export type PersonaRentalDetail = {
   status: string;
   bikeId: string;
   bikeNumber: string;
-  bikeChipId: string;
   bikeStatus: string;
   startStationId: string;
   startStationName: string;
@@ -127,12 +122,9 @@ export type PersonaRentalDetail = {
   returnConfirmationStationName: string | null;
   billedTotalAmount: number | null;
   billedBaseAmount: number | null;
-  billedOvertimeAmount: number | null;
   billedCouponDiscountAmount: number | null;
   billedSubscriptionDiscountAmount: number | null;
   billedDepositForfeited: boolean | null;
-  penaltiesTotalAmount: number | null;
-  penaltiesCount: number;
 };
 
 export type EmailJobRow = {
@@ -151,20 +143,236 @@ export type EmailJobRow = {
   html: string;
 };
 
-type RawEmailJobRow = {
-  id: string;
-  status: Exclude<EmailJobStatus, "ALL">;
-  attempts: number;
-  dedupeKey: string | null;
-  lastError: string | null;
-  createdAt: Date;
-  runAt: Date;
-  sentAt: Date | null;
-  payload: unknown;
-};
-
 async function withClient<T>(_connectionString: string, task: (client: PrismaClient) => Promise<T>) {
   return withPrismaClient(task);
+}
+
+function looksLikeUuid(value: string) {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
+}
+
+function toNumber(value: { toNumber: () => number } | number | null | undefined) {
+  if (value == null) {
+    return null;
+  }
+
+  return typeof value === "number" ? value : value.toNumber();
+}
+
+function summarizeBikeStatuses(bikes: Array<{ status: string }>) {
+  return bikes.reduce((counts, bike) => {
+    counts.totalBikes += 1;
+
+    switch (bike.status) {
+      case "AVAILABLE":
+        counts.availableBikes += 1;
+        break;
+      case "BOOKED":
+        counts.bookedBikes += 1;
+        break;
+      case "BROKEN":
+        counts.brokenBikes += 1;
+        break;
+      case "RESERVED":
+        counts.reservedBikes += 1;
+        break;
+      case "MAINTAINED":
+        counts.maintainedBikes += 1;
+        break;
+      case "UNAVAILABLE":
+        counts.unavailableBikes += 1;
+        break;
+    }
+
+    return counts;
+  }, {
+    totalBikes: 0,
+    availableBikes: 0,
+    bookedBikes: 0,
+    brokenBikes: 0,
+    reservedBikes: 0,
+    maintainedBikes: 0,
+    unavailableBikes: 0,
+  });
+}
+
+function toStationSummaryRow<T extends {
+  id: string;
+  name: string;
+  address: string;
+  stationType: string;
+  totalCapacity: number;
+  returnSlotLimit: number;
+  updatedAt: Date;
+  bikes: Array<{ status: string }>;
+}>(station: T) {
+  return {
+    id: station.id,
+    name: station.name,
+    address: station.address,
+    stationType: station.stationType as StationSummaryRow["stationType"],
+    totalCapacity: station.totalCapacity,
+    returnSlotLimit: station.returnSlotLimit,
+    updatedAt: station.updatedAt,
+    ...summarizeBikeStatuses(station.bikes),
+  } satisfies StationSummaryRow;
+}
+
+type StationInspectionRecord = {
+  id: string;
+  name: string;
+  address: string;
+  stationType: string;
+  totalCapacity: number;
+  returnSlotLimit: number;
+  updatedAt: Date;
+  bikes: Array<{
+    id: string;
+    bikeNumber: string;
+    status: string;
+    updatedAt: Date;
+    rentals: Array<{ id: string }>;
+    reservations: Array<{ id: string }>;
+  }>;
+};
+
+const stationInspectionSelect = {
+  id: true,
+  name: true,
+  address: true,
+  stationType: true,
+  totalCapacity: true,
+  returnSlotLimit: true,
+  updatedAt: true,
+  bikes: {
+    orderBy: { bikeNumber: "asc" },
+    select: {
+      id: true,
+      bikeNumber: true,
+      status: true,
+      updatedAt: true,
+      rentals: {
+        where: { status: "RENTED" },
+        orderBy: { startTime: "desc" },
+        take: 1,
+        select: { id: true },
+      },
+      reservations: {
+        where: { status: "PENDING" },
+        orderBy: { createdAt: "desc" },
+        take: 1,
+        select: { id: true },
+      },
+    },
+  },
+} as const;
+
+type BikeInspectionRecord = {
+  id: string;
+  bikeNumber: string;
+  status: string;
+  stationId: string | null;
+  supplierId: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  station: {
+    name: string;
+    address: string;
+  } | null;
+  supplier: {
+    name: string;
+  } | null;
+  rentals: Array<{ id: string }>;
+  reservations: Array<{ id: string }>;
+};
+
+const bikeInspectionBaseSelect = {
+  id: true,
+  bikeNumber: true,
+  status: true,
+  stationId: true,
+  supplierId: true,
+  createdAt: true,
+  updatedAt: true,
+  station: {
+    select: {
+      name: true,
+      address: true,
+    },
+  },
+  supplier: {
+    select: {
+      name: true,
+    },
+  },
+  rentals: {
+    where: { status: "RENTED" },
+    orderBy: { startTime: "desc" },
+    take: 1,
+    select: { id: true },
+  },
+  reservations: {
+    where: { status: "PENDING" },
+    orderBy: { createdAt: "desc" },
+    take: 1,
+    select: { id: true },
+  },
+} as const;
+
+async function findStationByInspectableValue(client: PrismaClient, value: string): Promise<StationInspectionRecord | null> {
+  if (looksLikeUuid(value)) {
+    const byId = await client.station.findUnique({
+      where: { id: value },
+      select: stationInspectionSelect,
+    });
+
+    if (byId) {
+      return byId;
+    }
+  }
+
+  const byExactName = await client.station.findFirst({
+    where: { name: { equals: value, mode: "insensitive" } },
+    select: stationInspectionSelect,
+  });
+
+  if (byExactName) {
+    return byExactName;
+  }
+
+  return client.station.findFirst({
+    where: { name: { contains: value, mode: "insensitive" } },
+    orderBy: { updatedAt: "desc" },
+    select: stationInspectionSelect,
+  });
+}
+
+async function findBikeByInspectableValue(client: PrismaClient, value: string): Promise<BikeInspectionRecord | null> {
+  if (looksLikeUuid(value)) {
+    const byId = await client.bike.findUnique({
+      where: { id: value },
+      select: bikeInspectionBaseSelect,
+    });
+
+    if (byId) {
+      return byId;
+    }
+  }
+
+  const byExactBikeNumber = await client.bike.findFirst({
+    where: { bikeNumber: { equals: value, mode: "insensitive" } },
+    select: bikeInspectionBaseSelect,
+  });
+
+  if (byExactBikeNumber) {
+    return byExactBikeNumber;
+  }
+
+  return client.bike.findFirst({
+    where: { bikeNumber: { contains: value, mode: "insensitive" } },
+    orderBy: { updatedAt: "desc" },
+    select: bikeInspectionBaseSelect,
+  });
 }
 
 export async function listStations(args: {
@@ -173,30 +381,33 @@ export async function listStations(args: {
   search?: string;
 }) {
   return withClient(args.connectionString, async (client) => {
-    const search = args.search ?? null;
-    return client.$queryRaw<StationSummaryRow[]>`
-        SELECT
-          s.id,
-          s.name,
-          s.address,
-          s.station_type AS "stationType",
-          s.total_capacity AS "totalCapacity",
-          s.return_slot_limit AS "returnSlotLimit",
-          s.updated_at AS "updatedAt",
-          COUNT(b.id)::int AS "totalBikes",
-          COUNT(*) FILTER (WHERE b.status = 'AVAILABLE')::int AS "availableBikes",
-          COUNT(*) FILTER (WHERE b.status = 'BOOKED')::int AS "bookedBikes",
-          COUNT(*) FILTER (WHERE b.status = 'BROKEN')::int AS "brokenBikes",
-          COUNT(*) FILTER (WHERE b.status = 'RESERVED')::int AS "reservedBikes",
-          COUNT(*) FILTER (WHERE b.status = 'MAINTAINED')::int AS "maintainedBikes",
-          COUNT(*) FILTER (WHERE b.status = 'UNAVAILABLE')::int AS "unavailableBikes"
-        FROM "Station" s
-        LEFT JOIN "Bike" b ON b."stationId" = s.id
-        WHERE (${search}::text IS NULL OR s.id::text = ${search} OR s.name ILIKE '%' || ${search} || '%')
-        GROUP BY s.id
-        ORDER BY s.name ASC
-        LIMIT ${args.limit ?? 25}
-      `;
+    const search = args.search?.trim();
+    const stations = await client.station.findMany({
+      where: search
+        ? {
+            OR: [
+              ...(looksLikeUuid(search) ? [{ id: search }] : []),
+              { name: { contains: search, mode: "insensitive" } },
+            ],
+          }
+        : undefined,
+      orderBy: { name: "asc" },
+      take: args.limit ?? 25,
+      select: {
+        id: true,
+        name: true,
+        address: true,
+        stationType: true,
+        totalCapacity: true,
+        returnSlotLimit: true,
+        updatedAt: true,
+        bikes: {
+          select: { status: true },
+        },
+      },
+    });
+
+    return stations.map(toStationSummaryRow);
   });
 }
 
@@ -205,70 +416,21 @@ export async function getStationInspection(args: {
   value: string;
 }) {
   return withClient(args.connectionString, async (client) => {
-    const stationRows = await client.$queryRaw<StationSummaryRow[]>`
-        SELECT
-          s.id,
-          s.name,
-          s.address,
-          s.station_type AS "stationType",
-          s.total_capacity AS "totalCapacity",
-          s.return_slot_limit AS "returnSlotLimit",
-          s.updated_at AS "updatedAt",
-          COUNT(b.id)::int AS "totalBikes",
-          COUNT(*) FILTER (WHERE b.status = 'AVAILABLE')::int AS "availableBikes",
-          COUNT(*) FILTER (WHERE b.status = 'BOOKED')::int AS "bookedBikes",
-          COUNT(*) FILTER (WHERE b.status = 'BROKEN')::int AS "brokenBikes",
-          COUNT(*) FILTER (WHERE b.status = 'RESERVED')::int AS "reservedBikes",
-          COUNT(*) FILTER (WHERE b.status = 'MAINTAINED')::int AS "maintainedBikes",
-          COUNT(*) FILTER (WHERE b.status = 'UNAVAILABLE')::int AS "unavailableBikes"
-        FROM "Station" s
-        LEFT JOIN "Bike" b ON b."stationId" = s.id
-        WHERE s.id::text = ${args.value} OR s.name ILIKE '%' || ${args.value} || '%'
-        GROUP BY s.id
-        ORDER BY
-          CASE
-            WHEN s.id::text = ${args.value} THEN 0
-            WHEN s.name = ${args.value} THEN 1
-            ELSE 2
-          END,
-          s.updated_at DESC
-        LIMIT 1
-      `;
-
-    const station = stationRows[0] ?? null;
+    const station = await findStationByInspectableValue(client, args.value);
     if (!station) {
       return null;
     }
 
-    const bikes = await client.$queryRaw<StationBikeRow[]>`
-        SELECT
-          b.id,
-          b.bike_number AS "bikeNumber",
-          b.chip_id AS "chipId",
-          b.status,
-          b.updated_at AS "updatedAt",
-          (
-            SELECT r.id
-            FROM "Rental" r
-            WHERE r.bike_id = b.id AND r.status = 'RENTED'
-            ORDER BY r.start_time DESC
-            LIMIT 1
-          ) AS "activeRentalId",
-          (
-            SELECT res.id
-            FROM "Reservation" res
-            WHERE res.bike_id = b.id AND res.status = 'PENDING'
-            ORDER BY res.created_at DESC
-            LIMIT 1
-          ) AS "pendingReservationId"
-        FROM "Bike" b
-        WHERE b."stationId" = ${station.id}::uuid
-        ORDER BY b.bike_number ASC
-      `;
-
     return {
-      ...station,
-      bikes,
+      ...toStationSummaryRow(station),
+      bikes: station.bikes.map(bike => ({
+        id: bike.id,
+        bikeNumber: bike.bikeNumber,
+        status: bike.status,
+        updatedAt: bike.updatedAt,
+        activeRentalId: bike.rentals[0]?.id ?? null,
+        pendingReservationId: bike.reservations[0]?.id ?? null,
+      } satisfies StationBikeRow)),
     } satisfies StationInspection;
   });
 }
@@ -278,71 +440,50 @@ export async function getBikeInspection(args: {
   value: string;
 }) {
   return withClient(args.connectionString, async (client) => {
-    const bikeRows = await client.$queryRaw<Array<Omit<BikeInspection, "recentRentals">>>`
-        SELECT
-          b.id,
-          b.bike_number AS "bikeNumber",
-          b.chip_id AS "chipId",
-          b.status,
-          b."stationId" AS "stationId",
-          s.name AS "stationName",
-          s.address AS "stationAddress",
-          b."supplierId" AS "supplierId",
-          sup.name AS "supplierName",
-          b.created_at AS "createdAt",
-          b.updated_at AS "updatedAt",
-          (
-            SELECT r.id
-            FROM "Rental" r
-            WHERE r.bike_id = b.id AND r.status = 'RENTED'
-            ORDER BY r.start_time DESC
-            LIMIT 1
-          ) AS "activeRentalId",
-          (
-            SELECT res.id
-            FROM "Reservation" res
-            WHERE res.bike_id = b.id AND res.status = 'PENDING'
-            ORDER BY res.created_at DESC
-            LIMIT 1
-          ) AS "pendingReservationId"
-        FROM "Bike" b
-        LEFT JOIN "Station" s ON s.id = b."stationId"
-        LEFT JOIN "Supplier" sup ON sup.id = b."supplierId"
-        WHERE b.id::text = ${args.value} OR b.bike_number ILIKE '%' || ${args.value} || '%' OR b.chip_id ILIKE '%' || ${args.value} || '%'
-        ORDER BY
-          CASE
-            WHEN b.id::text = ${args.value} THEN 0
-            WHEN b.bike_number = ${args.value} THEN 1
-            WHEN b.chip_id = ${args.value} THEN 2
-            ELSE 3
-          END,
-          b.updated_at DESC
-        LIMIT 1
-      `;
-
-    const bike = bikeRows[0] ?? null;
+    const bike = await findBikeByInspectableValue(client, args.value);
     if (!bike) {
       return null;
     }
 
-    const recentRentals = await client.$queryRaw<BikeRentalSnapshot[]>`
-        SELECT
-          r.id,
-          r.status,
-          r.start_time AS "startTime",
-          r.end_time AS "endTime",
-          u.id AS "userId",
-          u.email AS "userEmail"
-        FROM "Rental" r
-        INNER JOIN users u ON u.id = r.user_id
-        WHERE r.bike_id = ${bike.id}::uuid
-        ORDER BY r.start_time DESC
-        LIMIT 5
-      `;
+    const recentRentals = await client.rental.findMany({
+      where: { bikeId: bike.id },
+      orderBy: { startTime: "desc" },
+      take: 5,
+      select: {
+        id: true,
+        status: true,
+        startTime: true,
+        endTime: true,
+        userId: true,
+        user: {
+          select: {
+            email: true,
+          },
+        },
+      },
+    });
 
     return {
-      ...bike,
-      recentRentals,
+      id: bike.id,
+      bikeNumber: bike.bikeNumber,
+      status: bike.status,
+      stationId: bike.stationId,
+      stationName: bike.station?.name ?? null,
+      stationAddress: bike.station?.address ?? null,
+      supplierId: bike.supplierId,
+      supplierName: bike.supplier?.name ?? null,
+      createdAt: bike.createdAt,
+      updatedAt: bike.updatedAt,
+      activeRentalId: bike.rentals[0]?.id ?? null,
+      pendingReservationId: bike.reservations[0]?.id ?? null,
+      recentRentals: recentRentals.map(rental => ({
+        id: rental.id,
+        status: rental.status,
+        startTime: rental.startTime,
+        endTime: rental.endTime,
+        userId: rental.userId,
+        userEmail: rental.user.email,
+      } satisfies BikeRentalSnapshot)),
     } satisfies BikeInspection;
   });
 }
@@ -352,26 +493,34 @@ export async function listActiveRentals(args: {
   limit?: number;
 }) {
   return withClient(args.connectionString, async (client) => {
-    return client.$queryRaw<ActiveRentalInspectorRow[]>`
-        SELECT
-          r.id,
-          r.user_id AS "userId",
-          u.email AS "userEmail",
-          r.bike_id AS "bikeId",
-          b.bike_number AS "bikeNumber",
-          b.chip_id AS "bikeChipId",
-          r.start_station AS "startStationId",
-          s.name AS "startStationName",
-          r.start_time AS "startTime",
-          r.status
-        FROM "Rental" r
-        INNER JOIN users u ON u.id = r.user_id
-        INNER JOIN "Bike" b ON b.id = r.bike_id
-        INNER JOIN "Station" s ON s.id = r.start_station
-        WHERE r.status = 'RENTED'
-        ORDER BY r.start_time DESC
-        LIMIT ${args.limit ?? 25}
-      `;
+    const rentals = await client.rental.findMany({
+      where: { status: "RENTED" },
+      orderBy: { startTime: "desc" },
+      take: args.limit ?? 25,
+      select: {
+        id: true,
+        userId: true,
+        user: { select: { email: true } },
+        bikeId: true,
+        bike: { select: { bikeNumber: true } },
+        startStationId: true,
+        startStation: { select: { name: true } },
+        startTime: true,
+        status: true,
+      },
+    });
+
+    return rentals.map(rental => ({
+      id: rental.id,
+      userId: rental.userId,
+      userEmail: rental.user.email,
+      bikeId: rental.bikeId,
+      bikeNumber: rental.bike.bikeNumber,
+      startStationId: rental.startStationId,
+      startStationName: rental.startStation.name,
+      startTime: rental.startTime,
+      status: rental.status,
+    } satisfies ActiveRentalInspectorRow));
   });
 }
 
@@ -379,35 +528,48 @@ export async function listPersonaRentalHistory(args: {
   connectionString: string;
   userId: string;
   limit?: number;
-  status?: "RENTED" | "COMPLETED" | "CANCELLED";
+  status?: "RENTED" | "COMPLETED" | "OVERDUE_UNRETURNED";
 }) {
   return withClient(args.connectionString, async (client) => {
-    const status = args.status ?? null;
-    return client.$queryRaw<PersonaRentalHistoryRow[]>`
-        SELECT
-          r.id,
-          r.status,
-          r.bike_id AS "bikeId",
-          b.bike_number AS "bikeNumber",
-          b.chip_id AS "bikeChipId",
-          r.start_station AS "startStationId",
-          start_station.name AS "startStationName",
-          r.end_station AS "endStationId",
-          end_station.name AS "endStationName",
-          r.start_time AS "startTime",
-          r.end_time AS "endTime",
-          r.duration AS "durationMinutes",
-          CASE WHEN r.total_price IS NULL THEN NULL ELSE r.total_price::float8 END AS "totalPrice",
-          r.updated_at AS "updatedAt"
-        FROM "Rental" r
-        INNER JOIN "Bike" b ON b.id = r.bike_id
-        INNER JOIN "Station" start_station ON start_station.id = r.start_station
-        LEFT JOIN "Station" end_station ON end_station.id = r.end_station
-        WHERE r.user_id = ${args.userId}::uuid
-          AND (${status}::text IS NULL OR r.status = ${status})
-        ORDER BY r.start_time DESC, r.created_at DESC
-        LIMIT ${args.limit ?? 20}
-      `;
+    const rentals = await client.rental.findMany({
+      where: {
+        userId: args.userId,
+        ...(args.status ? { status: args.status } : {}),
+      },
+      orderBy: [{ startTime: "desc" }, { createdAt: "desc" }],
+      take: args.limit ?? 20,
+      select: {
+        id: true,
+        status: true,
+        bikeId: true,
+        bike: { select: { bikeNumber: true } },
+        startStationId: true,
+        startStation: { select: { name: true } },
+        endStationId: true,
+        endStation: { select: { name: true } },
+        startTime: true,
+        endTime: true,
+        duration: true,
+        totalPrice: true,
+        updatedAt: true,
+      },
+    });
+
+    return rentals.map(rental => ({
+      id: rental.id,
+      status: rental.status,
+      bikeId: rental.bikeId,
+      bikeNumber: rental.bike.bikeNumber,
+      startStationId: rental.startStationId,
+      startStationName: rental.startStation.name,
+      endStationId: rental.endStationId,
+      endStationName: rental.endStation?.name ?? null,
+      startTime: rental.startTime,
+      endTime: rental.endTime,
+      durationMinutes: rental.duration,
+      totalPrice: toNumber(rental.totalPrice),
+      updatedAt: rental.updatedAt,
+    } satisfies PersonaRentalHistoryRow));
   });
 }
 
@@ -417,66 +579,88 @@ export async function getPersonaRentalDetail(args: {
   rentalId: string;
 }) {
   return withClient(args.connectionString, async (client) => {
-    const rows = await client.$queryRaw<PersonaRentalDetail[]>`
-        SELECT
-          r.id,
-          r.user_id AS "userId",
-          u.email AS "userEmail",
-          r.status,
-          r.bike_id AS "bikeId",
-          b.bike_number AS "bikeNumber",
-          b.chip_id AS "bikeChipId",
-          b.status AS "bikeStatus",
-          r.start_station AS "startStationId",
-          start_station.name AS "startStationName",
-          start_station.address AS "startStationAddress",
-          r.end_station AS "endStationId",
-          end_station.name AS "endStationName",
-          end_station.address AS "endStationAddress",
-          r.start_time AS "startTime",
-          r.end_time AS "endTime",
-          r.duration AS "durationMinutes",
-          CASE WHEN r.total_price IS NULL THEN NULL ELSE r.total_price::float8 END AS "totalPrice",
-          r.subscription_id AS "subscriptionId",
-          r.updated_at AS "updatedAt",
-          rc.confirmed_at AS "returnConfirmedAt",
-          rc.confirmation_method AS "returnConfirmationMethod",
-          rc.handover_status AS "returnHandoverStatus",
-          rc.confirmed_by_user_id AS "returnConfirmedByUserId",
-          confirmed_by.email AS "returnConfirmedByUserEmail",
-          rc.station_id AS "returnConfirmationStationId",
-          confirmation_station.name AS "returnConfirmationStationName",
-          CASE WHEN rbr.total_amount IS NULL THEN NULL ELSE rbr.total_amount::float8 END AS "billedTotalAmount",
-          CASE WHEN rbr.base_amount IS NULL THEN NULL ELSE rbr.base_amount::float8 END AS "billedBaseAmount",
-          CASE WHEN rbr.overtime_amount IS NULL THEN NULL ELSE rbr.overtime_amount::float8 END AS "billedOvertimeAmount",
-          CASE WHEN rbr.coupon_discount_amount IS NULL THEN NULL ELSE rbr.coupon_discount_amount::float8 END AS "billedCouponDiscountAmount",
-          CASE WHEN rbr.subscription_discount_amount IS NULL THEN NULL ELSE rbr.subscription_discount_amount::float8 END AS "billedSubscriptionDiscountAmount",
-          rbr.deposit_forfeited AS "billedDepositForfeited",
-          penalties.total_amount AS "penaltiesTotalAmount",
-          penalties.count AS "penaltiesCount"
-        FROM "Rental" r
-        INNER JOIN users u ON u.id = r.user_id
-        INNER JOIN "Bike" b ON b.id = r.bike_id
-        INNER JOIN "Station" start_station ON start_station.id = r.start_station
-        LEFT JOIN "Station" end_station ON end_station.id = r.end_station
-        LEFT JOIN return_confirmations rc ON rc.rental_id = r.id
-        LEFT JOIN users confirmed_by ON confirmed_by.id = rc.confirmed_by_user_id
-        LEFT JOIN "Station" confirmation_station ON confirmation_station.id = rc.station_id
-        LEFT JOIN rental_billing_records rbr ON rbr.rental_id = r.id
-        LEFT JOIN (
-          SELECT
-            rental_id,
-            COUNT(*)::int AS count,
-            COALESCE(SUM(amount)::float8, 0) AS total_amount
-          FROM rental_penalties
-          GROUP BY rental_id
-        ) penalties ON penalties.rental_id = r.id
-        WHERE r.user_id = ${args.userId}::uuid
-          AND r.id = ${args.rentalId}::uuid
-        LIMIT 1
-      `;
+    const rental = await client.rental.findFirst({
+      where: {
+        id: args.rentalId,
+        userId: args.userId,
+      },
+      select: {
+        id: true,
+        userId: true,
+        user: { select: { email: true } },
+        status: true,
+        bikeId: true,
+        bike: { select: { bikeNumber: true, status: true } },
+        startStationId: true,
+        startStation: { select: { name: true, address: true } },
+        endStationId: true,
+        endStation: { select: { name: true, address: true } },
+        startTime: true,
+        endTime: true,
+        duration: true,
+        totalPrice: true,
+        subscriptionId: true,
+        updatedAt: true,
+        returnConfirmation: {
+          select: {
+            confirmedAt: true,
+            confirmationMethod: true,
+            handoverStatus: true,
+            confirmedByUserId: true,
+            confirmedByUser: { select: { email: true } },
+            stationId: true,
+            station: { select: { name: true } },
+          },
+        },
+        rentalBillingRecord: {
+          select: {
+            totalAmount: true,
+            baseAmount: true,
+            couponDiscountAmount: true,
+            subscriptionDiscountAmount: true,
+            depositForfeited: true,
+          },
+        },
+      },
+    });
 
-    return rows[0] ?? null;
+    if (!rental) {
+      return null;
+    }
+
+    return {
+      id: rental.id,
+      userId: rental.userId,
+      userEmail: rental.user.email,
+      status: rental.status,
+      bikeId: rental.bikeId,
+      bikeNumber: rental.bike.bikeNumber,
+      bikeStatus: rental.bike.status,
+      startStationId: rental.startStationId,
+      startStationName: rental.startStation.name,
+      startStationAddress: rental.startStation.address,
+      endStationId: rental.endStationId,
+      endStationName: rental.endStation?.name ?? null,
+      endStationAddress: rental.endStation?.address ?? null,
+      startTime: rental.startTime,
+      endTime: rental.endTime,
+      durationMinutes: rental.duration,
+      totalPrice: toNumber(rental.totalPrice),
+      subscriptionId: rental.subscriptionId,
+      updatedAt: rental.updatedAt,
+      returnConfirmedAt: rental.returnConfirmation?.confirmedAt ?? null,
+      returnConfirmationMethod: rental.returnConfirmation?.confirmationMethod ?? null,
+      returnHandoverStatus: rental.returnConfirmation?.handoverStatus ?? null,
+      returnConfirmedByUserId: rental.returnConfirmation?.confirmedByUserId ?? null,
+      returnConfirmedByUserEmail: rental.returnConfirmation?.confirmedByUser.email ?? null,
+      returnConfirmationStationId: rental.returnConfirmation?.stationId ?? null,
+      returnConfirmationStationName: rental.returnConfirmation?.station?.name ?? null,
+      billedTotalAmount: toNumber(rental.rentalBillingRecord?.totalAmount),
+      billedBaseAmount: toNumber(rental.rentalBillingRecord?.baseAmount),
+      billedCouponDiscountAmount: toNumber(rental.rentalBillingRecord?.couponDiscountAmount),
+      billedSubscriptionDiscountAmount: toNumber(rental.rentalBillingRecord?.subscriptionDiscountAmount),
+      billedDepositForfeited: rental.rentalBillingRecord?.depositForfeited ?? null,
+    } satisfies PersonaRentalDetail;
   });
 }
 
@@ -499,40 +683,25 @@ export async function listEmailJobs(args: {
   limit?: number;
 }) {
   return withClient(args.connectionString, async (client) => {
-    const rows = args.status === "ALL"
-      ? await client.$queryRaw<RawEmailJobRow[]>`
-          SELECT
-            id,
-            status,
-            attempts,
-            dedupe_key AS "dedupeKey",
-            last_error AS "lastError",
-            created_at AS "createdAt",
-            run_at AS "runAt",
-            sent_at AS "sentAt",
-            payload
-          FROM job_outbox
-          WHERE type = ${EMAIL_JOB_TYPE}
-          ORDER BY created_at DESC
-          LIMIT ${args.limit ?? 30}
-        `
-      : await client.$queryRaw<RawEmailJobRow[]>`
-          SELECT
-            id,
-            status,
-            attempts,
-            dedupe_key AS "dedupeKey",
-            last_error AS "lastError",
-            created_at AS "createdAt",
-            run_at AS "runAt",
-            sent_at AS "sentAt",
-            payload
-          FROM job_outbox
-          WHERE type = ${EMAIL_JOB_TYPE}
-            AND status = ${args.status}
-          ORDER BY created_at DESC
-          LIMIT ${args.limit ?? 30}
-        `;
+    const rows = await client.jobOutbox.findMany({
+      where: {
+        type: EMAIL_JOB_TYPE,
+        ...(args.status === "ALL" ? {} : { status: args.status }),
+      },
+      orderBy: { createdAt: "desc" },
+      take: args.limit ?? 30,
+      select: {
+        id: true,
+        status: true,
+        attempts: true,
+        dedupeKey: true,
+        lastError: true,
+        createdAt: true,
+        runAt: true,
+        sentAt: true,
+        payload: true,
+      },
+    });
 
     return rows.map((row) => {
       const parsed = safeParseJobPayload(EMAIL_JOB_TYPE, row.payload);

--- a/apps/server/src/dev-cli/device.ts
+++ b/apps/server/src/dev-cli/device.ts
@@ -1,14 +1,12 @@
 import type { Buffer } from "node:buffer";
 
-import { execFile } from "node:child_process";
-import { open } from "node:fs/promises";
-import { promisify } from "node:util";
+import { SerialPort } from "serialport";
 
-const execFileAsync = promisify(execFile);
 const PROVISIONING_PREFIX = "CFG ";
 const DEFAULT_BAUD_RATE = 115200;
 const DEFAULT_TIMEOUT_MS = 5000;
 const SERIAL_SETTLE_MS = 250;
+const KNOWN_USB_SERIAL_VENDOR_IDS = new Set(["0403", "10c4", "1a86", "303a"]);
 
 export type DeviceConfig = {
   bikeId: string;
@@ -35,6 +33,8 @@ type ProvisioningResponse = {
   mqttPassword?: string;
 };
 
+type PortInfo = Awaited<ReturnType<typeof SerialPort.list>>[number];
+
 export async function getDeviceConfig(portPath: string) {
   const response = await sendProvisioningCommand(portPath, { type: "get-config" });
   return {
@@ -59,6 +59,34 @@ export async function restartDevice(portPath: string) {
   await sendProvisioningCommand(portPath, { type: "restart" }, 8000);
 }
 
+export async function suggestDevicePort() {
+  const ports = await SerialPort.list();
+  const detection = detectDevicePort(ports);
+  return detection.kind === "single" ? detection.port.path : null;
+}
+
+export async function resolveDevicePort(portPath?: string) {
+  if (portPath) {
+    return portPath;
+  }
+
+  const ports = await SerialPort.list();
+  const detection = detectDevicePort(ports);
+
+  if (detection.kind === "single") {
+    return detection.port.path;
+  }
+
+  const availablePortsMessage = formatAvailablePortsMessage(ports);
+  if (detection.kind === "ambiguous") {
+    throw new Error(
+      `Multiple likely device ports detected: ${detection.ports.map(port => port.path).join(", ")}. Use --port <serial-port> to choose manually. ${availablePortsMessage}`,
+    );
+  }
+
+  throw new Error(`Could not auto-detect an ESP32 serial port. Use --port <serial-port> to choose manually. ${availablePortsMessage}`);
+}
+
 async function sendProvisioningCommand(
   portPath: string,
   payload: Record<string, string | number | undefined>,
@@ -69,16 +97,18 @@ async function sendProvisioningCommand(
   for (let attempt = 1; attempt <= 2; attempt += 1) {
     const requestId = `${Date.now()}-${Math.random().toString(16).slice(2, 10)}`;
     const request = `${PROVISIONING_PREFIX}${JSON.stringify({ ...payload, requestId })}\n`;
-
-    await execFileAsync("stty", ["-F", portPath, String(DEFAULT_BAUD_RATE), "raw", "-echo", "-icanon", "min", "0", "time", "5"]);
-
-    const handle = await open(portPath, "r+");
-    const stream = handle.createReadStream({ encoding: "utf8" });
+    const port = new SerialPort({
+      path: portPath,
+      baudRate: DEFAULT_BAUD_RATE,
+      autoOpen: false,
+    });
 
     try {
+      await openSerialPort(port);
       await sleep(SERIAL_SETTLE_MS);
-      const responsePromise = waitForProvisioningResponse(stream, requestId, timeoutMs);
-      await handle.writeFile(request, { encoding: "utf8" });
+      const responsePromise = waitForProvisioningResponse(port, requestId, timeoutMs);
+      await writeSerialPort(port, request);
+      await drainSerialPort(port);
       const response = await responsePromise;
       if (!response.ok) {
         throw new Error(response.message ?? response.error ?? "device rejected request");
@@ -93,8 +123,7 @@ async function sendProvisioningCommand(
       await sleep(750);
     }
     finally {
-      stream.destroy();
-      await handle.close();
+      await closeSerialPort(port);
     }
   }
 
@@ -152,6 +181,141 @@ function waitForProvisioningResponse(stream: NodeJS.ReadableStream, requestId: s
 
     stream.on("data", onData);
     stream.on("error", onError);
+  });
+}
+
+function detectDevicePort(ports: PortInfo[]) {
+  const rankedPorts = ports
+    .map(port => ({ port, score: scorePort(port) }))
+    .filter(candidate => candidate.score > 0)
+    .sort((left, right) => right.score - left.score || left.port.path.localeCompare(right.port.path));
+
+  if (rankedPorts.length === 0) {
+    return { kind: "none" as const };
+  }
+
+  const topScore = rankedPorts[0].score;
+  const topPorts = rankedPorts.filter(candidate => candidate.score === topScore).map(candidate => candidate.port);
+  if (topPorts.length > 1) {
+    return { kind: "ambiguous" as const, ports: topPorts };
+  }
+
+  return { kind: "single" as const, port: rankedPorts[0].port };
+}
+
+function scorePort(port: PortInfo) {
+  let score = 0;
+  const vendorId = port.vendorId?.toLowerCase();
+  const combined = [port.path, port.manufacturer, port.pnpId, port.vendorId, port.productId]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+
+  if (combined.includes("esp32") || combined.includes("espressif")) {
+    score += 100;
+  }
+  if (vendorId && KNOWN_USB_SERIAL_VENDOR_IDS.has(vendorId)) {
+    score += 50;
+  }
+  if (combined.includes("cp210") || combined.includes("silicon labs")) {
+    score += 35;
+  }
+  if (combined.includes("ch340") || combined.includes("wch")) {
+    score += 35;
+  }
+  if (combined.includes("ftdi")) {
+    score += 30;
+  }
+  if (combined.includes("usb serial") || combined.includes("usb-serial")) {
+    score += 20;
+  }
+  if (port.pnpId?.toLowerCase().includes("usb")) {
+    score += 15;
+  }
+  if (isLikelySerialPath(port.path)) {
+    score += 15;
+  }
+
+  return score;
+}
+
+function isLikelySerialPath(path: string) {
+  return /^COM\d+$/i.test(path)
+    || /^\/dev\/tty(?:USB|ACM)\d+$/i.test(path)
+    || /^\/dev\/tty\.usb(?:serial|modem)/i.test(path);
+}
+
+function formatAvailablePortsMessage(ports: PortInfo[]) {
+  if (ports.length === 0) {
+    return "No serial ports found.";
+  }
+
+  return `Available ports: ${ports.map(formatPortSummary).join(", ")}.`;
+}
+
+function formatPortSummary(port: PortInfo) {
+  const details = [
+    port.manufacturer,
+    port.vendorId ? `VID:${port.vendorId}` : undefined,
+    port.productId ? `PID:${port.productId}` : undefined,
+  ].filter(Boolean);
+
+  return details.length > 0 ? `${port.path} (${details.join(", ")})` : port.path;
+}
+
+function openSerialPort(port: SerialPort) {
+  return new Promise<void>((resolve, reject) => {
+    port.open((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+}
+
+function writeSerialPort(port: SerialPort, value: string) {
+  return new Promise<void>((resolve, reject) => {
+    port.write(value, (error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+}
+
+function drainSerialPort(port: SerialPort) {
+  return new Promise<void>((resolve, reject) => {
+    port.drain((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+}
+
+async function closeSerialPort(port: SerialPort) {
+  if (!port.isOpen) {
+    return;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    port.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
   });
 }
 

--- a/apps/server/src/dev-cli/device.ts
+++ b/apps/server/src/dev-cli/device.ts
@@ -105,6 +105,7 @@ async function sendProvisioningCommand(
 
     try {
       await openSerialPort(port);
+      port.setEncoding("utf8");
       await sleep(SERIAL_SETTLE_MS);
       const responsePromise = waitForProvisioningResponse(port, requestId, timeoutMs);
       await writeSerialPort(port, request);
@@ -123,7 +124,7 @@ async function sendProvisioningCommand(
       await sleep(750);
     }
     finally {
-      await closeSerialPort(port);
+      await closeSerialPort(port).catch(() => {});
     }
   }
 

--- a/apps/server/src/dev-cli/index.ts
+++ b/apps/server/src/dev-cli/index.ts
@@ -137,7 +137,7 @@ try {
       writeLine(`${chalk.gray("returnSlots")}: ${station.returnSlotLimit}`);
       writeLine(`${chalk.gray("bikes")}: available ${station.availableBikes}, booked ${station.bookedBikes}, reserved ${station.reservedBikes}, broken ${station.brokenBikes}, maintained ${station.maintainedBikes}, unavailable ${station.unavailableBikes}`);
       for (const bike of station.bikes) {
-        writeLine(`- ${bike.bikeNumber} ${bike.status} ${bike.id} ${bike.chipId}`);
+        writeLine(`- ${bike.bikeNumber} ${bike.status} ${bike.id}`);
       }
       break;
     }
@@ -145,7 +145,7 @@ try {
       const connectionString = requireConnectionString();
       const value = args[0];
       if (!value) {
-        throw new Error("Need bike id, bike number, or chip id: pnpm dev:cli bike <value>");
+        throw new Error("Need bike id or bike number: pnpm dev:cli bike <value>");
       }
 
       const bike = await getBikeInspection({ connectionString, value });
@@ -155,7 +155,6 @@ try {
 
       writeLine(chalk.cyan(`Bike ${bike.bikeNumber}`));
       writeLine(`${chalk.gray("id")}: ${bike.id}`);
-      writeLine(`${chalk.gray("chip")}: ${bike.chipId}`);
       writeLine(`${chalk.gray("status")}: ${bike.status}`);
       writeLine(`${chalk.gray("station")}: ${bike.stationName ?? "-"}`);
       writeLine(`${chalk.gray("supplier")}: ${bike.supplierName ?? "-"}`);
@@ -295,8 +294,8 @@ function printHelp() {
   writeLine("  pnpm dev:cli list --interactive");
   writeLine("  pnpm dev:cli stations [search]");
   writeLine("  pnpm dev:cli station <station-id|name>");
-  writeLine("  pnpm dev:cli bike <bike-id|bike-number|chip-id>");
-  writeLine("  pnpm dev:cli rentals [RENTED|COMPLETED|CANCELLED]");
+  writeLine("  pnpm dev:cli bike <bike-id|bike-number>");
+  writeLine("  pnpm dev:cli rentals [RENTED|COMPLETED|OVERDUE_UNRETURNED]");
   writeLine("  pnpm dev:cli rental <rental-id>");
   writeLine("  pnpm dev:cli show <job-id>");
   writeLine("  pnpm dev:cli process-once");
@@ -480,7 +479,6 @@ async function handleRentalDetailCommand(connectionString: string, args: string[
   writeLine(`${chalk.gray("user")}: ${rental.userEmail}`);
   writeLine(`${chalk.gray("status")}: ${rental.status}`);
   writeLine(`${chalk.gray("bike")}: ${rental.bikeNumber} ${chalk.gray(`(${rental.bikeId})`)}`);
-  writeLine(`${chalk.gray("chip")}: ${rental.bikeChipId}`);
   writeLine(`${chalk.gray("bikeStatus")}: ${rental.bikeStatus}`);
   writeLine(`${chalk.gray("startStation")}: ${rental.startStationName} ${chalk.gray(`(${rental.startStationId})`)}`);
   writeLine(`${chalk.gray("endStation")}: ${rental.endStationName ?? "-"} ${rental.endStationId ? chalk.gray(`(${rental.endStationId})`) : ""}`.trimEnd());
@@ -497,11 +495,9 @@ async function handleRentalDetailCommand(connectionString: string, args: string[
   writeLine(`${chalk.gray("returnStation")}: ${rental.returnConfirmationStationName ?? rental.returnConfirmationStationId ?? "-"}`);
   writeLine(`${chalk.gray("billedTotal")}: ${rental.billedTotalAmount ?? "-"}`);
   writeLine(`${chalk.gray("billedBase")}: ${rental.billedBaseAmount ?? "-"}`);
-  writeLine(`${chalk.gray("billedOvertime")}: ${rental.billedOvertimeAmount ?? "-"}`);
   writeLine(`${chalk.gray("couponDiscount")}: ${rental.billedCouponDiscountAmount ?? "-"}`);
   writeLine(`${chalk.gray("subscriptionDiscount")}: ${rental.billedSubscriptionDiscountAmount ?? "-"}`);
   writeLine(`${chalk.gray("depositForfeited")}: ${rental.billedDepositForfeited ?? "-"}`);
-  writeLine(`${chalk.gray("penalties")}: ${rental.penaltiesCount} item(s), total ${rental.penaltiesTotalAmount ?? 0}`);
 }
 
 async function requireCurrentPersona(connectionString: string, repoRoot: string) {
@@ -524,8 +520,8 @@ function normalizeRentalStatus(input?: string) {
       return undefined;
     case "RENTED":
     case "COMPLETED":
-    case "CANCELLED":
-      return input.toUpperCase() as "RENTED" | "COMPLETED" | "CANCELLED";
+    case "OVERDUE_UNRETURNED":
+      return input.toUpperCase() as "RENTED" | "COMPLETED" | "OVERDUE_UNRETURNED";
     default:
       throw new Error(`Unknown rental status filter: ${input}`);
   }

--- a/apps/server/src/dev-cli/index.ts
+++ b/apps/server/src/dev-cli/index.ts
@@ -19,6 +19,7 @@ import {
 } from "./data";
 import {
   getDeviceConfig,
+  resolveDevicePort,
   restartDevice,
   setDeviceConfig,
 } from "./device";
@@ -285,9 +286,9 @@ function printHelp() {
   writeLine("  pnpm dev:cli persona current");
   writeLine("  pnpm dev:cli persona use <handle|email>");
   writeLine("  pnpm dev:cli persona clear");
-  writeLine("  pnpm dev:cli device config get [--port /dev/ttyUSB0]");
-  writeLine("  pnpm dev:cli device config set --bike-id <id> [--wifi-ssid <ssid>] [--wifi-pass <pass>] [--mqtt-broker-ip <ip>] [--mqtt-port <port>] [--mqtt-username <user>] [--mqtt-password <pass>] [--port /dev/ttyUSB0]");
-  writeLine("  pnpm dev:cli device restart [--port /dev/ttyUSB0]");
+  writeLine("  pnpm dev:cli device config get [--port <serial-port>]");
+  writeLine("  pnpm dev:cli device config set --bike-id <id> [--wifi-ssid <ssid>] [--wifi-pass <pass>] [--mqtt-broker-ip <ip>] [--mqtt-port <port>] [--mqtt-username <user>] [--mqtt-password <pass>] [--port <serial-port>]");
+  writeLine("  pnpm dev:cli device restart [--port <serial-port>]");
   writeLine("  pnpm dev:cli user-card <user-id|email|handle> <card-uid>");
   writeLine("  pnpm dev:cli user-card <user-id|email|handle> --clear");
   writeLine("  pnpm dev:cli list [ALL|PENDING|SENT|FAILED|CANCELLED]");
@@ -328,7 +329,7 @@ async function handleDeviceCommand(args: string[]) {
 
   if (subcommand === "restart") {
     const flags = parseFlags([maybeAction, ...rest].filter(Boolean) as string[]);
-    const portPath = flags.port ?? "/dev/ttyUSB0";
+    const portPath = await resolveDevicePort(flags.port);
     await restartDevice(portPath);
     writeLine(chalk.green(`Restart command sent to ${portPath}.`));
     return;
@@ -336,7 +337,7 @@ async function handleDeviceCommand(args: string[]) {
 
   const action = maybeAction;
   const flags = parseFlags(rest);
-  const portPath = flags.port ?? "/dev/ttyUSB0";
+  const portPath = await resolveDevicePort(flags.port);
 
   if (subcommand === "config" && action === "get") {
     const config = await getDeviceConfig(portPath);

--- a/apps/server/src/dev-cli/interactive.ts
+++ b/apps/server/src/dev-cli/interactive.ts
@@ -20,7 +20,7 @@ import {
   sendSampleEmails,
   stripHtml,
 } from "./data";
-import { getDeviceConfig, restartDevice, setDeviceConfig } from "./device";
+import { getDeviceConfig, resolveDevicePort, restartDevice, setDeviceConfig, suggestDevicePort } from "./device";
 import { writeError, writeLine } from "./output";
 import { printPersona } from "./persona-output";
 import {
@@ -33,7 +33,6 @@ import {
 import { updateUserCardBinding } from "./user-card";
 
 const STATUS_OPTIONS: EmailJobStatus[] = ["ALL", "PENDING", "SENT", "FAILED", "CANCELLED"];
-const DEFAULT_DEVICE_PORT = "/dev/ttyUSB0";
 
 export async function runInteractiveCli(args: {
   connectionString: string;
@@ -149,14 +148,13 @@ async function runInteractiveAction(action: () => Promise<void>) {
 }
 
 async function deviceConfigInteractive() {
-  const portPath = await input({
-    message: "Serial port",
-    default: DEFAULT_DEVICE_PORT,
+  const suggestedPortPath = await suggestDevicePort();
+  const requestedPortPath = await input({
+    message: suggestedPortPath ? "Serial port" : "Serial port (leave empty to auto-detect)",
+    default: suggestedPortPath ?? "",
   });
 
-  if (!portPath) {
-    return;
-  }
+  const portPath = await resolveDevicePort(requestedPortPath || undefined);
 
   while (true) {
     const action = await select<string>({

--- a/apps/server/src/dev-cli/interactive.ts
+++ b/apps/server/src/dev-cli/interactive.ts
@@ -95,7 +95,7 @@ export async function runInteractiveCli(args: {
         await browseStations(args.connectionString);
         break;
       case "bike": {
-        const value = await input({ message: "Bike id, bike number, or chip id" });
+        const value = await input({ message: "Bike id or bike number" });
         if (value) {
           await inspectBike(args.connectionString, value);
         }
@@ -411,13 +411,13 @@ async function browsePersonaRentals(
     return;
   }
 
-  const status = await select<"ALL" | "RENTED" | "COMPLETED" | "CANCELLED" | "__back">({
+  const status = await select<"ALL" | "RENTED" | "COMPLETED" | "OVERDUE_UNRETURNED" | "__back">({
     message: "Choose rental status",
     choices: [
       { name: "All", value: "ALL" },
       { name: "Rented", value: "RENTED" },
       { name: "Completed", value: "COMPLETED" },
-      { name: "Cancelled", value: "CANCELLED" },
+      { name: "Overdue unreturned", value: "OVERDUE_UNRETURNED" },
       { name: "Back", value: "__back" },
     ],
   });
@@ -469,7 +469,6 @@ async function inspectPersonaRental(connectionString: string, userId: string, re
     writeLine(chalk.cyan(`Rental ${rental.id}`));
     writeLine(`${chalk.gray("status")}: ${rental.status}`);
     writeLine(`${chalk.gray("bike")}: ${rental.bikeNumber} ${chalk.gray(`(${rental.bikeId})`)}`);
-    writeLine(`${chalk.gray("chip")}: ${rental.bikeChipId}`);
     writeLine(`${chalk.gray("bikeStatus")}: ${rental.bikeStatus}`);
     writeLine(`${chalk.gray("startStation")}: ${rental.startStationName} ${chalk.gray(`(${rental.startStationAddress})`)}`);
     writeLine(`${chalk.gray("endStation")}: ${rental.endStationName ?? "-"} ${rental.endStationAddress ? chalk.gray(`(${rental.endStationAddress})`) : ""}`.trimEnd());
@@ -485,11 +484,9 @@ async function inspectPersonaRental(connectionString: string, userId: string, re
     writeLine(`${chalk.gray("returnStation")}: ${rental.returnConfirmationStationName ?? rental.returnConfirmationStationId ?? "-"}`);
     writeLine(`${chalk.gray("billedTotal")}: ${rental.billedTotalAmount ?? "-"}`);
     writeLine(`${chalk.gray("billedBase")}: ${rental.billedBaseAmount ?? "-"}`);
-    writeLine(`${chalk.gray("billedOvertime")}: ${rental.billedOvertimeAmount ?? "-"}`);
     writeLine(`${chalk.gray("couponDiscount")}: ${rental.billedCouponDiscountAmount ?? "-"}`);
     writeLine(`${chalk.gray("subscriptionDiscount")}: ${rental.billedSubscriptionDiscountAmount ?? "-"}`);
     writeLine(`${chalk.gray("depositForfeited")}: ${rental.billedDepositForfeited ?? "-"}`);
-    writeLine(`${chalk.gray("penalties")}: ${rental.penaltiesCount} item(s), total ${rental.penaltiesTotalAmount ?? 0}`);
 
     writeLine(chalk.gray("Press r to refresh, b/Enter/q to go back."));
     const action = await readDetailAction({ allowInspectBike: false });
@@ -606,7 +603,7 @@ async function inspectStation(connectionString: string, value: string) {
           bike.activeRentalId ? chalk.green("active-rental") : null,
           bike.pendingReservationId ? chalk.yellow("pending-reservation") : null,
         ].filter(Boolean).join(", ");
-        writeLine(`  ${chalk.white(bike.bikeNumber.padEnd(8))} ${chalk.gray(bike.id)} ${bike.status.padEnd(11)} ${bike.chipId}${activity ? ` ${chalk.gray(`(${activity})`)}` : ""}`);
+        writeLine(`  ${chalk.white(bike.bikeNumber.padEnd(8))} ${chalk.gray(bike.id)} ${bike.status.padEnd(11)}${activity ? ` ${chalk.gray(`(${activity})`)}` : ""}`);
       }
     }
 
@@ -649,7 +646,6 @@ async function inspectBike(connectionString: string, value: string) {
     writeLine("");
     writeLine(chalk.cyan(`Bike ${bike.bikeNumber}`));
     writeLine(`${chalk.gray("id")}: ${bike.id}`);
-    writeLine(`${chalk.gray("chip")}: ${bike.chipId}`);
     writeLine(`${chalk.gray("status")}: ${bike.status}`);
     writeLine(`${chalk.gray("station")}: ${bike.stationName ?? "-"} ${bike.stationAddress ? `(${bike.stationAddress})` : ""}`);
     writeLine(`${chalk.gray("supplier")}: ${bike.supplierName ?? "-"}`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -698,6 +698,9 @@ importers:
       react-native:
         specifier: 0.81.5
         version: 0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)
+      serialport:
+        specifier: ^13.0.0
+        version: 13.0.0
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
@@ -4122,6 +4125,70 @@ packages:
   '@scarf/scarf@1.4.0':
     resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
 
+  '@serialport/binding-mock@10.2.2':
+    resolution: {integrity: sha512-HAFzGhk9OuFMpuor7aT5G1ChPgn5qSsklTFOTUX72Rl6p0xwcSVsRtG/xaGp6bxpN7fI9D/S8THLBWbBgS6ldw==}
+    engines: {node: '>=12.0.0'}
+
+  '@serialport/bindings-cpp@13.0.0':
+    resolution: {integrity: sha512-r25o4Bk/vaO1LyUfY/ulR6hCg/aWiN6Wo2ljVlb4Pj5bqWGcSRC4Vse4a9AcapuAu/FeBzHCbKMvRQeCuKjzIQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@serialport/bindings-interface@1.2.2':
+    resolution: {integrity: sha512-CJaUd5bLvtM9c5dmO9rPBHPXTa9R2UwpkJ0wdh9JCYcbrPWsKz+ErvR0hBLeo7NPeiFdjFO4sonRljiw4d2XiA==}
+    engines: {node: ^12.22 || ^14.13 || >=16}
+
+  '@serialport/parser-byte-length@13.0.0':
+    resolution: {integrity: sha512-32yvqeTAqJzAEtX5zCrN1Mej56GJ5h/cVFsCDPbF9S1ZSC9FWjOqNAgtByseHfFTSTs/4ZBQZZcZBpolt8sUng==}
+    engines: {node: '>=20.0.0'}
+
+  '@serialport/parser-cctalk@13.0.0':
+    resolution: {integrity: sha512-RErAe57g9gvnlieVYGIn1xymb1bzNXb2QtUQd14FpmbQQYlcrmuRnJwKa1BgTCujoCkhtaTtgHlbBWOxm8U2uA==}
+    engines: {node: '>=20.0.0'}
+
+  '@serialport/parser-delimiter@12.0.0':
+    resolution: {integrity: sha512-gu26tVt5lQoybhorLTPsH2j2LnX3AOP2x/34+DUSTNaUTzu2fBXw+isVjQJpUBFWu6aeQRZw5bJol5X9Gxjblw==}
+    engines: {node: '>=12.0.0'}
+
+  '@serialport/parser-delimiter@13.0.0':
+    resolution: {integrity: sha512-Qqyb0FX1avs3XabQqNaZSivyVbl/yl0jywImp7ePvfZKLwx7jBZjvL+Hawt9wIG6tfq6zbFM24vzCCK7REMUig==}
+    engines: {node: '>=20.0.0'}
+
+  '@serialport/parser-inter-byte-timeout@13.0.0':
+    resolution: {integrity: sha512-a0w0WecTW7bD2YHWrpTz1uyiWA2fDNym0kjmPeNSwZ2XCP+JbirZt31l43m2ey6qXItTYVuQBthm75sPVeHnGA==}
+    engines: {node: '>=20.0.0'}
+
+  '@serialport/parser-packet-length@13.0.0':
+    resolution: {integrity: sha512-60ZDDIqYRi0Xs2SPZUo4Jr5LLIjtb+rvzPKMJCohrO6tAqSDponcNpcB1O4W21mKTxYjqInSz+eMrtk0LLfZIg==}
+    engines: {node: '>=8.6.0'}
+
+  '@serialport/parser-readline@12.0.0':
+    resolution: {integrity: sha512-O7cywCWC8PiOMvo/gglEBfAkLjp/SENEML46BXDykfKP5mTPM46XMaX1L0waWU6DXJpBgjaL7+yX6VriVPbN4w==}
+    engines: {node: '>=12.0.0'}
+
+  '@serialport/parser-readline@13.0.0':
+    resolution: {integrity: sha512-dov3zYoyf0dt1Sudd1q42VVYQ4WlliF0MYvAMA3MOyiU1IeG4hl0J6buBA2w4gl3DOCC05tGgLDN/3yIL81gsA==}
+    engines: {node: '>=20.0.0'}
+
+  '@serialport/parser-ready@13.0.0':
+    resolution: {integrity: sha512-JNUQA+y2Rfs4bU+cGYNqOPnNMAcayhhW+XJZihSLQXOHcZsFnOa2F9YtMg9VXRWIcnHldHYtisp62Etjlw24bw==}
+    engines: {node: '>=20.0.0'}
+
+  '@serialport/parser-regex@13.0.0':
+    resolution: {integrity: sha512-m7HpIf56G5XcuDdA3DB34Z0pJiwxNRakThEHjSa4mG05OnWYv0IG8l2oUyYfuGMowQWaVnQ+8r+brlPxGVH+eA==}
+    engines: {node: '>=20.0.0'}
+
+  '@serialport/parser-slip-encoder@13.0.0':
+    resolution: {integrity: sha512-fUHZEExm6izJ7rg0A1yjXwu4sOzeBkPAjDZPfb+XQoqgtKAk+s+HfICiYn7N2QU9gyaeCO8VKgWwi+b/DowYOg==}
+    engines: {node: '>=20.0.0'}
+
+  '@serialport/parser-spacepacket@13.0.0':
+    resolution: {integrity: sha512-DoXJ3mFYmyD8X/8931agJvrBPxqTaYDsPoly9/cwQSeh/q4EjQND9ySXBxpWz5WcpyCU4jOuusqCSAPsbB30Eg==}
+    engines: {node: '>=20.0.0'}
+
+  '@serialport/stream@13.0.0':
+    resolution: {integrity: sha512-F7xLJKsjGo2WuEWMSEO1SimRcOA+WtWICsY13r0ahx8s2SecPQH06338g28OT7cW7uRXI7oEQAk62qh5gHJW3g==}
+    engines: {node: '>=20.0.0'}
+
   '@shikijs/engine-oniguruma@3.21.0':
     resolution: {integrity: sha512-OYknTCct6qiwpQDqDdf3iedRdzj6hFlOPv5hMvI+hkWfCKs5mlJ4TXziBG9nyabLwGulrUjHiCq3xCspSzErYQ==}
 
@@ -6789,6 +6856,15 @@ packages:
       supports-color:
         optional: true
 
+  debug@4.4.0:
+    resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -7743,7 +7819,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: '>=4.0.4'
+      picomatch: '>=3.0.2'
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -9662,6 +9738,10 @@ packages:
   node-abort-controller@3.1.1:
     resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
 
+  node-addon-api@8.3.0:
+    resolution: {integrity: sha512-8VOpLHFrOQlAH+qA0ZzuGRlALRA6/LVh8QJldbrC4DY0hXoMP0l4Acq8TzFC018HztWiRqyCEj2aTWY2UvnJUg==}
+    engines: {node: ^18 || ^20 || >= 21}
+
   node-addon-api@8.5.0:
     resolution: {integrity: sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==}
     engines: {node: ^18 || ^20 || >= 21}
@@ -10855,6 +10935,10 @@ packages:
   serialize-error@2.1.0:
     resolution: {integrity: sha512-ghgmKt5o4Tly5yEG/UJp8qTd0AN7Xalw4XBtDEKP655B699qMEtra1WlXeE6WIvdEG481JvRxULKsInq/iNysw==}
     engines: {node: '>=0.10.0'}
+
+  serialport@13.0.0:
+    resolution: {integrity: sha512-PHpnTd8isMGPfFTZNCzOZp9m4mAJSNWle9Jxu6BPTcWq7YXl5qN7tp8Sgn0h+WIGcD6JFz5QDgixC2s4VW7vzg==}
+    engines: {node: '>=20.0.0'}
 
   serve-static@1.16.3:
     resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
@@ -16510,6 +16594,60 @@ snapshots:
 
   '@scarf/scarf@1.4.0': {}
 
+  '@serialport/binding-mock@10.2.2':
+    dependencies:
+      '@serialport/bindings-interface': 1.2.2
+      debug: 4.4.3(supports-color@5.5.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@serialport/bindings-cpp@13.0.0':
+    dependencies:
+      '@serialport/bindings-interface': 1.2.2
+      '@serialport/parser-readline': 12.0.0
+      debug: 4.4.0
+      node-addon-api: 8.3.0
+      node-gyp-build: 4.8.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@serialport/bindings-interface@1.2.2': {}
+
+  '@serialport/parser-byte-length@13.0.0': {}
+
+  '@serialport/parser-cctalk@13.0.0': {}
+
+  '@serialport/parser-delimiter@12.0.0': {}
+
+  '@serialport/parser-delimiter@13.0.0': {}
+
+  '@serialport/parser-inter-byte-timeout@13.0.0': {}
+
+  '@serialport/parser-packet-length@13.0.0': {}
+
+  '@serialport/parser-readline@12.0.0':
+    dependencies:
+      '@serialport/parser-delimiter': 12.0.0
+
+  '@serialport/parser-readline@13.0.0':
+    dependencies:
+      '@serialport/parser-delimiter': 13.0.0
+
+  '@serialport/parser-ready@13.0.0': {}
+
+  '@serialport/parser-regex@13.0.0': {}
+
+  '@serialport/parser-slip-encoder@13.0.0': {}
+
+  '@serialport/parser-spacepacket@13.0.0': {}
+
+  '@serialport/stream@13.0.0':
+    dependencies:
+      '@serialport/bindings-interface': 1.2.2
+      debug: 4.4.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@shikijs/engine-oniguruma@3.21.0':
     dependencies:
       '@shikijs/types': 3.21.0
@@ -20887,6 +21025,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  debug@4.4.0:
+    dependencies:
+      ms: 2.1.3
+
   debug@4.4.3(supports-color@5.5.0):
     dependencies:
       ms: 2.1.3
@@ -24755,6 +24897,8 @@ snapshots:
 
   node-abort-controller@3.1.1: {}
 
+  node-addon-api@8.3.0: {}
+
   node-addon-api@8.5.0: {}
 
   node-domexception@1.0.0: {}
@@ -26165,6 +26309,25 @@ snapshots:
       type-fest: 4.41.0
 
   serialize-error@2.1.0: {}
+
+  serialport@13.0.0:
+    dependencies:
+      '@serialport/binding-mock': 10.2.2
+      '@serialport/bindings-cpp': 13.0.0
+      '@serialport/parser-byte-length': 13.0.0
+      '@serialport/parser-cctalk': 13.0.0
+      '@serialport/parser-delimiter': 13.0.0
+      '@serialport/parser-inter-byte-timeout': 13.0.0
+      '@serialport/parser-packet-length': 13.0.0
+      '@serialport/parser-readline': 13.0.0
+      '@serialport/parser-ready': 13.0.0
+      '@serialport/parser-regex': 13.0.0
+      '@serialport/parser-slip-encoder': 13.0.0
+      '@serialport/parser-spacepacket': 13.0.0
+      '@serialport/stream': 13.0.0
+      debug: 4.4.0
+    transitivePeerDependencies:
+      - supports-color
 
   serve-static@1.16.3:
     dependencies:


### PR DESCRIPTION
## Summary
- replace the Linux-only device provisioning path with `serialport` so the dev CLI can talk to ESP devices from both Windows and Linux
- auto-detect likely ESP32 serial ports when `--port` is omitted, while keeping manual port override for ambiguous setups
- update interactive and help flows to stop assuming `/dev/ttyUSB0`

## Verification
- `pnpm tsc --noEmit`
- `pnpm dev:cli help`