### PR TITLE
Allow guests to open subscriptions

### DIFF
--- a/apps/mobile/components/subscription/subscription-toggle.tsx
+++ b/apps/mobile/components/subscription/subscription-toggle.tsx
@@ -5,32 +5,41 @@ export type SubscriptionSectionKey = "plans" | "history";
 
 type Props = {
   active: SubscriptionSectionKey;
+  historyDisabled?: boolean;
   onChange: (section: SubscriptionSectionKey) => void;
 };
 
-export function SubscriptionToggle({ active, onChange }: Props) {
+export function SubscriptionToggle({ active, historyDisabled = false, onChange }: Props) {
   return (
     <View style={styles.container}>
       <Segment label="Gói tháng" isActive={active === "plans"} onPress={() => onChange("plans")} />
-      <Segment label="Lịch sử" isActive={active === "history"} onPress={() => onChange("history")} />
+      <Segment
+        disabled={historyDisabled}
+        label="Lịch sử"
+        isActive={active === "history"}
+        onPress={() => onChange("history")}
+      />
     </View>
   );
 }
 
 type SegmentProps = {
   label: string;
+  disabled?: boolean;
   isActive: boolean;
   onPress: () => void;
 };
 
-function Segment({ label, isActive, onPress }: SegmentProps) {
+function Segment({ label, disabled = false, isActive, onPress }: SegmentProps) {
   return (
     <TouchableOpacity
-      style={[styles.segment, isActive && styles.segmentActive]}
+      accessibilityState={{ disabled }}
+      disabled={disabled}
+      style={[styles.segment, isActive && styles.segmentActive, disabled && styles.segmentDisabled]}
       onPress={onPress}
       activeOpacity={0.85}
     >
-      <Text style={[styles.segmentText, isActive && styles.segmentTextActive]}>{label}</Text>
+      <Text style={[styles.segmentText, isActive && styles.segmentTextActive, disabled && styles.segmentTextDisabled]}>{label}</Text>
     </TouchableOpacity>
   );
 }
@@ -57,11 +66,17 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.05,
     shadowRadius: 4,
   },
+  segmentDisabled: {
+    opacity: 0.45,
+  },
   segmentText: {
     fontWeight: "600",
     color: "#6B7280",
   },
   segmentTextActive: {
     color: "#111827",
+  },
+  segmentTextDisabled: {
+    color: "#9CA3AF",
   },
 });

