### PR TITLE
fix(server): guard dev CLI user-card UUID lookup

### DIFF
--- a/apps/server/src/dev-cli/personas.ts
+++ b/apps/server/src/dev-cli/personas.ts
@@ -42,6 +42,10 @@ const roleRank: Record<string, number> = {
   TECHNICIAN: 4,
 };
 
+function looksLikeUuid(value: string) {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
+}
+
 function toPersonaRecord(row: {
   id: string;
   fullName: string;
@@ -96,7 +100,7 @@ export async function resolveUserCardTarget(connectionString: string, value: str
     client.user.findMany({
       where: {
         OR: [
-          { id: value },
+          ...(looksLikeUuid(value) ? [{ id: value }] : []),
           { email: value },
           { email: handleEmail },
         ],


### PR DESCRIPTION
## Summary
- fix dev CLI user-card lookup so email and handle input no longer get sent to the UUID `id` filter
- keep UUID lookup support for direct user-id input while preventing invalid Postgres uuid casts

## Verification
- `pnpm tsc --noEmit`