### PR TITLE
fix(mobile): isolate current-user caches by session

### DIFF
--- a/apps/mobile/hooks/query/environment/environment-query-keys.ts
+++ b/apps/mobile/hooks/query/environment/environment-query-keys.ts
@@ -1,19 +1,21 @@
 export const environmentKeys = {
   all: () => ["environment"] as const,
-  summary: () => ["environment", "summary"] as const,
-  historyRoot: () => ["environment", "history"] as const,
+  summary: (scope: string | null | undefined) => ["environment", scope ?? "guest", "summary"] as const,
+  historyRoot: (scope: string | null | undefined) => ["environment", scope ?? "guest", "history"] as const,
   history: (args: {
+    scope?: string | null;
     pageSize: number;
     sortOrder?: "asc" | "desc";
     dateFrom?: string;
     dateTo?: string;
   }) => [
     "environment",
+    args.scope ?? "guest",
     "history",
     args.pageSize,
     args.sortOrder ?? null,
     args.dateFrom ?? null,
     args.dateTo ?? null,
   ] as const,
-  detail: (rentalId: string) => ["environment", "detail", rentalId] as const,
+  detail: (scope: string | null | undefined, rentalId: string) => ["environment", scope ?? "guest", "detail", rentalId] as const,
 };

--- a/apps/mobile/hooks/query/environment/use-environment-impact-detail-query.ts
+++ b/apps/mobile/hooks/query/environment/use-environment-impact-detail-query.ts
@@ -10,9 +10,10 @@ import { environmentKeys } from "./environment-query-keys";
 export function useEnvironmentImpactDetailQuery(
   rentalId: string,
   enabled: boolean = true,
+  scope?: string | null,
 ) {
   return useQuery<EnvironmentImpactDetail, EnvironmentError>({
-    queryKey: environmentKeys.detail(rentalId),
+    queryKey: environmentKeys.detail(scope, rentalId),
     enabled: enabled && Boolean(rentalId),
     queryFn: async () => {
       const result = await environmentService.getDetail(rentalId);

--- a/apps/mobile/hooks/query/environment/use-environment-impact-history-query.ts
+++ b/apps/mobile/hooks/query/environment/use-environment-impact-history-query.ts
@@ -15,6 +15,7 @@ const DEFAULT_PAGE_SIZE = 20;
 export function useEnvironmentImpactHistoryQuery(
   params: EnvironmentImpactHistoryQuery = {},
   enabled: boolean = true,
+  scope?: string | null,
 ) {
   const {
     pageSize = DEFAULT_PAGE_SIZE,
@@ -25,6 +26,7 @@ export function useEnvironmentImpactHistoryQuery(
 
   return useInfiniteQuery<EnvironmentImpactHistoryResponse, EnvironmentError>({
     queryKey: environmentKeys.history({
+      scope,
       pageSize,
       sortOrder,
       dateFrom,

--- a/apps/mobile/hooks/query/environment/use-environment-summary-query.ts
+++ b/apps/mobile/hooks/query/environment/use-environment-summary-query.ts
@@ -7,9 +7,9 @@ import type { EnvironmentSummary } from "@/contracts/server";
 
 import { environmentKeys } from "./environment-query-keys";
 
-export function useEnvironmentSummaryQuery(enabled: boolean = true) {
+export function useEnvironmentSummaryQuery(enabled: boolean = true, scope?: string | null) {
   return useQuery<EnvironmentSummary, EnvironmentError>({
-    queryKey: environmentKeys.summary(),
+    queryKey: environmentKeys.summary(scope),
     enabled,
     queryFn: async () => {
       const result = await environmentService.getSummary();

--- a/apps/mobile/hooks/query/fixed-slots/fixed-slot-query-keys.ts
+++ b/apps/mobile/hooks/query/fixed-slots/fixed-slot-query-keys.ts
@@ -1,0 +1,13 @@
+import type { FixedSlotTemplateListParams } from "@/contracts/server";
+
+export const fixedSlotQueryKeys = {
+  all: () => ["fixed-slots"] as const,
+  list: (scope: string | null | undefined, params: FixedSlotTemplateListParams = {}) => [
+    "fixed-slots",
+    scope ?? "guest",
+    params.pageSize ?? 10,
+    params.status ?? null,
+    params.stationId ?? null,
+  ] as const,
+  detail: (scope: string | null | undefined, id?: string) => ["fixed-slots", scope ?? "guest", "detail", id] as const,
+};

--- a/apps/mobile/hooks/query/fixed-slots/use-fixed-slot-template-detail-query.ts
+++ b/apps/mobile/hooks/query/fixed-slots/use-fixed-slot-template-detail-query.ts
@@ -5,12 +5,15 @@ import { useQuery } from "@tanstack/react-query";
 
 import type { FixedSlotTemplate } from "@/contracts/server";
 
+import { fixedSlotQueryKeys } from "./fixed-slot-query-keys";
+
 export function useFixedSlotTemplateDetailQuery(
   id?: string,
   enabled: boolean = false,
+  scope?: string | null,
 ) {
   return useQuery<FixedSlotTemplate, FixedSlotError>({
-    queryKey: ["fixed-slots", "detail", id],
+    queryKey: fixedSlotQueryKeys.detail(scope, id),
     enabled: Boolean(id) && enabled,
     queryFn: async () => {
       const result = await fixedSlotService.getDetail(id!);

--- a/apps/mobile/hooks/query/fixed-slots/use-fixed-slot-templates-query.ts
+++ b/apps/mobile/hooks/query/fixed-slots/use-fixed-slot-templates-query.ts
@@ -5,16 +5,19 @@ import { useInfiniteQuery } from "@tanstack/react-query";
 
 import type { FixedSlotTemplateListParams, FixedSlotTemplateListResponse } from "@/contracts/server";
 
+import { fixedSlotQueryKeys } from "./fixed-slot-query-keys";
+
 const DEFAULT_PAGE_SIZE = 10;
 
 export function useFixedSlotTemplatesQuery(
   params: FixedSlotTemplateListParams = {},
   enabled: boolean = true,
+  scope?: string | null,
 ) {
   const { pageSize = DEFAULT_PAGE_SIZE, status, stationId } = params;
 
   return useInfiniteQuery<FixedSlotTemplateListResponse, FixedSlotError>({
-    queryKey: ["fixed-slots", pageSize, status ?? null, stationId ?? null],
+    queryKey: fixedSlotQueryKeys.list(scope, { pageSize, status, stationId }),
     enabled,
     initialPageParam: 1,
     queryFn: async ({ pageParam }) => {

--- a/apps/mobile/hooks/query/rentals/rental-query-keys.ts
+++ b/apps/mobile/hooks/query/rentals/rental-query-keys.ts
@@ -6,14 +6,15 @@ import type {
 export const rentalKeys = {
   all: () => ["rentals"] as const,
 
-  me: () => ["rentals", "me"] as const,
-  meHistory: () => ["rentals", "me", "history"] as const,
-  meHistoryPage: (pageSize: number) => ["rentals", "me", "history", pageSize] as const,
-  meCounts: (status?: RentalStatus | null) =>
-    ["rentals", "me", "counts", status ?? null] as const,
-  meDetail: (rentalId: string) => ["rentals", "me", "detail", rentalId] as const,
-  meResolvedDetail: (rentalId: string) =>
-    ["rentals", "me", "resolved-detail", rentalId] as const,
+  meRoot: () => ["rentals", "me"] as const,
+  me: (scope: string | null | undefined) => ["rentals", "me", scope ?? "guest"] as const,
+  meHistory: (scope: string | null | undefined) => ["rentals", "me", scope ?? "guest", "history"] as const,
+  meHistoryPage: (scope: string | null | undefined, pageSize: number) => ["rentals", "me", scope ?? "guest", "history", pageSize] as const,
+  meCounts: (scope: string | null | undefined, status?: RentalStatus | null) =>
+    ["rentals", "me", scope ?? "guest", "counts", status ?? null] as const,
+  meDetail: (scope: string | null | undefined, rentalId: string) => ["rentals", "me", scope ?? "guest", "detail", rentalId] as const,
+  meResolvedDetail: (scope: string | null | undefined, rentalId: string) =>
+    ["rentals", "me", scope ?? "guest", "resolved-detail", rentalId] as const,
 
   staff: () => ["rentals", "staff"] as const,
   staffDetail: (rentalId: string) => ["rentals", "staff", "detail", rentalId] as const,
@@ -21,12 +22,13 @@ export const rentalKeys = {
     ["rentals", "staff", "active-by-phone", phone, page, pageSize] as const,
 
   bikeSwap: {
-    mePreview: (rentalId: string) =>
-      ["rentals", "me", "bike-swap", "preview", rentalId] as const,
-    meList: (params: BikeSwapRequestListParams = {}) =>
+    mePreview: (scope: string | null | undefined, rentalId: string) =>
+      ["rentals", "me", scope ?? "guest", "bike-swap", "preview", rentalId] as const,
+    meList: (scope: string | null | undefined, params: BikeSwapRequestListParams = {}) =>
       [
         "rentals",
         "me",
+        scope ?? "guest",
         "bike-swap",
         "list",
         params.rentalId ?? null,
@@ -36,8 +38,8 @@ export const rentalKeys = {
         params.page ?? null,
         params.pageSize ?? null,
       ] as const,
-    meDetail: (bikeSwapRequestId: string | null) =>
-      ["rentals", "me", "bike-swap", "detail", bikeSwapRequestId] as const,
+    meDetail: (scope: string | null | undefined, bikeSwapRequestId: string | null) =>
+      ["rentals", "me", scope ?? "guest", "bike-swap", "detail", bikeSwapRequestId] as const,
     staff: () => ["rentals", "staff", "bike-swap"] as const,
     staffList: (params: BikeSwapRequestListParams = {}) =>
       [

--- a/apps/mobile/hooks/query/rentals/use-my-rental-counts-query.ts
+++ b/apps/mobile/hooks/query/rentals/use-my-rental-counts-query.ts
@@ -7,13 +7,14 @@ import { useQuery } from "@tanstack/react-query";
 import type { RentalCounts, RentalStatus } from "@/types/rental-types";
 
 export function useMyRentalCountsQuery(
-  options?: { status?: RentalStatus; enabled?: boolean },
+  options?: { status?: RentalStatus; enabled?: boolean; scope?: string | null },
 ) {
   const status = options?.status;
   const enabled = options?.enabled ?? true;
+  const scope = options?.scope;
 
   return useQuery<RentalCounts, RentalError>({
-    queryKey: rentalKeys.meCounts(status),
+    queryKey: rentalKeys.meCounts(scope, status),
     enabled,
     queryFn: async () => {
       const result = await rentalServiceV1.getMyRentalCounts(status);

--- a/apps/mobile/hooks/query/rentals/use-my-rental-query.ts
+++ b/apps/mobile/hooks/query/rentals/use-my-rental-query.ts
@@ -6,9 +6,9 @@ import { useQuery } from "@tanstack/react-query";
 
 import type { Rental } from "@/types/rental-types";
 
-export function useMyRentalQuery(rentalId: string, enabled: boolean = true) {
+export function useMyRentalQuery(rentalId: string, enabled: boolean = true, scope?: string | null) {
   return useQuery<Rental, RentalError>({
-    queryKey: rentalKeys.meDetail(rentalId),
+    queryKey: rentalKeys.meDetail(scope, rentalId),
     enabled: enabled && Boolean(rentalId),
     queryFn: async () => {
       const result = await rentalServiceV1.getMyRental(rentalId);

--- a/apps/mobile/hooks/query/rentals/use-my-rental-resolved-detail-query.ts
+++ b/apps/mobile/hooks/query/rentals/use-my-rental-resolved-detail-query.ts
@@ -6,9 +6,9 @@ import { useQuery } from "@tanstack/react-query";
 
 import type { MyRentalResolvedDetail } from "@/types/rental-types";
 
-export function useMyRentalResolvedDetailQuery(rentalId: string, enabled: boolean = true) {
+export function useMyRentalResolvedDetailQuery(rentalId: string, enabled: boolean = true, scope?: string | null) {
   return useQuery<MyRentalResolvedDetail, RentalError>({
-    queryKey: rentalKeys.meResolvedDetail(rentalId),
+    queryKey: rentalKeys.meResolvedDetail(scope, rentalId),
     enabled: enabled && Boolean(rentalId),
     queryFn: async () => {
       const result = await rentalServiceV1.getMyRentalResolvedDetail(rentalId);

--- a/apps/mobile/hooks/query/reservation/reservation-query-keys.ts
+++ b/apps/mobile/hooks/query/reservation/reservation-query-keys.ts
@@ -1,0 +1,10 @@
+export const reservationQueryKeys = {
+  root: () => ["reservations"] as const,
+  pending: (scope: string | null | undefined, page: number, pageSize: number) =>
+    ["reservations", scope ?? "guest", "pending", page, pageSize] as const,
+  history: (scope: string | null | undefined, page: number, pageSize: number, version: number) =>
+    ["reservations", scope ?? "guest", "history", page, pageSize, version] as const,
+  detail: (scope: string | null | undefined, reservationId: string) =>
+    ["reservations", scope ?? "guest", "detail", reservationId] as const,
+  stationLookup: (stationId?: string | null) => ["reservations", "station-lookup", stationId ?? null] as const,
+};

--- a/apps/mobile/hooks/query/reservation/use-get-pending-reservations-query.ts
+++ b/apps/mobile/hooks/query/reservation/use-get-pending-reservations-query.ts
@@ -4,13 +4,16 @@ import type { ReservationError } from "@services/reservations";
 import { reservationService } from "@services/reservations";
 import { useQuery } from "@tanstack/react-query";
 
+import { reservationQueryKeys } from "./reservation-query-keys";
+
 export function useGetPendingReservationsQuery(
   page: number = 1,
   pageSize: number = 10,
   enabled: boolean = true,
+  scope?: string | null,
 ) {
   return useQuery<PaginatedReservations, ReservationError>({
-    queryKey: ["reservations", "pending", page, pageSize],
+    queryKey: reservationQueryKeys.pending(scope, page, pageSize),
     enabled,
     queryFn: async () => {
       const result = await reservationService.getCurrentReservations({

--- a/apps/mobile/hooks/query/reservation/use-get-reservation-detail-query.ts
+++ b/apps/mobile/hooks/query/reservation/use-get-reservation-detail-query.ts
@@ -4,12 +4,15 @@ import type { ReservationError } from "@services/reservations";
 import { reservationService } from "@services/reservations";
 import { useQuery } from "@tanstack/react-query";
 
+import { reservationQueryKeys } from "./reservation-query-keys";
+
 export function useGetReservationDetailQuery(
   reservationId: string,
   enabled: boolean = true,
+  scope?: string | null,
 ) {
   return useQuery<Reservation, ReservationError>({
-    queryKey: ["reservations", "detail", reservationId],
+    queryKey: reservationQueryKeys.detail(scope, reservationId),
     enabled: enabled && Boolean(reservationId),
     queryFn: async () => {
       const result = await reservationService.getReservationDetails(reservationId);

--- a/apps/mobile/hooks/query/reservation/use-get-reservation-history-query.ts
+++ b/apps/mobile/hooks/query/reservation/use-get-reservation-history-query.ts
@@ -4,14 +4,17 @@ import type { ReservationError } from "@services/reservations";
 import { reservationService } from "@services/reservations";
 import { useQuery } from "@tanstack/react-query";
 
+import { reservationQueryKeys } from "./reservation-query-keys";
+
 export function useGetReservationHistoryQuery(
   page: number = 1,
   pageSize: number = 10,
   enabled: boolean = true,
   version: number = 0,
+  scope?: string | null,
 ) {
   return useQuery<PaginatedReservations, ReservationError>({
-    queryKey: ["reservations", "history", page, pageSize, version],
+    queryKey: reservationQueryKeys.history(scope, page, pageSize, version),
     enabled,
     queryFn: async () => {
       const result = await reservationService.getReservationHistory({

--- a/apps/mobile/hooks/query/subscription/subscription-query-keys.ts
+++ b/apps/mobile/hooks/query/subscription/subscription-query-keys.ts
@@ -1,0 +1,12 @@
+import type { SubscriptionListParams } from "@/types/subscription-types";
+
+export const subscriptionQueryKeys = {
+  all: () => ["subscriptions"] as const,
+  list: (scope: string | null | undefined, params: SubscriptionListParams = {}) => [
+    "subscriptions",
+    scope ?? "guest",
+    params.page ?? 1,
+    params.pageSize ?? 10,
+    params.status ?? null,
+  ] as const,
+};

--- a/apps/mobile/hooks/query/subscription/use-get-subscriptions-query.ts
+++ b/apps/mobile/hooks/query/subscription/use-get-subscriptions-query.ts
@@ -5,12 +5,15 @@ import { useQuery } from "@tanstack/react-query";
 
 import type { SubscriptionListParams, SubscriptionListResponse } from "@/types/subscription-types";
 
+import { subscriptionQueryKeys } from "./subscription-query-keys";
+
 const DEFAULT_PAGE = 1;
 const DEFAULT_PAGE_SIZE = 10;
 
 export function useGetSubscriptionsQuery(
   params: SubscriptionListParams = {},
   enabled: boolean = true,
+  scope?: string | null,
 ) {
   const {
     page = DEFAULT_PAGE,
@@ -19,12 +22,7 @@ export function useGetSubscriptionsQuery(
   } = params;
 
   return useQuery<SubscriptionListResponse, SubscriptionError>({
-    queryKey: [
-      "subscriptions",
-      page,
-      pageSize,
-      status ?? null,
-    ],
+    queryKey: subscriptionQueryKeys.list(scope, { page, pageSize, status }),
     enabled,
     queryFn: async () => {
       const result = await subscriptionService.getList({

--- a/apps/mobile/hooks/query/wallet/use-get-my-transaction-query.ts
+++ b/apps/mobile/hooks/query/wallet/use-get-my-transaction-query.ts
@@ -2,6 +2,8 @@ import { presentWalletError } from "@/presenters/wallets/wallet-error-presenter"
 import { walletServiceV1 } from "@services/wallets/wallet.service";
 import { useInfiniteQuery } from "@tanstack/react-query";
 
+import { walletQueryKeys } from "./wallet-query-keys";
+
 export async function fetchMyTransactions(page: number = 1, limit: number = 5) {
   const result = await walletServiceV1.listMyWalletTransactions({ page, pageSize: limit });
   if (result.ok) {
@@ -9,10 +11,11 @@ export async function fetchMyTransactions(page: number = 1, limit: number = 5) {
   }
   throw new Error(presentWalletError(result.error));
 }
-export function useGetMyTransactionsQuery(limit: number = 5) {
+export function useGetMyTransactionsQuery(limit: number = 5, enabled: boolean = true, scope: string | null | undefined) {
   return useInfiniteQuery({
-    queryKey: ["myTransactions"],
+    queryKey: walletQueryKeys.myTransactions(scope),
     queryFn: ({ pageParam = 1 }) => fetchMyTransactions(pageParam, limit),
+    enabled,
     getNextPageParam: (lastPage) => {
       if (lastPage.pagination.page < lastPage.pagination.totalPages) {
         return lastPage.pagination.page + 1;

--- a/apps/mobile/hooks/query/wallet/use-get-my-wallet-query.ts
+++ b/apps/mobile/hooks/query/wallet/use-get-my-wallet-query.ts
@@ -2,6 +2,8 @@ import { presentWalletError } from "@/presenters/wallets/wallet-error-presenter"
 import { walletServiceV1 } from "@services/wallets/wallet.service";
 import { useQuery } from "@tanstack/react-query";
 
+import { walletQueryKeys } from "./wallet-query-keys";
+
 export async function fetchMyWallet() {
   const result = await walletServiceV1.getMyWallet();
   if (result.ok) {
@@ -9,10 +11,11 @@ export async function fetchMyWallet() {
   }
   throw new Error(presentWalletError(result.error));
 }
-export function useGetMyWalletQuery() {
+export function useGetMyWalletQuery(enabled: boolean, scope: string | null | undefined) {
   return useQuery({
-    queryKey: ["my-wallet"],
+    queryKey: walletQueryKeys.myWallet(scope),
     queryFn: () => fetchMyWallet(),
+    enabled,
     staleTime: 5 * 60 * 1000,
   });
 }

--- a/apps/mobile/hooks/query/wallet/wallet-query-keys.ts
+++ b/apps/mobile/hooks/query/wallet/wallet-query-keys.ts
@@ -1,0 +1,4 @@
+export const walletQueryKeys = {
+  myWallet: (scope: string | null | undefined) => ["my-wallet", scope ?? "guest"] as const,
+  myTransactions: (scope: string | null | undefined) => ["myTransactions", scope ?? "guest"] as const,
+};

--- a/apps/mobile/hooks/rentals/rental-cache.ts
+++ b/apps/mobile/hooks/rentals/rental-cache.ts
@@ -22,11 +22,11 @@ export function invalidateAllRentalQueries(queryClient: QueryClient) {
 }
 
 export function invalidateMyRentalQueries(queryClient: QueryClient) {
-  return queryClient.invalidateQueries({ queryKey: rentalKeys.me() });
+  return queryClient.invalidateQueries({ queryKey: rentalKeys.meRoot() });
 }
 
 export function invalidateMyRentalCountsQuery(queryClient: QueryClient) {
-  return queryClient.invalidateQueries({ queryKey: rentalKeys.meCounts() });
+  return queryClient.invalidateQueries({ queryKey: rentalKeys.meRoot() });
 }
 
 export function invalidateStaffRentalQueries(queryClient: QueryClient) {

--- a/apps/mobile/hooks/rentals/use-my-bike-swap-preview.ts
+++ b/apps/mobile/hooks/rentals/use-my-bike-swap-preview.ts
@@ -1,4 +1,5 @@
 import { rentalKeys } from "@hooks/query/rentals/rental-query-keys";
+import { useAuthNext } from "@providers/auth-provider-next";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 
@@ -14,7 +15,8 @@ export type MyBikeSwapPreview = {
 
 export function useMyBikeSwapPreview(rentalId: string) {
   const queryClient = useQueryClient();
-  const queryKey = rentalKeys.bikeSwap.mePreview(rentalId);
+  const { user } = useAuthNext();
+  const queryKey = rentalKeys.bikeSwap.mePreview(user?.id, rentalId);
 
   const previewQuery = useQuery<MyBikeSwapPreview | null>({
     queryKey,

--- a/apps/mobile/hooks/rentals/use-my-bike-swap-request-query.ts
+++ b/apps/mobile/hooks/rentals/use-my-bike-swap-request-query.ts
@@ -1,4 +1,5 @@
 import { rentalKeys } from "@hooks/query/rentals/rental-query-keys";
+import { useAuthNext } from "@providers/auth-provider-next";
 import { isRentalApiError, rentalServiceV1 } from "@services/rentals";
 import { useQuery } from "@tanstack/react-query";
 
@@ -17,8 +18,9 @@ export function useMyBikeSwapRequestQuery({
   enabled = true,
   keepPollingWhenMissing = false,
 }: UseMyBikeSwapRequestQueryOptions) {
+  const { user } = useAuthNext();
   const detailQuery = useQuery<BikeSwapRequestDetail | null>({
-    queryKey: rentalKeys.bikeSwap.meDetail(requestId ?? null),
+    queryKey: rentalKeys.bikeSwap.meDetail(user?.id, requestId ?? null),
     enabled: enabled && Boolean(requestId),
     queryFn: async () => {
       if (!requestId) {
@@ -50,7 +52,7 @@ export function useMyBikeSwapRequestQuery({
   });
 
   const rentalQuery = useQuery<BikeSwapRequestDetail | null>({
-    queryKey: rentalKeys.bikeSwap.meList({ page: 1, pageSize: 20, rentalId }),
+    queryKey: rentalKeys.bikeSwap.meList(user?.id, { page: 1, pageSize: 20, rentalId }),
     enabled: enabled && Boolean(rentalId) && (!requestId || detailQuery.data === null),
     queryFn: async () => {
       const result = await rentalServiceV1.listMyBikeSwapRequests({

--- a/apps/mobile/hooks/reservation/use-reservation-queries.ts
+++ b/apps/mobile/hooks/reservation/use-reservation-queries.ts
@@ -10,6 +10,7 @@ const EMPTY_RESERVATIONS: Reservation[] = [];
 
 type UseReservationQueriesParams = {
   hasToken: boolean;
+  userId?: string | null;
   pendingPage?: number;
   pendingLimit?: number;
   historyPage?: number;
@@ -23,6 +24,7 @@ type UseReservationQueriesParams = {
 
 export function useReservationQueries({
   hasToken,
+  userId,
   pendingPage = 1,
   pendingLimit = 10,
   historyPage = 1,
@@ -40,21 +42,21 @@ export function useReservationQueries({
     data: pendingReservationsResponse,
     isLoading: isPendingReservationsLoading,
     isFetching: isPendingReservationsFetching,
-  } = useGetPendingReservationsQuery(pendingPage, pendingLimit, shouldFetchLists);
+  } = useGetPendingReservationsQuery(pendingPage, pendingLimit, shouldFetchLists, userId);
 
   const {
     refetch: refetchReservationHistory,
     data: reservationHistoryResponse,
     isLoading: isReservationHistoryLoading,
     isFetching: isReservationHistoryFetching,
-  } = useGetReservationHistoryQuery(historyPage, historyLimit, shouldFetchLists, historyVersion);
+  } = useGetReservationHistoryQuery(historyPage, historyLimit, shouldFetchLists, historyVersion, userId);
 
   const {
     refetch: refetchReservationDetail,
     data: reservationDetail,
     isLoading: isReservationDetailLoading,
     isFetching: isReservationDetailFetching,
-  } = useGetReservationDetailQuery(reservationId ?? "", enableDetailQuery);
+  } = useGetReservationDetailQuery(reservationId ?? "", enableDetailQuery, userId);
 
   const fetchPendingReservations = useCallback(async () => {
     if (!ensureAuthenticated()) {

--- a/apps/mobile/hooks/use-reservation-actions.ts
+++ b/apps/mobile/hooks/use-reservation-actions.ts
@@ -1,6 +1,8 @@
 import { useNavigation } from "@react-navigation/native";
 import { useCallback } from "react";
 
+import { useAuthNext } from "@providers/auth-provider-next";
+
 import { useReservationMutations } from "./reservation/use-reservation-mutations";
 import { useReservationQueries } from "./reservation/use-reservation-queries";
 
@@ -28,6 +30,7 @@ export function useReservationActions({
   autoFetch = true,
 }: UseReservationActionsParams) {
   const navigation = useNavigation();
+  const { user } = useAuthNext();
 
   const ensureAuthenticated = useCallback(() => {
     if (!hasToken) {
@@ -39,6 +42,7 @@ export function useReservationActions({
 
   const queryState = useReservationQueries({
     hasToken,
+    userId: user?.id,
     pendingPage,
     pendingLimit,
     historyPage,

--- a/apps/mobile/hooks/use-wallet-action.ts
+++ b/apps/mobile/hooks/use-wallet-action.ts
@@ -1,6 +1,5 @@
 import type { WalletTransactionDetail } from "@services/wallets/wallet.service";
 
-import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useMemo } from "react";
 
 import { useGetMyTransactionsQuery } from "./query/wallet/use-get-my-transaction-query";
@@ -19,10 +18,9 @@ type ErrorWithMessage = {
   message: string;
 };
 
-export function useWalletActions(hasToken: boolean, limit: number = 5) {
-  const queryClient = useQueryClient();
-  const useGetMyWallet = useGetMyWalletQuery();
-  const useGetMyTransaction = useGetMyTransactionsQuery(limit);
+export function useWalletActions(hasToken: boolean, limit: number = 5, scope: string | null | undefined = null) {
+  const useGetMyWallet = useGetMyWalletQuery(hasToken, scope);
+  const useGetMyTransaction = useGetMyTransactionsQuery(limit, hasToken, scope);
   const { refetch, data: response, isLoading } = useGetMyWallet;
   const getMyWallet = useCallback(async () => {
     if (!hasToken) {

--- a/apps/mobile/providers/auth-provider-next.tsx
+++ b/apps/mobile/providers/auth-provider-next.tsx
@@ -65,6 +65,10 @@ type AuthContextValue = {
 
 const AuthContextNext = createContext<AuthContextValue | undefined>(undefined);
 
+function clearSessionQueries(queryClient: ReturnType<typeof useQueryClient>) {
+  queryClient.clear();
+}
+
 export const AuthProviderNext: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const queryClient = useQueryClient();
   const [tokenState, setTokenState] = useState<TokenState>("checking");
@@ -114,7 +118,7 @@ export const AuthProviderNext: React.FC<{ children: React.ReactNode }> = ({ chil
       void clearTokens().finally(() => {
         setSessionUser(null);
         setTokenState("missing");
-        queryClient.removeQueries({ queryKey: authQueryKeys.me() });
+        clearSessionQueries(queryClient);
       });
     }
   }, [meQuery.error, queryClient, tokenState]);
@@ -125,7 +129,7 @@ export const AuthProviderNext: React.FC<{ children: React.ReactNode }> = ({ chil
     setTokenState(nextTokenState);
 
     if (nextTokenState === "missing") {
-      queryClient.removeQueries({ queryKey: authQueryKeys.me() });
+      clearSessionQueries(queryClient);
       return;
     }
 
@@ -155,7 +159,7 @@ export const AuthProviderNext: React.FC<{ children: React.ReactNode }> = ({ chil
     await clearTokens();
     setSessionUser(null);
     setTokenState("missing");
-    queryClient.removeQueries({ queryKey: authQueryKeys.me() });
+    clearSessionQueries(queryClient);
   }, [queryClient]);
 
   const value = useMemo<AuthContextValue>(() => {

--- a/apps/mobile/screen/account/profile/hooks/use-profile.ts
+++ b/apps/mobile/screen/account/profile/hooks/use-profile.ts
@@ -42,6 +42,7 @@ export function useProfile() {
 
   const { data: rentalCounts, isLoading: isRentalCountsLoading } = useMyRentalCountsQuery({
     enabled: shouldLoadRentalCounts,
+    scope: user?.id,
   });
   const completedTrips = rentalCounts?.COMPLETED ?? 0;
   const {

--- a/apps/mobile/screen/environment/hooks/use-environment-impact-detail-screen.ts
+++ b/apps/mobile/screen/environment/hooks/use-environment-impact-detail-screen.ts
@@ -1,4 +1,5 @@
 import { useEnvironmentImpactDetailQuery } from "@hooks/query/environment/use-environment-impact-detail-query";
+import { useAuthNext } from "@providers/auth-provider-next";
 import { useNavigation } from "@react-navigation/native";
 import { useCallback, useState } from "react";
 
@@ -7,7 +8,8 @@ import type { EnvironmentImpactDetailNavigationProp } from "@/types/navigation";
 export function useEnvironmentImpactDetailScreen(rentalId: string) {
   const navigation = useNavigation<EnvironmentImpactDetailNavigationProp>();
   const [isRefreshing, setIsRefreshing] = useState(false);
-  const detailQuery = useEnvironmentImpactDetailQuery(rentalId);
+  const { isAuthenticated, user } = useAuthNext();
+  const detailQuery = useEnvironmentImpactDetailQuery(rentalId, isAuthenticated, user?.id);
 
   const handleRefresh = useCallback(async () => {
     setIsRefreshing(true);

--- a/apps/mobile/screen/environment/hooks/use-environment-impact-screen.ts
+++ b/apps/mobile/screen/environment/hooks/use-environment-impact-screen.ts
@@ -1,5 +1,6 @@
 import { useEnvironmentImpactHistoryQuery } from "@hooks/query/environment/use-environment-impact-history-query";
 import { useEnvironmentSummaryQuery } from "@hooks/query/environment/use-environment-summary-query";
+import { useAuthNext } from "@providers/auth-provider-next";
 import { useNavigation } from "@react-navigation/native";
 import { useCallback, useMemo, useState } from "react";
 
@@ -188,6 +189,7 @@ function flattenHistory(pages: Array<{ data: EnvironmentImpactHistoryItem[] }> |
 
 export function useEnvironmentImpactScreen() {
   const navigation = useNavigation<EnvironmentImpactNavigationProp>();
+  const { isAuthenticated, user } = useAuthNext();
   const [isFilterOpen, setIsFilterOpen] = useState(false);
   const [selectedRange, setSelectedRange] = useState<HistoryRangeKey>("all");
   const [draftRange, setDraftRange] = useState<HistoryRangeKey>("all");
@@ -200,8 +202,8 @@ export function useEnvironmentImpactScreen() {
     () => buildHistoryParams(selectedRange, customRange),
     [customRange, selectedRange],
   );
-  const summaryQuery = useEnvironmentSummaryQuery();
-  const historyQuery = useEnvironmentImpactHistoryQuery(historyParams);
+  const summaryQuery = useEnvironmentSummaryQuery(isAuthenticated, user?.id);
+  const historyQuery = useEnvironmentImpactHistoryQuery(historyParams, isAuthenticated, user?.id);
   const historyItems = useMemo(() => flattenHistory(historyQuery.data?.pages), [historyQuery.data?.pages]);
   const activeRange = HISTORY_RANGE_OPTIONS.find(option => option.key === selectedRange) ?? HISTORY_RANGE_OPTIONS[0];
 

--- a/apps/mobile/screen/fixed-slot-detail/use-fixed-slot-detail-screen.ts
+++ b/apps/mobile/screen/fixed-slot-detail/use-fixed-slot-detail-screen.ts
@@ -1,6 +1,8 @@
 import { useCancelFixedSlotTemplateMutation } from "@hooks/mutations/fixed-slots/use-cancel-fixed-slot-template-mutation";
 import { useRemoveFixedSlotTemplateDateMutation } from "@hooks/mutations/fixed-slots/use-remove-fixed-slot-template-date-mutation";
+import { fixedSlotQueryKeys } from "@hooks/query/fixed-slots/fixed-slot-query-keys";
 import { useFixedSlotTemplateDetailQuery } from "@hooks/query/fixed-slots/use-fixed-slot-template-detail-query";
+import { useAuthNext } from "@providers/auth-provider-next";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useMemo } from "react";
 import { Alert } from "react-native";
@@ -18,9 +20,10 @@ type UseFixedSlotDetailScreenParams = {
 
 export function useFixedSlotDetailScreen({ navigation, templateId }: UseFixedSlotDetailScreenParams) {
   const queryClient = useQueryClient();
+  const { isAuthenticated, user } = useAuthNext();
   const cancelMutation = useCancelFixedSlotTemplateMutation();
   const removeDateMutation = useRemoveFixedSlotTemplateDateMutation();
-  const detailQuery = useFixedSlotTemplateDetailQuery(templateId, true);
+  const detailQuery = useFixedSlotTemplateDetailQuery(templateId, isAuthenticated, user?.id);
 
   const template = detailQuery.data;
   const templateCode = useMemo(() => templateId.split("-")[1]?.toUpperCase() ?? templateId, [templateId]);
@@ -29,9 +32,9 @@ export function useFixedSlotDetailScreen({ navigation, templateId }: UseFixedSlo
   const canMutate = template?.status === "ACTIVE";
 
   const syncTemplate = useCallback((nextTemplate: NonNullable<typeof template>) => {
-    queryClient.setQueryData(["fixed-slots", "detail", templateId], nextTemplate);
+    queryClient.setQueryData(fixedSlotQueryKeys.detail(user?.id, templateId), nextTemplate);
     queryClient.invalidateQueries({ queryKey: ["fixed-slots"] });
-  }, [queryClient, templateId]);
+  }, [queryClient, templateId, user?.id]);
 
   const handleNavigateToEditor = useCallback(() => {
     if (!template || !canMutate) {

--- a/apps/mobile/screen/fixed-slot-editor/use-fixed-slot-editor.ts
+++ b/apps/mobile/screen/fixed-slot-editor/use-fixed-slot-editor.ts
@@ -1,7 +1,9 @@
 import { useCreateFixedSlotTemplateMutation } from "@hooks/mutations/fixed-slots/use-create-fixed-slot-template-mutation";
 import { useUpdateFixedSlotTemplateMutation } from "@hooks/mutations/fixed-slots/use-update-fixed-slot-template-mutation";
+import { fixedSlotQueryKeys } from "@hooks/query/fixed-slots/fixed-slot-query-keys";
 import { useFixedSlotTemplateDetailQuery } from "@hooks/query/fixed-slots/use-fixed-slot-template-detail-query";
 import { useGetStationDetailQuery } from "@hooks/query/stations/use-get-station-detail-query";
+import { useAuthNext } from "@providers/auth-provider-next";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { DateTimePickerAndroid } from "@react-native-community/datetimepicker";
 import { useQueryClient } from "@tanstack/react-query";
@@ -47,6 +49,7 @@ function getDefaultSlotStartDate(): Date {
 
 export function useFixedSlotEditor({ navigation, routeParams }: FixedSlotEditorHookParams) {
   const queryClient = useQueryClient();
+  const { isAuthenticated, user } = useAuthNext();
   const { stationId: initialStationId, stationName, templateId } = routeParams ?? {};
   const isEditMode = Boolean(templateId);
   const canEditStation = !isEditMode && !initialStationId;
@@ -64,7 +67,8 @@ export function useFixedSlotEditor({ navigation, routeParams }: FixedSlotEditorH
   const updateMutation = useUpdateFixedSlotTemplateMutation();
   const { data: templateData, isLoading: isDetailLoading } = useFixedSlotTemplateDetailQuery(
     templateId,
-    isEditMode,
+    isEditMode && isAuthenticated,
+    user?.id,
   );
 
   const lookupStationId = !canEditStation
@@ -208,7 +212,7 @@ export function useFixedSlotEditor({ navigation, routeParams }: FixedSlotEditorH
           onSuccess: async () => {
             await Promise.all([
               queryClient.invalidateQueries({ queryKey: ["fixed-slots"] }),
-              queryClient.invalidateQueries({ queryKey: ["fixed-slots", "detail", templateId] }),
+              queryClient.invalidateQueries({ queryKey: fixedSlotQueryKeys.detail(user?.id, templateId) }),
             ]);
             Alert.alert("Đã lưu", "Khung giờ đã được cập nhật.");
             navigation.goBack();
@@ -251,6 +255,8 @@ export function useFixedSlotEditor({ navigation, routeParams }: FixedSlotEditorH
     queryClient,
     navigation,
     createMutation,
+    isAuthenticated,
+    user?.id,
   ]);
 
   return {

--- a/apps/mobile/screen/fixed-slot-templates/use-fixed-slot-templates-screen.ts
+++ b/apps/mobile/screen/fixed-slot-templates/use-fixed-slot-templates-screen.ts
@@ -13,7 +13,7 @@ type UseFixedSlotTemplatesScreenParams = {
 
 export function useFixedSlotTemplatesScreen({ navigation, routeParams }: UseFixedSlotTemplatesScreenParams) {
   const { stationId, stationName } = routeParams ?? {};
-  const { isAuthenticated } = useAuthNext();
+  const { isAuthenticated, user } = useAuthNext();
 
   const [statusFilter, setStatusFilter] = useState<FixedSlotStatus | undefined>();
   const [isRefreshing, setIsRefreshing] = useState(false);
@@ -23,6 +23,7 @@ export function useFixedSlotTemplatesScreen({ navigation, routeParams }: UseFixe
   const templatesQuery = useFixedSlotTemplatesQuery(
     { pageSize, stationId, status: statusFilter },
     isAuthenticated,
+    user?.id,
   );
 
   const templates = useMemo(

--- a/apps/mobile/screen/my-wallet/hooks/use-my-wallet-screen.ts
+++ b/apps/mobile/screen/my-wallet/hooks/use-my-wallet-screen.ts
@@ -1,10 +1,12 @@
 import { useMemo } from "react";
 
 import { useWalletActions } from "@hooks/use-wallet-action";
+import { useAuthNext } from "@providers/auth-provider-next";
 import { WALLET_CONSTANTS } from "@utils/wallet/constants";
 
 export function useMyWalletScreen() {
-  const wallet = useWalletActions(true, WALLET_CONSTANTS.DEFAULT_LIMIT);
+  const { isAuthenticated, user } = useAuthNext();
+  const wallet = useWalletActions(isAuthenticated, WALLET_CONSTANTS.DEFAULT_LIMIT, user?.id);
 
   return useMemo(() => ({
     getMyTransaction: wallet.getMyTransaction,
@@ -15,6 +17,7 @@ export function useMyWalletScreen() {
     isLoadingWallet: wallet.isLoadingGetMyWallet,
     loadMoreTransactions: wallet.loadMoreTransactions,
     myWallet: wallet.myWallet,
+    userId: user?.id ?? null,
     totalTransactions: wallet.totalTransactions,
     transactions: wallet.myTransactions,
   }), [
@@ -28,5 +31,6 @@ export function useMyWalletScreen() {
     wallet.myTransactions,
     wallet.myWallet,
     wallet.totalTransactions,
+    user?.id,
   ]);
 }

--- a/apps/mobile/screen/my-wallet/index.tsx
+++ b/apps/mobile/screen/my-wallet/index.tsx
@@ -13,6 +13,8 @@ import { ActivityIndicator, Pressable, RefreshControl, ScrollView, StatusBar, Vi
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTheme, XStack, YStack } from "tamagui";
 
+import { walletQueryKeys } from "@/hooks/query/wallet/wallet-query-keys";
+
 import { WalletHeroCard } from "./components/wallet-hero-card";
 import { WalletTopUpCta } from "./components/wallet-top-up-cta";
 import { WalletTransactionRow } from "./components/wallet-transaction-row";
@@ -32,19 +34,19 @@ function MyWalletScreen() {
   const [selectedTransaction, setSelectedTransaction] = useState<WalletTransactionDetail | null>(null);
 
   const wallet = useMyWalletScreen();
-  const { getMyTransaction, getMyWallet } = wallet;
+  const { getMyTransaction, getMyWallet, userId } = wallet;
 
   const refreshWalletData = useCallback(async () => {
     await Promise.all([
-      queryClient.invalidateQueries({ queryKey: ["my-wallet"] }),
-      queryClient.invalidateQueries({ queryKey: ["myTransactions"] }),
+      queryClient.invalidateQueries({ queryKey: walletQueryKeys.myWallet(userId) }),
+      queryClient.invalidateQueries({ queryKey: walletQueryKeys.myTransactions(userId) }),
     ]);
 
     await Promise.all([
       getMyWallet(),
       getMyTransaction(),
     ]);
-  }, [getMyTransaction, getMyWallet, queryClient]);
+  }, [getMyTransaction, getMyWallet, queryClient, userId]);
 
   useFocusEffect(
     useCallback(() => {

--- a/apps/mobile/screen/rental/bike-detail/bike-detail-screen.tsx
+++ b/apps/mobile/screen/rental/bike-detail/bike-detail-screen.tsx
@@ -50,6 +50,7 @@ export default function BikeDetailScreen() {
   } = useBikeDetail({
     routeParams,
     hasToken: isAuthenticated,
+    userId: user?.id,
     verifyStatus: user?.verify,
     navigation,
   });

--- a/apps/mobile/screen/rental/bike-detail/hooks/use-bike-detail-data.ts
+++ b/apps/mobile/screen/rental/bike-detail/hooks/use-bike-detail-data.ts
@@ -17,12 +17,13 @@ import type { BikeDetailRouteParams } from "../types";
 type UseBikeDetailDataArgs = {
   routeParams: BikeDetailRouteParams;
   hasToken: boolean;
+  walletScope?: string | null;
 };
 
-export function useBikeDetailData({ routeParams, hasToken }: UseBikeDetailDataArgs) {
+export function useBikeDetailData({ routeParams, hasToken, walletScope }: UseBikeDetailDataArgs) {
   const { bike, station } = routeParams;
 
-  const { myWallet, getMyWallet } = useWalletActions(hasToken);
+  const { myWallet, getMyWallet } = useWalletActions(hasToken, 5, walletScope);
   const {
     pendingReservations,
     fetchPendingReservations,

--- a/apps/mobile/screen/rental/bike-detail/hooks/use-bike-detail-data.ts
+++ b/apps/mobile/screen/rental/bike-detail/hooks/use-bike-detail-data.ts
@@ -18,9 +18,10 @@ type UseBikeDetailDataArgs = {
   routeParams: BikeDetailRouteParams;
   hasToken: boolean;
   walletScope?: string | null;
+  userId?: string | null;
 };
 
-export function useBikeDetailData({ routeParams, hasToken, walletScope }: UseBikeDetailDataArgs) {
+export function useBikeDetailData({ routeParams, hasToken, walletScope, userId }: UseBikeDetailDataArgs) {
   const { bike, station } = routeParams;
 
   const { myWallet, getMyWallet } = useWalletActions(hasToken, 5, walletScope);
@@ -34,7 +35,7 @@ export function useBikeDetailData({ routeParams, hasToken, walletScope }: UseBik
     pendingLimit: 5,
   });
 
-  const subscriptionsQuery = useGetSubscriptionsQuery({ status: "ACTIVE" }, hasToken);
+  const subscriptionsQuery = useGetSubscriptionsQuery({ status: "ACTIVE" }, hasToken, userId);
   const bikeDetailQuery = useGetBikeDetailQuery(bike.id);
   const refetchBikeDetail = bikeDetailQuery.refetch;
   const refetchSubscriptions = subscriptionsQuery.refetch;

--- a/apps/mobile/screen/rental/bike-detail/hooks/use-bike-detail.ts
+++ b/apps/mobile/screen/rental/bike-detail/hooks/use-bike-detail.ts
@@ -9,12 +9,13 @@ import { useBikeDetailPayment } from "./use-bike-detail-payment";
 export type UseBikeDetailArgs = {
   routeParams: BikeDetailRouteParams;
   hasToken: boolean;
+  userId?: string | null;
   verifyStatus: "UNVERIFIED" | "VERIFIED" | string | undefined;
   navigation: BikeDetailNavigationProp;
 };
 
-export function useBikeDetail({ routeParams, hasToken, verifyStatus, navigation }: UseBikeDetailArgs) {
-  const data = useBikeDetailData({ routeParams, hasToken });
+export function useBikeDetail({ routeParams, hasToken, userId, verifyStatus, navigation }: UseBikeDetailArgs) {
+  const data = useBikeDetailData({ routeParams, hasToken, walletScope: userId });
   const payment = useBikeDetailPayment({
     activeSubscriptions: data.activeSubscriptions,
     canUseSubscription: data.canUseSubscription,

--- a/apps/mobile/screen/rental/bike-detail/hooks/use-bike-detail.ts
+++ b/apps/mobile/screen/rental/bike-detail/hooks/use-bike-detail.ts
@@ -15,7 +15,7 @@ export type UseBikeDetailArgs = {
 };
 
 export function useBikeDetail({ routeParams, hasToken, userId, verifyStatus, navigation }: UseBikeDetailArgs) {
-  const data = useBikeDetailData({ routeParams, hasToken, walletScope: userId });
+  const data = useBikeDetailData({ routeParams, hasToken, walletScope: userId, userId });
   const payment = useBikeDetailPayment({
     activeSubscriptions: data.activeSubscriptions,
     canUseSubscription: data.canUseSubscription,

--- a/apps/mobile/screen/rental/booking-history-detail/hooks/use-rental-detail-data.ts
+++ b/apps/mobile/screen/rental/booking-history-detail/hooks/use-rental-detail-data.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 
 import { useMyRentalResolvedDetailQuery } from "@hooks/query/rentals/use-my-rental-resolved-detail-query";
+import { useAuthNext } from "@providers/auth-provider-next";
 
 type Options = {
   onRentalEnd?: () => void;
@@ -9,8 +10,9 @@ type Options = {
 export function useRentalDetailData(bookingId: string, options?: Options) {
   const { onRentalEnd } = options || {};
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const { isAuthenticated, user } = useAuthNext();
 
-  const rentalQuery = useMyRentalResolvedDetailQuery(bookingId, true);
+  const rentalQuery = useMyRentalResolvedDetailQuery(bookingId, isAuthenticated, user?.id);
 
   const refreshAll = useCallback(async () => {
     setIsRefreshing(true);

--- a/apps/mobile/screen/rental/booking-history/hooks/use-booking-history.ts
+++ b/apps/mobile/screen/rental/booking-history/hooks/use-booking-history.ts
@@ -1,4 +1,5 @@
 import { rentalKeys } from "@hooks/query/rentals/rental-query-keys";
+import { useAuthNext } from "@providers/auth-provider-next";
 import { rentalServiceV1 } from "@services/rentals";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { useCallback, useMemo, useState } from "react";
@@ -17,9 +18,11 @@ async function fetchRentalHistory(page: number = 1) {
 
 export function useBookingHistory() {
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const { isAuthenticated, user } = useAuthNext();
 
   const query = useInfiniteQuery({
-    queryKey: rentalKeys.meHistoryPage(PAGE_SIZE),
+    queryKey: rentalKeys.meHistoryPage(user?.id, PAGE_SIZE),
+    enabled: isAuthenticated,
     queryFn: ({ pageParam = 1 }) =>
       fetchRentalHistory(pageParam as number),
     getNextPageParam: (lastPage) => {

--- a/apps/mobile/screen/rental/rental-qr/index.tsx
+++ b/apps/mobile/screen/rental/rental-qr/index.tsx
@@ -213,10 +213,10 @@ function RentalQrScreen() {
   const route = useRoute();
   const { bookingId } = route.params as RouteParams;
   const insets = useSafeAreaInsets();
-  const { isAuthenticated } = useAuthNext();
+  const { isAuthenticated, user } = useAuthNext();
   const hasToken = isAuthenticated;
 
-  const rentalQuery = useMyRentalQuery(bookingId, hasToken);
+  const rentalQuery = useMyRentalQuery(bookingId, hasToken, user?.id);
   const rental = rentalQuery.data;
 
   const [isSessionCompleted, setIsSessionCompleted] = useState(false);

--- a/apps/mobile/screen/reservation-flow/hooks/use-reservation-flow-data.ts
+++ b/apps/mobile/screen/reservation-flow/hooks/use-reservation-flow-data.ts
@@ -12,7 +12,7 @@ export function useReservationFlowData() {
   const navigation = useNavigation<ReservationFlowNavigationProp>();
   const route = useRoute<ReservationFlowRouteProp>();
   const insets = useSafeAreaInsets();
-  const { isAuthenticated } = useAuthNext();
+  const { isAuthenticated, user } = useAuthNext();
 
   const hasToken = isAuthenticated;
 
@@ -38,6 +38,7 @@ export function useReservationFlowData() {
   } = useGetSubscriptionsQuery(
     { status: "ACTIVE", pageSize: 10 },
     hasToken,
+    user?.id,
   );
 
   const activeSubscriptions = useMemo(

--- a/apps/mobile/screen/subscription/hooks/use-subscription-screen.ts
+++ b/apps/mobile/screen/subscription/hooks/use-subscription-screen.ts
@@ -33,7 +33,7 @@ function messageFromError(error: unknown, fallback: string): string {
 export function useSubscriptionScreen() {
   const navigation = useNavigation();
   const queryClient = useQueryClient();
-  const { status, isAuthenticated } = useAuthNext();
+  const { status, isAuthenticated, user } = useAuthNext();
 
   const [selectedId, setSelectedId] = useState<string | undefined>();
   const [activeSection, setActiveSection] = useState<SubscriptionSectionKey>("plans");
@@ -44,7 +44,7 @@ export function useSubscriptionScreen() {
     isLoading,
     isFetching,
     refetch,
-  } = useGetSubscriptionsQuery({ page: 1, pageSize: PAGE_SIZE }, isAuthenticated);
+  } = useGetSubscriptionsQuery({ page: 1, pageSize: PAGE_SIZE }, isAuthenticated, user?.id);
 
   const subscriptions: Subscription[] = data?.data ?? [];
   const activeSubscription = subscriptions.find(sub => toSubscriptionStatusLabel(sub.status) === "ĐANG HOẠT ĐỘNG") ?? null;


### PR DESCRIPTION
## Summary
- clear authenticated React Query state on logout/session expiry so account switches cannot retain stale private data
- scope current-user wallet, reservation, rental, subscription, environment, fixed-slot, and bike-swap queries by the active user id
- gate account-specific mobile queries on authenticated state and update affected screens/hooks to use the scoped keys

## Verification
- pnpm exec tsc --noEmit -p apps/mobile/tsconfig.json