### PR TITLE
chore(deploy): centralize Traefik stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ AGENTS.md
 .turbo
 .alchemy
 .env
+.env.*
+!.env.example
+!**/.env.example
 .docs
 .txt
 /docs
@@ -23,3 +26,7 @@ apps/iot-service/folder.md
 **/*.aab
 **/*.aar
 **/*.keystore
+
+# Traefik runtime state
+infra/traefik/letsencrypt/
+infra/traefik/logs/

--- a/compose.vps.env.example
+++ b/compose.vps.env.example
@@ -1,4 +1,5 @@
 # Copy to compose.vps.env before running Docker Compose.
+# Start the shared Traefik stack in `infra/traefik` first.
 # Example commands:
 # docker compose --env-file compose.vps.env -f compose.vps.yaml run --rm server-migrate
 # docker compose --env-file compose.vps.env -f compose.vps.yaml up -d --build

--- a/compose.vps.yaml
+++ b/compose.vps.yaml
@@ -67,6 +67,7 @@ services:
       - "traefik.http.routers.mebike-frontend.tls.certresolver=${TRAEFIK_CERT_RESOLVER}"
       - "traefik.http.routers.mebike-frontend.tls.domains[0].main=${APEX_DOMAIN}"
       - "traefik.http.routers.mebike-frontend.tls.domains[0].sans=*.${APEX_DOMAIN}"
+      - "traefik.http.routers.mebike-frontend.service=mebike-frontend"
       - "traefik.http.services.mebike-frontend.loadbalancer.server.port=3000"
 
   server:
@@ -97,6 +98,7 @@ services:
       - "traefik.http.routers.mebike-server.entrypoints=websecure"
       - "traefik.http.routers.mebike-server.tls=true"
       - "traefik.http.routers.mebike-server.tls.certresolver=${TRAEFIK_CERT_RESOLVER}"
+      - "traefik.http.routers.mebike-server.service=mebike-server"
       - "traefik.http.services.mebike-server.loadbalancer.server.port=4000"
 
   server-migrate:

--- a/infra/traefik/.env.example
+++ b/infra/traefik/.env.example
@@ -1,0 +1,8 @@
+TRAEFIK_NETWORK=traefik-public
+TRAEFIK_CERT_RESOLVER=default
+
+TRAEFIK_DASHBOARD_HOST=traefik.mebike.site
+TRAEFIK_DASHBOARD_USERS=
+
+# Cloudflare API token with zone:read, dns_records:read, dns_records:edit.
+CLOUDFLARE_DNS_API_TOKEN=

--- a/infra/traefik/README.md
+++ b/infra/traefik/README.md
@@ -1,0 +1,45 @@
+# Traefik
+
+This stack centralizes VPS ingress for MeBike and any other Docker app that joins the shared `traefik-public` network.
+
+## Files
+
+- `compose.yaml`: Traefik container and shared Docker network.
+- `traefik.yaml`: static Traefik configuration.
+- `.env.example`: variables required by the stack.
+
+## Setup
+
+1. Copy `.env.example` to `.env`.
+2. Set `CLOUDFLARE_DNS_API_TOKEN` to a token that can manage DNS for the required zones.
+3. Set `TRAEFIK_DASHBOARD_USERS` to an htpasswd entry, for example:
+
+```bash
+htpasswd -nbB your-user your-password
+```
+
+4. Create writable directories on the VPS:
+
+```bash
+mkdir -p infra/traefik/letsencrypt infra/traefik/logs
+touch infra/traefik/letsencrypt/acme.json
+chmod 600 infra/traefik/letsencrypt/acme.json
+```
+
+5. Start Traefik:
+
+```bash
+docker compose -f infra/traefik/compose.yaml up -d
+```
+
+## Migration From Skindora-Owned Traefik
+
+1. Copy `/home/amogus/skindora/letsencrypt/acme.json` into `infra/traefik/letsencrypt/acme.json` if you want to preserve existing certificates.
+2. Copy the valid Cloudflare token into `infra/traefik/.env`.
+3. Stop the old Traefik before starting the new one, because both bind to ports `80` and `443`.
+4. Leave app containers attached to `traefik-public`; they do not need their own Traefik instances.
+5. Start the new Traefik stack and verify the dashboard and routed domains.
+
+## MeBike Deploy
+
+The MeBike app stack in `compose.vps.yaml` already expects a shared external network named `traefik-public` and a certificate resolver named `default`.

--- a/infra/traefik/compose.yaml
+++ b/infra/traefik/compose.yaml
@@ -1,0 +1,38 @@
+services:
+  traefik:
+    image: traefik:v3.6.7
+    container_name: traefik
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    env_file:
+      - ${TRAEFIK_ENV_FILE:-./.env}
+    environment:
+      CLOUDFLARE_DNS_API_TOKEN: ${CLOUDFLARE_DNS_API_TOKEN}
+      TRAEFIK_DASHBOARD_USERS: ${TRAEFIK_DASHBOARD_USERS}
+    ports:
+      - "80:80"
+      - "443:443/tcp"
+      - "443:443/udp"
+    networks:
+      - traefik-public
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./letsencrypt:/etc/traefik
+      - ./traefik.yaml:/etc/traefik/traefik.yaml:ro
+      - ./logs:/var/log/traefik
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=${TRAEFIK_NETWORK}"
+      - "traefik.http.routers.traefik-dashboard.rule=Host(`${TRAEFIK_DASHBOARD_HOST}`)"
+      - "traefik.http.routers.traefik-dashboard.entrypoints=websecure"
+      - "traefik.http.routers.traefik-dashboard.service=api@internal"
+      - "traefik.http.routers.traefik-dashboard.tls=true"
+      - "traefik.http.routers.traefik-dashboard.tls.certresolver=${TRAEFIK_CERT_RESOLVER}"
+      - "traefik.http.routers.traefik-dashboard.middlewares=dashboard-auth"
+      - "traefik.http.middlewares.dashboard-auth.basicauth.users=${TRAEFIK_DASHBOARD_USERS}"
+
+networks:
+  traefik-public:
+    name: ${TRAEFIK_NETWORK}
+    driver: bridge

--- a/infra/traefik/traefik.yaml
+++ b/infra/traefik/traefik.yaml
@@ -1,0 +1,67 @@
+global:
+  checkNewVersion: true
+  sendAnonymousUsage: true
+
+accessLog:
+  format: common
+  filePath: /var/log/traefik/access.log
+
+log:
+  level: INFO
+  format: common
+  filePath: /var/log/traefik/traefik.log
+
+api:
+  dashboard: true
+
+entryPoints:
+  web:
+    address: ":80"
+    http:
+      redirections:
+        entryPoint:
+          to: websecure
+          scheme: https
+          permanent: true
+  websecure:
+    address: ":443"
+    forwardedHeaders:
+      trustedIPs:
+        - "173.245.48.0/20"
+        - "103.21.244.0/22"
+        - "103.22.200.0/22"
+        - "103.31.4.0/22"
+        - "141.101.64.0/18"
+        - "108.162.192.0/18"
+        - "190.93.240.0/20"
+        - "188.114.96.0/20"
+        - "197.234.240.0/22"
+        - "198.41.128.0/17"
+        - "162.158.0.0/15"
+        - "104.16.0.0/13"
+        - "104.24.0.0/14"
+        - "172.64.0.0/13"
+        - "131.0.72.0/22"
+    http:
+      tls: {}
+    http2:
+      maxConcurrentStreams: 400
+    http3:
+      advertisedPort: 443
+
+providers:
+  docker:
+    endpoint: unix:///var/run/docker.sock
+    exposedByDefault: false
+    network: traefik-public
+
+certificatesResolvers:
+  default:
+    acme:
+      email: annguyen2327@gmail.com
+      storage: /etc/traefik/acme.json
+      dnsChallenge:
+        provider: cloudflare
+        resolvers:
+          - 1.1.1.1:53
+          - 8.8.8.8:53


### PR DESCRIPTION
## Summary
- add a repo-owned Traefik stack under `infra/traefik` so ingress and Cloudflare DNS challenge config are no longer tied to the `skindora` app directory
- keep MeBike's VPS compose aligned with the shared `traefik-public` network and explicit Traefik service labels
- document the VPS migration flow and ignore local Traefik runtime state and env files