--- a/apps/mobile/navigation/root-navigator.tsx
+++ b/apps/mobile/navigation/root-navigator.tsx
@@ -127,6 +127,11 @@ function RootNavigator() {
         component={ResetPasswordFormScreen}
         options={standardScreenOptions}
       />
+      <Stack.Screen
+        name="Subscriptions"
+        component={SubscriptionScreen}
+        options={standardScreenOptions}
+      />
       {isAuthenticated
         ? (
             <>
@@ -168,11 +173,6 @@ function RootNavigator() {
               <Stack.Screen
                 name="MyWallet"
                 component={MyWalletScreen}
-                options={standardScreenOptions}
-              />
-              <Stack.Screen
-                name="Subscriptions"
-                component={SubscriptionScreen}
                 options={standardScreenOptions}
               />
               <Stack.Screen

--- a/apps/mobile/screen/rental/bike-detail/hooks/use-bike-detail-actions.ts
+++ b/apps/mobile/screen/rental/bike-detail/hooks/use-bike-detail-actions.ts
@@ -151,6 +151,7 @@ export function useBikeDetailActions({
     createRentalPayload,
     currentBike.status,
     ensureAuthenticated,
+    hasToken,
     navigation,
     paymentMode,
     queryClient,

--- a/apps/mobile/screen/rental/bike-detail/hooks/use-bike-detail-payment.ts
+++ b/apps/mobile/screen/rental/bike-detail/hooks/use-bike-detail-payment.ts
@@ -1,30 +1,16 @@
 import { useCallback, useEffect, useState } from "react";
-import { Alert } from "react-native";
 
 import type { BikeDetailNavigationProp } from "@/types/navigation";
 import type { Subscription } from "@/types/subscription-types";
 
 import type { PaymentMode } from "../types";
+import { showSubscriptionRequiredAlert } from "../helpers/create-rental-alerts";
 
 type UseBikeDetailPaymentArgs = {
   activeSubscriptions: Subscription[];
   canUseSubscription: boolean;
   navigation: BikeDetailNavigationProp;
 };
-
-function showSubscriptionRequiredAlert(navigation: BikeDetailNavigationProp) {
-  Alert.alert(
-    "Chưa có gói tháng",
-    "Bạn cần đăng ký gói tháng trước khi sử dụng hình thức này.",
-    [
-      { text: "Để sau", style: "cancel" },
-      {
-        text: "Xem gói tháng",
-        onPress: () => navigation.navigate("Subscriptions"),
-      },
-    ],
-  );
-}
 
 export function useBikeDetailPayment({
   activeSubscriptions,

--- a/apps/mobile/screen/subscription/hooks/use-subscription-screen.ts
+++ b/apps/mobile/screen/subscription/hooks/use-subscription-screen.ts
@@ -57,11 +57,17 @@ export function useSubscriptionScreen() {
 
   useEffect(() => {
     loadSubscriptionSection().then((saved) => {
-      if (saved) {
+      if (saved && (isAuthenticated || saved !== "history")) {
         setActiveSection(saved);
       }
     }).catch(() => {});
-  }, []);
+  }, [isAuthenticated]);
+
+  useEffect(() => {
+    if (!isAuthenticated && activeSection === "history") {
+      setActiveSection("plans");
+    }
+  }, [activeSection, isAuthenticated]);
 
   const handleSectionChange = useCallback(async (section: SubscriptionSectionKey) => {
     setActiveSection(section);
@@ -78,10 +84,7 @@ export function useSubscriptionScreen() {
     }
 
     if (!isAuthenticated) {
-      Alert.alert("Đăng nhập trước", "Bạn cần đăng nhập để đăng ký gói tháng", [
-        { text: "Hủy", style: "cancel" },
-        { text: "Đăng nhập", onPress: openLogin },
-      ]);
+      openLogin();
       return;
     }
 
@@ -118,6 +121,14 @@ export function useSubscriptionScreen() {
     );
   }, [isAuthenticated, openLogin, queryClient, status, subscribeMutation]);
 
+  const handleRefresh = useCallback(() => {
+    if (!isAuthenticated) {
+      return;
+    }
+
+    void refetch();
+  }, [isAuthenticated, refetch]);
+
   const handleActivate = useCallback(() => {
     if (!pendingSubscription) {
       return;
@@ -152,7 +163,7 @@ export function useSubscriptionScreen() {
     isAuthenticated,
     isLoading,
     isFetching,
-    refetch,
+    handleRefresh,
     subscriptions,
     activeSubscription,
     pendingSubscription,

--- a/apps/mobile/screen/subscription/index.tsx
+++ b/apps/mobile/screen/subscription/index.tsx
@@ -45,9 +45,10 @@ const styles = StyleSheet.create({
 
 export default function SubscriptionScreen() {
   const {
+    isAuthenticated,
     isLoading,
     isFetching,
-    refetch,
+    handleRefresh,
     subscriptions,
     activeSubscription,
     pendingSubscription,
@@ -66,7 +67,7 @@ export default function SubscriptionScreen() {
   const refreshControl = (
     <RefreshControl
       refreshing={isFetching && !isLoading}
-      onRefresh={refetch}
+      onRefresh={handleRefresh}
       tintColor="#2563EB"
     />
   );
@@ -91,7 +92,11 @@ export default function SubscriptionScreen() {
             activating={activateMutation.isPending}
           />
 
-          <SubscriptionToggle active={activeSection} onChange={handleSectionChange} />
+          <SubscriptionToggle
+            active={activeSection}
+            historyDisabled={!isAuthenticated}
+            onChange={handleSectionChange}
+          />
 
           {activeSection === "plans" && (
             <SubscriptionPlansSection


### PR DESCRIPTION
## Summary
- Move the subscriptions screen into the shared navigation stack so guests can open it from bike and station entry points.
- Keep subscription purchase gated to login, and disable guest history access in the subscription screen.
- Preserve the existing authenticated history/purchase flow for signed-in users.