### PR TITLE
fix(mobile): redirect to main after login

### DIFF
--- a/apps/mobile/app.tsx
+++ b/apps/mobile/app.tsx
@@ -12,6 +12,7 @@ import { TamaguiProvider } from "tamagui";
 
 import { runSharedContractsSmokeTest } from "./debug/shared-contract-smoke";
 import { log } from "./lib/log";
+import { navigationRef } from "./navigation/navigation-ref";
 import { STRIPE_PUBLISHABLE_KEY, STRIPE_URL_SCHEME } from "./lib/stripe";
 import RootNavigator from "./navigation/root-navigator";
 import tamaguiConfig from "./tamagui.config";
@@ -76,7 +77,7 @@ export default function App() {
   return (
     <TamaguiProvider config={tamaguiConfig} defaultTheme="light">
       <Providers>
-        <NavigationContainer>
+        <NavigationContainer ref={navigationRef}>
           <AuthProviderNext>
             <BikeStatusStreamProvider>
               <StatusBar style="dark" />

--- a/apps/mobile/navigation/navigation-ref.ts
+++ b/apps/mobile/navigation/navigation-ref.ts
@@ -1,0 +1,5 @@
+import { createNavigationContainerRef } from "@react-navigation/native";
+
+import type { RootStackParamList } from "@/types/navigation";
+
+export const navigationRef = createNavigationContainerRef<RootStackParamList>();

--- a/apps/mobile/navigation/root-navigator.tsx
+++ b/apps/mobile/navigation/root-navigator.tsx
@@ -1,7 +1,7 @@
 import { LoadingScreen } from "@components/LoadingScreen";
 import { useAuthNext } from "@providers/auth-provider-next";
 import { createStackNavigator } from "@react-navigation/stack";
-import React from "react";
+import React, { useEffect } from "react";
 
 import type { RootStackParamList } from "../types/navigation";
 
@@ -40,6 +40,7 @@ import {
   UpdateProfileScreen,
 } from "../screen";
 import StationSelectScreen from "../styles/StationSelect";
+import { navigationRef } from "./navigation-ref";
 import MainTabNavigator from "./main-tab-navigator";
 
 const Stack = createStackNavigator<RootStackParamList>();
@@ -49,6 +50,21 @@ const assistantScreenOptions = { headerShown: false, gestureEnabled: true } as c
 
 function RootNavigator() {
   const { status, isAuthenticated } = useAuthNext();
+
+  useEffect(() => {
+    if (!isAuthenticated || !navigationRef.isReady()) {
+      return;
+    }
+
+    if (navigationRef.getCurrentRoute()?.name !== "Login") {
+      return;
+    }
+
+    navigationRef.reset({
+      index: 0,
+      routes: [{ name: "Main" }],
+    });
+  }, [isAuthenticated]);
 
   if (status === "loading") {
     return <LoadingScreen />;

--- a/apps/mobile/screen/auth/login/hooks/use-login.ts
+++ b/apps/mobile/screen/auth/login/hooks/use-login.ts
@@ -80,6 +80,7 @@ export function useLogin() {
         Alert.alert("Đăng nhập thất bại", message);
         return;
       }
+
     }
     catch {
       rotateAnim.stopAnimation();


### PR DESCRIPTION
## Summary
- add a root navigation ref so auth transitions can reset from the navigation container
- reset to `Main` only when authentication completes while the current route is `Login`
- keep the register and email verification flow untouched

## Testing
- pnpm exec tsc --noEmit -p apps/mobile/tsconfig.json