### PR TITLE
Block duplicate technician teams per station

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,16 @@ apps/iot-service/folder.md
 # Traefik runtime state
 infra/traefik/letsencrypt/
 infra/traefik/logs/
+
+# Local spreadsheet/report artifacts
+*.xlsx
+*.fods
+.tmp-fods-out/
+
+# Python artifacts
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.mypy_cache/
+.venv/
+venv/

--- a/apps/server/src/domain/technician-teams/domain-errors.ts
+++ b/apps/server/src/domain/technician-teams/domain-errors.ts
@@ -15,6 +15,11 @@ export class TechnicianTeamInternalStationRequired extends Data.TaggedError("Tec
   readonly stationType: "INTERNAL" | "AGENCY";
 }> {}
 
+export class TechnicianTeamStationAlreadyAssigned extends Data.TaggedError("TechnicianTeamStationAlreadyAssigned")<{
+  readonly stationId: string;
+  readonly teamId?: string;
+}> {}
+
 export class TechnicianTeamNotFound extends Data.TaggedError("TechnicianTeamNotFound")<{
   readonly id: string;
 }> {}

--- a/apps/server/src/domain/technician-teams/services/technician-team-command.service.ts
+++ b/apps/server/src/domain/technician-teams/services/technician-team-command.service.ts
@@ -8,12 +8,13 @@ import type { TechnicianTeamCommandService } from "./technician-team.service.typ
 import {
   TechnicianTeamInternalStationRequired,
   TechnicianTeamNotFound,
+  TechnicianTeamStationAlreadyAssigned,
   TechnicianTeamStationNotFound,
 } from "../domain-errors";
 
 export function makeTechnicianTeamCommandService(args: {
   commandRepo: TechnicianTeamCommandRepo;
-  queryRepo: Pick<TechnicianTeamQueryRepo, "getById">;
+  queryRepo: Pick<TechnicianTeamQueryRepo, "getById" | "list">;
   stationRepo: Pick<StationQueryRepo, "getById">;
 }): TechnicianTeamCommandService {
   return {
@@ -28,6 +29,14 @@ export function makeTechnicianTeamCommandService(args: {
           return yield* Effect.fail(new TechnicianTeamInternalStationRequired({
             stationId: input.stationId,
             stationType: station.value.stationType,
+          }));
+        }
+
+        const existingTeams = yield* args.queryRepo.list({ stationId: input.stationId });
+        if (existingTeams.length > 0) {
+          return yield* Effect.fail(new TechnicianTeamStationAlreadyAssigned({
+            stationId: input.stationId,
+            teamId: existingTeams[0]!.id,
           }));
         }
 

--- a/apps/server/src/domain/technician-teams/services/technician-team.service.types.ts
+++ b/apps/server/src/domain/technician-teams/services/technician-team.service.types.ts
@@ -3,6 +3,7 @@ import type { Effect } from "effect";
 import type {
   TechnicianTeamInternalStationRequired,
   TechnicianTeamNotFound,
+  TechnicianTeamStationAlreadyAssigned,
   TechnicianTeamStationNotFound,
 } from "../domain-errors";
 import type {
@@ -18,7 +19,7 @@ export type TechnicianTeamCommandService = {
     input: CreateTechnicianTeamInput,
   ) => Effect.Effect<
     TechnicianTeamRow,
-    TechnicianTeamStationNotFound | TechnicianTeamInternalStationRequired
+    TechnicianTeamStationNotFound | TechnicianTeamInternalStationRequired | TechnicianTeamStationAlreadyAssigned
   >;
   updateTechnicianTeam: (
     id: string,

--- a/apps/server/src/http/controllers/technician-teams/admin.controller.ts
+++ b/apps/server/src/http/controllers/technician-teams/admin.controller.ts
@@ -81,6 +81,15 @@ const createTechnicianTeam: RouteHandler<TechnicianTeamsRoutes["adminCreate"]> =
           stationType,
         },
       }, 400)),
+    Match.tag("TechnicianTeamStationAlreadyAssigned", ({ stationId, teamId }) =>
+      c.json<TechnicianTeamErrorResponse, 400>({
+        error: technicianTeamErrorMessages.TECHNICIAN_TEAM_STATION_ALREADY_ASSIGNED,
+        details: {
+          code: TechnicianTeamErrorCodeSchema.enum.TECHNICIAN_TEAM_STATION_ALREADY_ASSIGNED,
+          stationId,
+          teamId,
+        },
+      }, 400)),
     Match.tag("TechnicianTeamStationNotFound", ({ stationId }) =>
       c.json<TechnicianTeamErrorResponse, 400>({
         error: technicianTeamErrorMessages.TECHNICIAN_TEAM_STATION_NOT_FOUND,

--- a/apps/server/src/http/test/e2e/admin-technician-teams-routing.e2e.int.test.ts
+++ b/apps/server/src/http/test/e2e/admin-technician-teams-routing.e2e.int.test.ts
@@ -107,6 +107,28 @@ describe("admin technician teams routing e2e", () => {
     expect(body.memberCount).toBe(0);
   });
 
+  it("rejects create when station already has technician team", async () => {
+    const station = await fixture.factories.station({ name: "Create Team Duplicate Station" });
+    await fixture.factories.technicianTeam({
+      name: "Existing Team For Station",
+      stationId: station.id,
+    });
+
+    const response = await fixture.app.request("http://test/v1/admin/technician-teams", {
+      method: "POST",
+      headers: authHeader(),
+      body: JSON.stringify({
+        name: "Second Team",
+        stationId: station.id,
+      }),
+    });
+    const body = await response.json() as TechnicianTeamsContracts.TechnicianTeamErrorResponse;
+
+    expect(response.status).toBe(400);
+    expect(body.details.code).toBe("TECHNICIAN_TEAM_STATION_ALREADY_ASSIGNED");
+    expect(body.details.stationId).toBe(station.id);
+  });
+
   it("rejects create when station does not exist", async () => {
     const response = await fixture.app.request("http://test/v1/admin/technician-teams", {
       method: "POST",

--- a/packages/shared/src/contracts/server/routes/technician-teams/mutations.ts
+++ b/packages/shared/src/contracts/server/routes/technician-teams/mutations.ts
@@ -34,7 +34,7 @@ export const adminCreateTechnicianTeamRoute = createRoute({
       },
     },
     400: {
-      description: "Invalid payload or station not found",
+      description: "Invalid payload, station not found, or station already assigned",
       content: {
         "application/json": {
           schema: TechnicianTeamErrorResponseSchema,
@@ -55,6 +55,16 @@ export const adminCreateTechnicianTeamRoute = createRoute({
                 details: {
                   code: TechnicianTeamErrorCodeSchema.enum.TECHNICIAN_TEAM_STATION_NOT_FOUND,
                   stationId: "019d1c26-9d34-7f97-ae3c-4c3f0c2d2210",
+                },
+              },
+            },
+            StationAlreadyAssigned: {
+              value: {
+                error: "Station already has a technician team assigned",
+                details: {
+                  code: TechnicianTeamErrorCodeSchema.enum.TECHNICIAN_TEAM_STATION_ALREADY_ASSIGNED,
+                  stationId: "019d1c26-9d34-7f97-ae3c-4c3f0c2d2210",
+                  teamId: "019d1c26-9d34-7f97-ae3c-4c3f0c2d2211",
                 },
               },
             },

--- a/packages/shared/src/contracts/server/technician-teams/errors.ts
+++ b/packages/shared/src/contracts/server/technician-teams/errors.ts
@@ -2,12 +2,14 @@ import { z } from "../../../zod";
 
 export const TechnicianTeamErrorCodeSchema = z.enum([
   "TECHNICIAN_TEAM_INTERNAL_STATION_REQUIRED",
+  "TECHNICIAN_TEAM_STATION_ALREADY_ASSIGNED",
   "TECHNICIAN_TEAM_NOT_FOUND",
   "TECHNICIAN_TEAM_STATION_NOT_FOUND",
 ]);
 
 export const technicianTeamErrorMessages = {
   TECHNICIAN_TEAM_INTERNAL_STATION_REQUIRED: "Technician teams require an internal station",
+  TECHNICIAN_TEAM_STATION_ALREADY_ASSIGNED: "Station already has a technician team assigned",
   TECHNICIAN_TEAM_NOT_FOUND: "Technician team not found",
   TECHNICIAN_TEAM_STATION_NOT_FOUND: "Station not found for technician team",
 } as const satisfies Record<z.infer<typeof TechnicianTeamErrorCodeSchema>, string>;


### PR DESCRIPTION
## Summary
- block technician team creation when an internal station already has a team assigned
- keep the existing internal-station validation and return a dedicated API error for duplicate station assignment
- add routing test coverage for the duplicate-team create path