### PR TITLE
fix(mobile): guard navigation for guest and auth flows

### DIFF
--- a/apps/mobile/screen/auth/email-verification/hooks/use-email-verification.ts
+++ b/apps/mobile/screen/auth/email-verification/hooks/use-email-verification.ts
@@ -1,13 +1,13 @@
 import type { StackNavigationProp } from "@react-navigation/stack";
 
+import { useResendVerifyEmailMutation } from "@hooks/mutations/AuthNext/use-resend-verify-email-mutation";
+import { useVerifyEmailOtpMutation } from "@hooks/mutations/AuthNext/use-verify-email-otp-mutation";
+import { useAuthNext } from "@providers/auth-provider-next";
 import { useIsFocused, useNavigation, useRoute } from "@react-navigation/native";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Alert } from "react-native";
 
 import { presentAuthError } from "@/presenters/auth/auth-error-presenter";
-import { useResendVerifyEmailMutation } from "@hooks/mutations/AuthNext/use-resend-verify-email-mutation";
-import { useVerifyEmailOtpMutation } from "@hooks/mutations/AuthNext/use-verify-email-otp-mutation";
-import { useAuthNext } from "@providers/auth-provider-next";
 
 import type { RootStackParamList } from "../../../../types/navigation";
 
@@ -150,6 +150,13 @@ export function useEmailVerification() {
 
   const canResend = resendTimeLeft <= 0 && !resendMutation.isPending;
 
+  const resetToMain = useCallback(() => {
+    navigation.reset({
+      index: 0,
+      routes: [{ name: "Main" }],
+    });
+  }, [navigation]);
+
   const setOtpDigit = useCallback((index: number, value: string) => {
     const next = value.slice(-1);
     setOtp((prev) => {
@@ -176,8 +183,8 @@ export function useEmailVerification() {
     }
 
     await hydrate();
-    navigation.navigate("Main");
-  }, [hydrate, isOtpComplete, navigation, otpCode, user?.id, verifyMutation]);
+    resetToMain();
+  }, [hydrate, isOtpComplete, otpCode, resetToMain, user?.id, verifyMutation]);
 
   const resend = useCallback(async () => {
     if (!canResend) {
@@ -213,20 +220,20 @@ export function useEmailVerification() {
         { text: "Không", style: "cancel" },
         {
           text: "Có, bỏ qua",
-          onPress: () => navigation.navigate("Main"),
+          onPress: resetToMain,
         },
       ],
     );
-  }, [navigation]);
+  }, [resetToMain]);
 
   const goBack = useCallback(() => {
     if (!navigation.canGoBack()) {
-      navigation.navigate("Main");
+      resetToMain();
       return;
     }
 
     navigation.goBack();
-  }, [navigation]);
+  }, [navigation, resetToMain]);
 
   return {
     email,

--- a/apps/mobile/screen/auth/reset-password-form/index.tsx
+++ b/apps/mobile/screen/auth/reset-password-form/index.tsx
@@ -152,7 +152,10 @@ export default function ResetPasswordFormScreen() {
       }
 
       Alert.alert("Thành công", "Đặt lại mật khẩu thành công");
-      navigation.navigate("Login");
+      navigation.reset({
+        index: 0,
+        routes: [{ name: "Login" }],
+      });
     }
     catch (error) {
       Alert.alert("Lỗi", error instanceof Error ? error.message : "Không thể đặt lại mật khẩu.");

--- a/apps/mobile/screen/station-detail/index.tsx
+++ b/apps/mobile/screen/station-detail/index.tsx
@@ -1,19 +1,20 @@
-import { useQueryClient } from "@tanstack/react-query";
-import { Alert, RefreshControl, ScrollView, View } from "react-native";
-import { useTheme, YStack } from "tamagui";
-
-import { presentRentalError } from "@/presenters/rentals/rental-error-presenter";
 import { IconSymbol } from "@components/IconSymbol";
 import { LoadingScreen } from "@components/LoadingScreen";
 import { useCreateMyReturnSlotMutation } from "@hooks/mutations/rentals/use-create-my-return-slot-mutation";
 import { useRequestBikeSwapMutation } from "@hooks/mutations/rentals/use-request-bike-swap-mutation";
 import { invalidateMyRentalQueries } from "@hooks/rentals/rental-cache";
 import { useMyBikeSwapPreview } from "@hooks/rentals/use-my-bike-swap-preview";
+import { useAuthNext } from "@providers/auth-provider-next";
+import { useQueryClient } from "@tanstack/react-query";
 import { spaceScale } from "@theme/metrics";
 import { AppButton } from "@ui/primitives/app-button";
 import { AppCard } from "@ui/primitives/app-card";
 import { AppText } from "@ui/primitives/app-text";
 import { Screen } from "@ui/primitives/screen";
+import { Alert, RefreshControl, ScrollView, View } from "react-native";
+import { useTheme, YStack } from "tamagui";
+
+import { presentRentalError } from "@/presenters/rentals/rental-error-presenter";
 import {
   getOvernightOperationsClosedMessage,
   isWithinVietnamOvernightOperationsWindow,
@@ -28,6 +29,7 @@ import { useStationDetail } from "./hooks/use-station-detail";
 export default function StationDetailScreen() {
   const queryClient = useQueryClient();
   const theme = useTheme();
+  const { isAuthenticated } = useAuthNext();
   const returnSlotMutation = useCreateMyReturnSlotMutation();
   const bikeSwapMutation = useRequestBikeSwapMutation();
   const {
@@ -126,6 +128,22 @@ export default function StationDetailScreen() {
         },
       },
     );
+  };
+
+  const handleOpenFixedSlots = () => {
+    if (!isAuthenticated) {
+      Alert.alert("Cần đăng nhập", "Vui lòng đăng nhập để sử dụng tính năng này.");
+      return;
+    }
+
+    if (!station) {
+      return;
+    }
+
+    navigation.navigate("FixedSlotTemplates", {
+      stationId: station.id,
+      stationName: station.name,
+    });
   };
 
   if (isLoading) {
@@ -234,10 +252,7 @@ export default function StationDetailScreen() {
               )
             : null}
           <FixedSlotBanner
-            onPress={() => navigation.navigate("FixedSlotTemplates", {
-              stationId: station.id,
-              stationName: station.name,
-            })}
+            onPress={handleOpenFixedSlots}
           />
           <BikeList
             bikes={loadedBikes}


### PR DESCRIPTION
## Summary
- Show a Vietnamese login-required alert when guests tap the fixed-slot banner instead of navigating to an auth-only screen.
- Reset navigation history after email verification success/skip so auth screens are not left behind.
- Reset navigation history after password reset success so OTP/reset-token screens are not left behind.

## Verification
- pnpm exec eslint apps/mobile/screen/station-detail/index.tsx apps/mobile/screen/auth/email-verification/hooks/use-email-verification.ts apps/mobile/screen/auth/reset-password-form/index.tsx
- pnpm exec tsc --noEmit *(still fails on unrelated existing error in apps/mobile/screen/environment/hooks/use-environment-impact-screen.ts:252)*