### PR TITLE
fix(mobile): correct subscription price display

### DIFF
--- a/apps/mobile/components/subscription/subscription-detail-modal.tsx
+++ b/apps/mobile/components/subscription/subscription-detail-modal.tsx
@@ -2,7 +2,13 @@ import React from "react";
 import { ActivityIndicator, Modal, Pressable, StyleSheet, Text, View } from "react-native";
 
 import { useGetSubscriptionDetailQuery } from "@hooks/query/subscription/use-get-subscription-detail-query";
-import { formatCurrency, formatDate, getStatusStyle, toSubscriptionStatusLabel } from "@utils/subscription";
+import {
+  formatCurrency,
+  formatDate,
+  getStatusStyle,
+  getSubscriptionDisplayPrice,
+  toSubscriptionStatusLabel,
+} from "@utils/subscription";
 
 type Props = {
   visible: boolean;
@@ -114,7 +120,7 @@ export function SubscriptionDetailModal({ visible, subscriptionId, onClose }: Pr
                   </View>
                 )}
               </View>
-              <Text style={styles.price}>{formatCurrency(data.price)}</Text>
+              <Text style={styles.price}>{formatCurrency(getSubscriptionDisplayPrice(data))}</Text>
               <View style={styles.section}>
                 <Text style={styles.sectionTitle}>Thông tin gói</Text>
                 <InfoRow label="Cập nhật" value={formatDate(data.updatedAt)} />

--- a/apps/mobile/components/subscription/subscription-history-item.tsx
+++ b/apps/mobile/components/subscription/subscription-history-item.tsx
@@ -3,7 +3,13 @@ import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 
 import type { Subscription } from "@/types/subscription-types";
 
-import { formatCurrency, formatDate, getStatusStyle, toSubscriptionStatusLabel } from "@utils/subscription";
+import {
+  formatCurrency,
+  formatDate,
+  getStatusStyle,
+  getSubscriptionDisplayPrice,
+  toSubscriptionStatusLabel,
+} from "@utils/subscription";
 
 type Props = {
   subscription: Subscription;
@@ -16,11 +22,17 @@ export function SubscriptionHistoryItem({ subscription, onPress }: Props) {
     <TouchableOpacity style={styles.container} onPress={() => onPress?.(subscription)} activeOpacity={0.9}>
       <View style={{ flex: 1 }}>
         <Text style={styles.title}>{subscription.packageName.toUpperCase()}</Text>
-        <Text style={styles.subtitle}>Cập nhật: {formatDate(subscription.updatedAt)}</Text>
-        <Text style={styles.subtitle}>Hết hạn: {formatDate(subscription.expiresAt)}</Text>
+        <Text style={styles.subtitle}>
+          Cập nhật:
+          {formatDate(subscription.updatedAt)}
+        </Text>
+        <Text style={styles.subtitle}>
+          Hết hạn:
+          {formatDate(subscription.expiresAt)}
+        </Text>
       </View>
       <View style={styles.meta}>
-        <Text style={styles.amount}>{formatCurrency(subscription.price)}</Text>
+        <Text style={styles.amount}>{formatCurrency(getSubscriptionDisplayPrice(subscription))}</Text>
         <View style={[styles.statusBadge, { backgroundColor: status.background }]}>
           <Text style={[styles.statusText, { color: status.text }]}>{toSubscriptionStatusLabel(subscription.status)}</Text>
         </View>

--- a/apps/mobile/components/subscription/subscription-summary.tsx
+++ b/apps/mobile/components/subscription/subscription-summary.tsx
@@ -4,7 +4,13 @@ import { ActivityIndicator, StyleSheet, Text, TouchableOpacity, View } from "rea
 
 import type { Subscription } from "@/types/subscription-types";
 
-import { formatCurrency, formatDate, getStatusStyle, toSubscriptionStatusLabel } from "@utils/subscription";
+import {
+  formatCurrency,
+  formatDate,
+  getStatusStyle,
+  getSubscriptionDisplayPrice,
+  toSubscriptionStatusLabel,
+} from "@utils/subscription";
 
 type Props = {
   activeSubscription?: Subscription | null;
@@ -32,8 +38,8 @@ export function SubscriptionSummary({
     if (hasActive && activeSubscription) {
       const limit = activeSubscription.maxUsages;
       const used = activeSubscription.usageCount;
-      const remaining =
-        typeof limit === "number" ? Math.max(0, limit - used) : null;
+      const remaining
+        = typeof limit === "number" ? Math.max(0, limit - used) : null;
       const quota = typeof limit === "number"
         ? `Còn ${remaining}/${limit} lượt`
         : `${used} lượt đã dùng`;
@@ -51,9 +57,9 @@ export function SubscriptionSummary({
       ? pendingSubscription?.status
       : undefined;
   const amount = hasActive
-    ? activeSubscription!.price
+    ? getSubscriptionDisplayPrice(activeSubscription!)
     : hasPending
-      ? pendingSubscription!.price
+      ? getSubscriptionDisplayPrice(pendingSubscription!)
       : "0";
 
   const statusStyle = status ? getStatusStyle(status) : undefined;
@@ -85,11 +91,13 @@ export function SubscriptionSummary({
           </View>
           {hasPending && onActivatePending && (
             <TouchableOpacity style={styles.activateButton} onPress={onActivatePending} disabled={activating}>
-              {activating ? (
-                <ActivityIndicator color="#fff" size="small" />
-              ) : (
-                <Text style={styles.activateText}>Kích hoạt ngay</Text>
-              )}
+              {activating
+                ? (
+                    <ActivityIndicator color="#fff" size="small" />
+                  )
+                : (
+                    <Text style={styles.activateText}>Kích hoạt ngay</Text>
+                  )}
             </TouchableOpacity>
           )}
         </View>

--- a/apps/mobile/utils/subscription.ts
+++ b/apps/mobile/utils/subscription.ts
@@ -1,5 +1,7 @@
 import type { Subscription, SubscriptionStatus } from "@/types/subscription-types";
 
+import { SUBSCRIPTION_PACKAGES } from "@constants/subscriptionPackages";
+
 const STATUS_COLORS: Record<SubscriptionStatus, { text: string; background: string }> = {
   PENDING: { text: "#B45309", background: "#FEF3C7" },
   ACTIVE: { text: "#15803D", background: "#DCFCE7" },
@@ -26,6 +28,10 @@ export function formatCurrency(amount: string | number): string {
   return `${safe.toLocaleString("vi-VN")} đ`;
 }
 
+export function getSubscriptionDisplayPrice(subscription: Pick<Subscription, "packageName" | "price">): number {
+  return SUBSCRIPTION_PACKAGES[subscription.packageName]?.price ?? Number(subscription.price) ?? 0;
+}
+
 export function formatDate(date?: string | null): string {
   if (!date)
     return "-";
@@ -43,9 +49,11 @@ export function getStatusStyle(status: SubscriptionStatus) {
 }
 
 export function extractLatestSubscription(subscriptions: Subscription[]): Subscription | null {
-  if (!subscriptions.length) return null;
+  if (!subscriptions.length)
+    return null;
   return subscriptions.reduce((latest, current) => {
-    if (!latest) return current;
+    if (!latest)
+      return current;
     const latestTime = new Date(latest.updatedAt).getTime();
     const currentTime = new Date(current.updatedAt).getTime();
     return currentTime > latestTime ? current : latest;


### PR DESCRIPTION
## Summary
- fix subscription summary, history, and detail views to show the package display price instead of the raw backend amount
- keep mobile subscription pricing consistent across purchased subscriptions and plan cards

## Verification
- `pnpm exec tsc --noEmit`