### PR TITLE
fix(mobile): preserve paginated load-more state

### DIFF
--- a/apps/mobile/hooks/query/environment/use-environment-impact-history-query.ts
+++ b/apps/mobile/hooks/query/environment/use-environment-impact-history-query.ts
@@ -35,7 +35,8 @@ export function useEnvironmentImpactHistoryQuery(
     enabled,
     initialPageParam: 1,
     queryFn: async ({ pageParam }) => {
-      const page = typeof pageParam === "number" ? pageParam : 1;
+      const requestedPage = typeof pageParam === "number" ? pageParam : Number(pageParam);
+      const page = Number.isFinite(requestedPage) && requestedPage >= 1 ? requestedPage : 1;
       const result = await environmentService.getHistory({
         page,
         pageSize,

--- a/apps/mobile/hooks/query/fixed-slots/use-fixed-slot-templates-query.ts
+++ b/apps/mobile/hooks/query/fixed-slots/use-fixed-slot-templates-query.ts
@@ -21,7 +21,8 @@ export function useFixedSlotTemplatesQuery(
     enabled,
     initialPageParam: 1,
     queryFn: async ({ pageParam }) => {
-      const page = typeof pageParam === "number" ? pageParam : 1;
+      const requestedPage = typeof pageParam === "number" ? pageParam : Number(pageParam);
+      const page = Number.isFinite(requestedPage) && requestedPage >= 1 ? requestedPage : 1;
       const result = await fixedSlotService.getList({
         page,
         pageSize,

--- a/apps/mobile/hooks/use-wallet-action.ts
+++ b/apps/mobile/hooks/use-wallet-action.ts
@@ -5,42 +5,41 @@ import { useCallback, useMemo } from "react";
 import { useGetMyTransactionsQuery } from "./query/wallet/use-get-my-transaction-query";
 import { useGetMyWalletQuery } from "./query/wallet/use-get-my-wallet-query";
 
-type ErrorResponse = {
-  response?: {
-    data?: {
-      errors?: Record<string, { msg?: string }>;
-      message?: string;
-    };
-  };
-};
-
-type ErrorWithMessage = {
-  message: string;
-};
-
 export function useWalletActions(hasToken: boolean, limit: number = 5, scope: string | null | undefined = null) {
   const useGetMyWallet = useGetMyWalletQuery(hasToken, scope);
   const useGetMyTransaction = useGetMyTransactionsQuery(limit, hasToken, scope);
   const { refetch, data: response, isLoading } = useGetMyWallet;
+  const {
+    refetch: refetchTransactions,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+    data: transactionsResponse,
+    isLoading: isLoadingTransactions,
+  } = useGetMyTransaction;
+
   const getMyWallet = useCallback(async () => {
     if (!hasToken) {
       return;
     }
     return await refetch();
   }, [refetch, hasToken]);
+
   const getMyTransaction = useCallback(async () => {
     if (!hasToken) {
       return;
     }
-    return await useGetMyTransaction.refetch();
-  }, [useGetMyTransaction, hasToken]);
-  const loadMoreTransactions = () => {
-    if (useGetMyTransaction.hasNextPage && !useGetMyTransaction.isFetchingNextPage) {
-      useGetMyTransaction.fetchNextPage();
+    return await refetchTransactions();
+  }, [refetchTransactions, hasToken]);
+
+  const loadMoreTransactions = useCallback(() => {
+    if (hasNextPage && !isFetchingNextPage) {
+      void fetchNextPage();
     }
-  };
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+
   const transactions = useMemo(() => {
-    const pages = useGetMyTransaction.data?.pages ?? [];
+    const pages = transactionsResponse?.pages ?? [];
     const seen = new Set<string>();
     const deduped: WalletTransactionDetail[] = [];
     pages.forEach((page) => {
@@ -52,18 +51,20 @@ export function useWalletActions(hasToken: boolean, limit: number = 5, scope: st
       });
     });
     return deduped;
-  }, [useGetMyTransaction.data]);
-  const totalTransactions = useGetMyTransaction.data?.pages[0]?.pagination?.total || 0;
+  }, [transactionsResponse]);
+
+  const totalTransactions = transactionsResponse?.pages[0]?.pagination?.total || 0;
+
   return {
     getMyWallet,
     myWallet: response,
     isLoadingGetMyWallet: isLoading,
     getMyTransaction,
     myTransactions: transactions,
-    isLoadingGetMyTransaction: useGetMyTransaction.isLoading,
+    isLoadingGetMyTransaction: isLoadingTransactions,
     loadMoreTransactions,
-    hasNextPageTransactions: useGetMyTransaction.hasNextPage,
-    isFetchingNextPageTransactions: useGetMyTransaction.isFetchingNextPage,
+    hasNextPageTransactions: hasNextPage,
+    isFetchingNextPageTransactions: isFetchingNextPage,
     totalTransactions,
   };
 }

--- a/apps/mobile/screen/environment/environment-impact-screen.tsx
+++ b/apps/mobile/screen/environment/environment-impact-screen.tsx
@@ -305,7 +305,7 @@ export default function EnvironmentImpactScreen() {
                         buttonSize="compact"
                         loading={vm.history.isFetchingNextPage}
                         onPress={() => {
-                          void vm.history.fetchNextPage();
+                          vm.history.loadMore();
                         }}
                         tone="ghost"
                       >

--- a/apps/mobile/screen/environment/hooks/use-environment-impact-screen.ts
+++ b/apps/mobile/screen/environment/hooks/use-environment-impact-screen.ts
@@ -204,25 +204,53 @@ export function useEnvironmentImpactScreen() {
   );
   const summaryQuery = useEnvironmentSummaryQuery(isAuthenticated, user?.id);
   const historyQuery = useEnvironmentImpactHistoryQuery(historyParams, isAuthenticated, user?.id);
-  const historyItems = useMemo(() => flattenHistory(historyQuery.data?.pages), [historyQuery.data?.pages]);
+  const {
+    data: summary,
+    error: summaryError,
+    isLoading: isSummaryLoading,
+    isRefetching: isSummaryRefetching,
+    refetch: refetchSummary,
+  } = summaryQuery;
+  const {
+    data: historyData,
+    error: historyError,
+    isLoading: isHistoryLoading,
+    isRefetching: isHistoryRefetching,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+    refetch: refetchHistory,
+  } = historyQuery;
+  const historyItems = flattenHistory(historyData?.pages);
   const activeRange = HISTORY_RANGE_OPTIONS.find(option => option.key === selectedRange) ?? HISTORY_RANGE_OPTIONS[0];
 
   const handleRefresh = useCallback(async () => {
     setIsRefreshing(true);
     try {
       await Promise.all([
-        summaryQuery.refetch(),
-        historyQuery.refetch(),
+        refetchSummary(),
+        refetchHistory(),
       ]);
     }
     finally {
       setIsRefreshing(false);
     }
-  }, [historyQuery, summaryQuery]);
+  }, [refetchHistory, refetchSummary]);
 
   const handleOpenDetail = useCallback((rentalId: string) => {
     navigation.navigate("EnvironmentImpactDetail", { rentalId });
   }, [navigation]);
+
+  const handleLoadMoreHistory = useCallback(() => {
+    if (!hasNextPage || isFetchingNextPage) {
+      return;
+    }
+
+    const lastPage = historyData?.pages[historyData.pages.length - 1];
+    const nextPage = lastPage ? lastPage.pagination.page + 1 : 1;
+
+    void fetchNextPage({ pageParam: nextPage });
+  }, [fetchNextPage, hasNextPage, historyData, isFetchingNextPage]);
 
   const handleSelectRange = useCallback((range: HistoryRangeKey) => {
     setDraftRange(range);
@@ -286,20 +314,20 @@ export function useEnvironmentImpactScreen() {
   }, [customRange, selectedRange]);
 
   return {
-    summary: summaryQuery.data ?? null,
-    summaryError: summaryQuery.error,
+    summary: summary ?? null,
+    summaryError,
     historyItems,
     activeRange,
-    isInitialLoading: (!summaryQuery.data && summaryQuery.isLoading)
-      || (historyItems.length === 0 && !historyQuery.data && historyQuery.isLoading),
-    initialError: summaryQuery.error ?? historyQuery.error,
-    isRefreshing: isRefreshing || summaryQuery.isRefetching || historyQuery.isRefetching,
-    hasHistoryRefreshError: Boolean(historyQuery.error) && historyItems.length > 0,
-    historyRefreshError: historyQuery.error,
+    isInitialLoading: (!summary && isSummaryLoading)
+      || (historyItems.length === 0 && !historyData && isHistoryLoading),
+    initialError: summaryError ?? historyError,
+    isRefreshing: isRefreshing || isSummaryRefetching || isHistoryRefetching,
+    hasHistoryRefreshError: Boolean(historyError) && historyItems.length > 0,
+    historyRefreshError: historyError,
     history: {
-      hasNextPage: historyQuery.hasNextPage,
-      isFetchingNextPage: historyQuery.isFetchingNextPage,
-      fetchNextPage: historyQuery.fetchNextPage,
+      hasNextPage,
+      isFetchingNextPage,
+      loadMore: handleLoadMoreHistory,
     },
     filter: {
       isOpen: isFilterOpen,

--- a/apps/mobile/screen/fixed-slot-templates/use-fixed-slot-templates-screen.ts
+++ b/apps/mobile/screen/fixed-slot-templates/use-fixed-slot-templates-screen.ts
@@ -25,10 +25,19 @@ export function useFixedSlotTemplatesScreen({ navigation, routeParams }: UseFixe
     isAuthenticated,
     user?.id,
   );
+  const {
+    data,
+    refetch,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+    isLoading,
+    isRefetching,
+  } = templatesQuery;
 
   const templates = useMemo(
-    () => templatesQuery.data?.pages.flatMap(page => page.data) ?? [],
-    [templatesQuery.data],
+    () => data?.pages.flatMap(page => page.data) ?? [],
+    [data],
   );
 
   const headerTitle = useMemo(() => stationName ?? "Lịch đặt cố định", [stationName]);
@@ -56,18 +65,18 @@ export function useFixedSlotTemplatesScreen({ navigation, routeParams }: UseFixe
     setIsRefreshing(true);
 
     try {
-      await templatesQuery.refetch();
+      await refetch();
     }
     finally {
       setIsRefreshing(false);
     }
-  }, [templatesQuery]);
+  }, [refetch]);
 
   const handleLoadMore = useCallback(() => {
-    if (templatesQuery.hasNextPage && !templatesQuery.isFetchingNextPage) {
-      templatesQuery.fetchNextPage();
+    if (hasNextPage && !isFetchingNextPage) {
+      void fetchNextPage();
     }
-  }, [templatesQuery]);
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
 
   const handleSelectTemplate = useCallback((templateId: string) => {
     navigation.navigate("FixedSlotDetail", { templateId });
@@ -80,10 +89,10 @@ export function useFixedSlotTemplatesScreen({ navigation, routeParams }: UseFixe
     listHeight,
     setListHeight,
     templates,
-    isLoading: templatesQuery.isLoading,
-    isRefreshing: isRefreshing || templatesQuery.isRefetching,
-    isFetchingMore: templatesQuery.isFetchingNextPage,
-    hasNextPage: Boolean(templatesQuery.hasNextPage),
+    isLoading,
+    isRefreshing: isRefreshing || isRefetching,
+    isFetchingMore: isFetchingNextPage,
+    hasNextPage: Boolean(hasNextPage),
     handleCreateTemplate,
     handleRefresh,
     handleLoadMore,

--- a/apps/mobile/screen/rental/booking-history/hooks/use-booking-history.ts
+++ b/apps/mobile/screen/rental/booking-history/hooks/use-booking-history.ts
@@ -34,15 +34,24 @@ export function useBookingHistory() {
     initialPageParam: 1,
     staleTime: 5 * 60 * 1000,
   });
+  const {
+    data,
+    refetch,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+    isLoading,
+    isRefetching,
+  } = query;
 
   const bookings = useMemo(() => {
-    if (!query.data?.pages) {
+    if (!data?.pages) {
       return [];
     }
     const seenIds = new Set<string>();
     const unique: Rental[] = [];
 
-    query.data.pages.forEach((page) => {
+    data.pages.forEach((page) => {
       page.data.forEach((item) => {
         if (item && !seenIds.has(item.id)) {
           seenIds.add(item.id);
@@ -52,30 +61,30 @@ export function useBookingHistory() {
     });
 
     return unique;
-  }, [query.data]);
+  }, [data]);
 
   const onRefresh = useCallback(async () => {
     setIsRefreshing(true);
     try {
-      await query.refetch();
+      await refetch();
     }
     finally {
       setIsRefreshing(false);
     }
-  }, [query]);
+  }, [refetch]);
 
   const loadMore = useCallback(() => {
-    if (query.hasNextPage && !query.isFetchingNextPage) {
-      query.fetchNextPage();
+    if (hasNextPage && !isFetchingNextPage) {
+      void fetchNextPage();
     }
-  }, [query.hasNextPage, query.isFetchingNextPage, query.fetchNextPage]);
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
 
   return {
     bookings,
-    isLoading: query.isLoading && !query.data,
-    isFetchingNextPage: query.isFetchingNextPage,
-    hasNextPage: query.hasNextPage,
-    refreshing: isRefreshing || query.isRefetching,
+    isLoading: isLoading && !data,
+    isFetchingNextPage,
+    hasNextPage,
+    refreshing: isRefreshing || isRefetching,
     onRefresh,
     loadMore,
   };

--- a/apps/mobile/services/environment/environment.service.ts
+++ b/apps/mobile/services/environment/environment.service.ts
@@ -5,6 +5,7 @@ import { kyClient } from "@lib/ky-client";
 import { err, ok } from "@lib/result";
 import { routePath, ServerRoutes } from "@lib/server-routes";
 import { ServerContracts } from "@mebike/shared";
+import { toSearchParams } from "@services/shared/search-params";
 import { StatusCodes } from "http-status-codes";
 
 import type {
@@ -19,27 +20,13 @@ import type { EnvironmentError } from "./environment-error";
 import { asNetworkError, parseEnvironmentError } from "./environment-error";
 
 function buildHistorySearchParams(params: EnvironmentImpactHistoryQuery = {}) {
-  const searchParams = new URLSearchParams();
-
-  const page = params.page ?? 1;
-  const pageSize = params.pageSize ?? 20;
-
-  searchParams.set("page", String(page));
-  searchParams.set("pageSize", String(pageSize));
-
-  if (params.sortOrder) {
-    searchParams.set("sortOrder", params.sortOrder);
-  }
-
-  if (params.dateFrom) {
-    searchParams.set("dateFrom", params.dateFrom);
-  }
-
-  if (params.dateTo) {
-    searchParams.set("dateTo", params.dateTo);
-  }
-
-  return searchParams;
+  return toSearchParams({
+    page: params.page ?? 1,
+    pageSize: params.pageSize ?? 20,
+    sortOrder: params.sortOrder,
+    dateFrom: params.dateFrom,
+    dateTo: params.dateTo,
+  });
 }
 
 export const environmentService = {


### PR DESCRIPTION
## Summary
- fix environment history pagination by sending query params through the same mobile serializer used by the working paginated clients
- preserve paginated query state across wallet, booking history, environment history, and fixed-slot screens by narrowing callback dependencies to stable query methods
- normalize infinite-query page params for environment and fixed-slot hooks so non-number page params do not silently fall back to page 1

## Verification
- ran `pnpm eslint` on the touched mobile files
- verified environment history load more against seeded `user19` data until it advanced beyond the first page