### PR TITLE
fix(mobile): tighten auth validation and email verify flow

### DIFF
--- a/apps/mobile/components/verify-email-modal/components/otp-timer.tsx
+++ b/apps/mobile/components/verify-email-modal/components/otp-timer.tsx
@@ -1,4 +1,4 @@
-import { StyleSheet, Text, View } from "react-native";
+import { Pressable, StyleSheet, Text, View } from "react-native";
 
 const styles = StyleSheet.create({
   timerContainer: {
@@ -41,6 +41,21 @@ const styles = StyleSheet.create({
     color: "#999",
     fontStyle: "italic",
   },
+  resendButton: {
+    marginTop: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 10,
+    backgroundColor: "#0066FF",
+  },
+  resendButtonDisabled: {
+    opacity: 0.6,
+  },
+  resendButtonText: {
+    fontSize: 13,
+    color: "white",
+    fontWeight: "600",
+  },
 });
 
 type OtpTimerProps = {
@@ -73,7 +88,15 @@ export function OtpTimer({ timeLeft }: { timeLeft: number }) {
   );
 }
 
-export function OtpResendInfo({ resendTimeLeft }: { resendTimeLeft: number }) {
+export function OtpResendInfo({
+  resendTimeLeft,
+  onResend,
+  isResending = false,
+}: {
+  resendTimeLeft: number;
+  onResend?: () => void;
+  isResending?: boolean;
+}) {
   const formatTime = (seconds: number) => {
     const mins = Math.floor(seconds / 60);
     const secs = seconds % 60;
@@ -92,9 +115,19 @@ export function OtpResendInfo({ resendTimeLeft }: { resendTimeLeft: number }) {
             </Text>
           )
         : (
-            <Text style={styles.resendInfo}>
-              Kiểm tra email của bạn hoặc yêu cầu gửi lại từ Profile
-            </Text>
+            <Pressable
+              disabled={!onResend || isResending}
+              onPress={onResend}
+              style={({ pressed }) => [
+                styles.resendButton,
+                (!onResend || isResending) && styles.resendButtonDisabled,
+                pressed && onResend && !isResending ? { opacity: 0.9 } : null,
+              ]}
+            >
+              <Text style={styles.resendButtonText}>
+                {isResending ? "Đang gửi mã..." : "Gửi lại mã"}
+              </Text>
+            </Pressable>
           )}
     </View>
   );

--- a/apps/mobile/components/verify-email-modal/hooks/use-otp-timers.ts
+++ b/apps/mobile/components/verify-email-modal/hooks/use-otp-timers.ts
@@ -12,6 +12,11 @@ export function useOtpTimers(visible: boolean) {
     setResendTimeLeft(0);
   }, []);
 
+  const restartTimers = useCallback(() => {
+    setTimeLeft(OTP_EXPIRY);
+    setResendTimeLeft(_RESEND_COOLDOWN);
+  }, []);
+
   useEffect(() => {
     if (!visible) {
       setTimeLeft(OTP_EXPIRY);
@@ -57,5 +62,6 @@ export function useOtpTimers(visible: boolean) {
     timeLeft,
     resendTimeLeft,
     resetTimers,
+    restartTimers,
   };
 }

--- a/apps/mobile/components/verify-email-modal/index.tsx
+++ b/apps/mobile/components/verify-email-modal/index.tsx
@@ -67,18 +67,22 @@ type VerifyEmailModalProps = {
   visible: boolean;
   onClose: () => void;
   onSubmit: (otp: string) => Promise<void>;
+  onResend?: () => Promise<boolean>;
   isLoading?: boolean;
+  isResending?: boolean;
 };
 
 export function VerifyEmailModal({
   visible,
   onClose,
   onSubmit,
+  onResend,
   isLoading = false,
+  isResending = false,
 }: VerifyEmailModalProps) {
   const [otp, setOtp] = useState(["", "", "", "", "", ""]);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const { timeLeft, resendTimeLeft, resetTimers } = useOtpTimers(visible);
+  const { timeLeft, resendTimeLeft, resetTimers, restartTimers } = useOtpTimers(visible);
 
   useEffect(() => {
     if (!visible) {
@@ -104,6 +108,18 @@ export function VerifyEmailModal({
     }
     finally {
       setIsSubmitting(false);
+    }
+  };
+
+  const handleResend = async () => {
+    if (!onResend || resendTimeLeft > 0 || isResending) {
+      return;
+    }
+
+    const resent = await onResend();
+    if (resent) {
+      setOtp(["", "", "", "", "", ""]);
+      restartTimers();
     }
   };
 
@@ -141,7 +157,13 @@ export function VerifyEmailModal({
             </TouchableOpacity>
 
             <View style={styles.resendInfo}>
-              <OtpResendInfo resendTimeLeft={resendTimeLeft} />
+              <OtpResendInfo
+                isResending={isResending}
+                onResend={() => {
+                  void handleResend();
+                }}
+                resendTimeLeft={resendTimeLeft}
+              />
             </View>
           </View>
         </View>

--- a/apps/mobile/screen/account/profile/components/profile-header.tsx
+++ b/apps/mobile/screen/account/profile/components/profile-header.tsx
@@ -14,7 +14,6 @@ type ProfileHeaderProps = {
   completedTrips?: number;
   isLoadingTrips?: boolean;
   topInset: number;
-  onVerifyEmail: () => void;
   formatDate: (dateString: string) => string;
 };
 
@@ -26,7 +25,6 @@ function ProfileHeader({
   completedTrips,
   isLoadingTrips,
   topInset,
-  onVerifyEmail,
   formatDate,
 }: ProfileHeaderProps) {
   const theme = useTheme();
@@ -120,28 +118,6 @@ function ProfileHeader({
                         Chuyến đi
                       </AppText>
                     </XStack>
-                  )
-                : null}
-
-              {!isVerified
-                ? (
-                    <Pressable onPress={onVerifyEmail} style={({ pressed }) => ({ opacity: pressed ? 0.92 : 1 })}>
-                      <XStack
-                        alignItems="center"
-                        backgroundColor="$overlayGlass"
-                        borderColor="$overlayGlass"
-                        borderRadius="$4"
-                        borderWidth={borderWidths.subtle}
-                        gap="$2"
-                        paddingHorizontal="$4"
-                        paddingVertical="$2"
-                      >
-                        <IconSymbol color={theme.onSurfaceBrand.val} name="mail" size="sm" />
-                        <AppText tone="inverted" variant="badgeLabel">
-                          Xác thực email
-                        </AppText>
-                      </XStack>
-                    </Pressable>
                   )
                 : null}
             </XStack>

--- a/apps/mobile/screen/account/profile/hooks/use-profile-email-verification.ts
+++ b/apps/mobile/screen/account/profile/hooks/use-profile-email-verification.ts
@@ -26,7 +26,7 @@ export function useProfileEmailVerification({
   const handleResendOtp = useCallback(async () => {
     if (profile.verify === "VERIFIED") {
       Alert.alert("Info", "Email của bạn đã được xác thực.");
-      return;
+      return false;
     }
 
     try {
@@ -38,14 +38,16 @@ export function useProfileEmailVerification({
 
       if (!result.ok) {
         Alert.alert("Lỗi", presentAuthError(result.error));
-        return;
+        return false;
       }
 
       Alert.alert("Success", "Mã OTP mới đã được gửi đến email của bạn!");
       setIsVerifyEmailModalOpen(true);
+      return true;
     }
     catch {
       Alert.alert("Lỗi", "Không thể gửi lại OTP. Vui lòng thử lại.");
+      return false;
     }
   }, [profile.email, profile.fullName, profile.id, profile.verify, resendOtpMutation]);
 

--- a/apps/mobile/screen/account/profile/hooks/use-profile-email-verification.ts
+++ b/apps/mobile/screen/account/profile/hooks/use-profile-email-verification.ts
@@ -25,7 +25,7 @@ export function useProfileEmailVerification({
 
   const handleResendOtp = useCallback(async () => {
     if (profile.verify === "VERIFIED") {
-      Alert.alert("Info", "Email của bạn đã được xác thực.");
+      Alert.alert("Thông báo", "Email của bạn đã được xác thực.");
       return false;
     }
 
@@ -41,7 +41,7 @@ export function useProfileEmailVerification({
         return false;
       }
 
-      Alert.alert("Success", "Mã OTP mới đã được gửi đến email của bạn!");
+      Alert.alert("Thành công", "Mã OTP mới đã được gửi đến email của bạn!");
       setIsVerifyEmailModalOpen(true);
       return true;
     }
@@ -60,7 +60,7 @@ export function useProfileEmailVerification({
         return;
       }
 
-      Alert.alert("Success", "Email đã được xác thực.");
+      Alert.alert("Thành công", "Email đã được xác thực.");
       void queryClient.invalidateQueries({ queryKey: authQueryKeys.me() });
       await hydrate();
       setTimeout(() => {

--- a/apps/mobile/screen/account/profile/hooks/use-profile.ts
+++ b/apps/mobile/screen/account/profile/hooks/use-profile.ts
@@ -123,6 +123,10 @@ export function useProfile() {
     Alert.alert("Sắp ra mắt", "Quản lý thông báo sẽ sớm được cập nhật.");
   };
 
+  const handleVerifyEmailPress = () => {
+    openVerifyModal();
+  };
+
   return {
     profile,
     isVerifyEmailModalOpen,
@@ -146,5 +150,6 @@ export function useProfile() {
     handleNotifications,
     handleResendOtp,
     handleVerifyEmail,
+    handleVerifyEmailPress,
   };
 }

--- a/apps/mobile/screen/account/profile/index.tsx
+++ b/apps/mobile/screen/account/profile/index.tsx
@@ -69,13 +69,16 @@ function ProfileScreen() {
     formatDate,
     handleLogout,
     handleChangePassword,
+    handleVerifyEmailPress,
     handleUpdateProfile,
     handleReservations,
     handleSubscriptions,
     handleEnvironmentImpact,
     handleMetroJourney,
     handleNotifications,
+    isResendingOtp,
     handleVerifyEmail,
+    handleResendOtp,
   } = useProfile();
 
   const activityItems = useMemo<MenuItem[]>(() => {
@@ -141,6 +144,16 @@ function ProfileScreen() {
       iconBackground: theme.surfaceWarning.val,
       onPress: handleChangePassword,
     },
+    ...(profile.verify === "VERIFIED"
+      ? []
+      : [{
+          icon: "mail" as const,
+          title: "Xác thực email",
+          subtitle: "Email của bạn chưa được xác thực",
+          iconColor: theme.actionPrimary.val,
+          iconBackground: theme.surfaceAccent.val,
+          onPress: handleVerifyEmailPress,
+        }]),
     {
       icon: "map",
       title: "Hành trình Metro",
@@ -162,6 +175,8 @@ function ProfileScreen() {
     handleMetroJourney,
     handleNotifications,
     handleUpdateProfile,
+    handleVerifyEmailPress,
+    profile.verify,
     theme.actionPrimary.val,
     theme.statusSuccess.val,
     theme.statusWarning.val,
@@ -225,7 +240,9 @@ function ProfileScreen() {
 
       <VerifyEmailModal
         isLoading={isVerifyingOtp}
+        isResending={isResendingOtp}
         onClose={closeVerifyModal}
+        onResend={handleResendOtp}
         onSubmit={handleVerifyEmail}
         visible={isVerifyEmailModalOpen}
       />

--- a/apps/mobile/screen/account/update-profile/schema.ts
+++ b/apps/mobile/screen/account/update-profile/schema.ts
@@ -11,7 +11,10 @@ const updateProfileContractSchema = ServerContracts.UsersContracts.UpdateMeReque
 export const updateProfileSchema = updateProfileContractSchema.extend({
   fullname: z.string().trim().min(1, { message: "Vui lòng nhập họ tên" }).max(50),
   username: z.string().trim().max(30).optional().or(z.literal("")),
-  phoneNumber: z.string().trim().min(1, { message: "Vui lòng nhập số điện thoại" }),
+  phoneNumber: z.string()
+    .trim()
+    .min(1, { message: "Vui lòng nhập số điện thoại" })
+    .regex(/^\d{10}$/, { message: "Số điện thoại phải gồm đúng 10 chữ số" }),
   location: z.string().trim().optional().or(z.literal("")),
 });
 

--- a/apps/mobile/screen/auth/forgot-password/hooks/use-forgot-password.ts
+++ b/apps/mobile/screen/auth/forgot-password/hooks/use-forgot-password.ts
@@ -37,7 +37,14 @@ export function useForgotPassword() {
       return;
     }
 
-    navigation.navigate("ResetPasswordOTP", { email: data.email });
+    Alert.alert("Thành công", "Mã OTP đã được gửi đến email của bạn.", [
+      {
+        text: "Tiếp tục",
+        onPress: () => {
+          navigation.navigate("ResetPasswordOTP", { email: data.email });
+        },
+      },
+    ]);
   });
 
   return {

--- a/apps/mobile/screen/auth/register/hooks/use-register.ts
+++ b/apps/mobile/screen/auth/register/hooks/use-register.ts
@@ -17,9 +17,13 @@ const registerSchema = AuthContracts.RegisterRequestSchema
   .extend({
     fullname: z.string().min(1, { message: "Họ tên là bắt buộc" }),
     email: z.string().min(1, { message: "Email là bắt buộc" }).email("Email không hợp lệ"),
-    password: z.string().min(1, { message: "Mật khẩu là bắt buộc" }),
+    password: z.string()
+      .min(1, { message: "Mật khẩu là bắt buộc" })
+      .min(8, { message: "Mật khẩu phải có ít nhất 8 ký tự" }),
     phoneNumber: z.string().optional().nullable().or(z.literal("")),
-    confirmPassword: z.string().min(1, { message: "Xác nhận mật khẩu là bắt buộc" }),
+    confirmPassword: z.string()
+      .min(1, { message: "Xác nhận mật khẩu là bắt buộc" })
+      .min(8, { message: "Mật khẩu xác nhận phải có ít nhất 8 ký tự" }),
   })
   .refine(data => data.password === data.confirmPassword, {
     message: "Mật khẩu xác nhận không khớp",

--- a/packages/shared/src/contracts/server/auth/schemas.ts
+++ b/packages/shared/src/contracts/server/auth/schemas.ts
@@ -12,7 +12,7 @@ import type {
   VerifyResetPasswordOtpRequest,
 } from "./models";
 
-import { OptionalTrimmedNullableStringSchema } from "../schemas";
+import { OptionalPhoneNumberNullableSchema } from "../schemas";
 
 export const TokensSchema = z.object({
   accessToken: z.string(),
@@ -31,8 +31,8 @@ export const LoginRequestSchema = z.object({
 export const RegisterRequestSchema = z.object({
   fullname: z.string().min(1),
   email: z.string().email(),
-  password: z.string().min(1),
-  phoneNumber: OptionalTrimmedNullableStringSchema,
+  password: z.string().min(8),
+  phoneNumber: OptionalPhoneNumberNullableSchema,
 }).openapi("RegisterRequest") satisfies z.ZodType<RegisterRequest>;
 
 export const RefreshRequestSchema = z.object({
@@ -56,7 +56,7 @@ export const SendResetPasswordRequestSchema = z.object({
 
 export const ResetPasswordRequestSchema = z.object({
   resetToken: z.string().min(1),
-  newPassword: z.string().min(1),
+  newPassword: z.string().min(8),
 }).openapi("ResetPasswordRequest") satisfies z.ZodType<ResetPasswordRequest>;
 
 export const VerifyResetPasswordOtpRequestSchema = z.object({

--- a/packages/shared/src/contracts/server/routes/users/shared.ts
+++ b/packages/shared/src/contracts/server/routes/users/shared.ts
@@ -36,7 +36,7 @@ export const MeResponseSchema = UserDetailSchema.openapi("MeResponse");
 
 export const UpdateMeRequestSchema = z.object({
   fullname: z.string().min(1).optional(),
-  phoneNumber: OptionalTrimmedNullableStringSchema,
+  phoneNumber: OptionalPhoneNumberNullableSchema,
   username: z.string().optional().nullable(),
   avatar: z.string().url().optional().nullable(),
   location: z.string().optional().nullable(),


### PR DESCRIPTION
## Summary
- require stronger password and phone validation in register and profile update flows
- improve email verification UX by moving the action into account settings and adding explicit OTP resend inside the modal
- show success feedback in forgot-password before navigating to the OTP screen