### PR TITLE
fix(server): allow agency access to operator station context

### DIFF
--- a/apps/server/src/http/middlewares/auth.ts
+++ b/apps/server/src/http/middlewares/auth.ts
@@ -129,6 +129,7 @@ export const requireAgencyMiddleware = requireRoles("AGENCY");
 export const requireManagerMiddleware = requireRoles("MANAGER");
 export const requireStaffMiddleware = requireRoles("STAFF");
 export const requireStaffOrManagerMiddleware = requireRoles("STAFF", "MANAGER");
+export const requireStaffOrManagerOrAgencyMiddleware = requireRoles("STAFF", "MANAGER", "AGENCY");
 export const requireStationScopedOperatorMiddleware = requireRoles("STAFF", "MANAGER", "TECHNICIAN");
 export const requireUserMiddleware = requireRoles("USER");
 export const requireTechnicianMiddleware = requireRoles("TECHNICIAN");

--- a/apps/server/src/http/routes/operators.ts
+++ b/apps/server/src/http/routes/operators.ts
@@ -3,14 +3,14 @@ import type { RouteConfig } from "@hono/zod-openapi";
 import { serverRoutes } from "@mebike/shared";
 
 import { OperatorController } from "@/http/controllers/operators.controller";
-import { requireStaffOrManagerMiddleware } from "@/http/middlewares/auth";
+import { requireStaffOrManagerOrAgencyMiddleware } from "@/http/middlewares/auth";
 
 export function registerOperatorRoutes(app: import("@hono/zod-openapi").OpenAPIHono) {
   const operators = serverRoutes.operators;
 
   const stationContextRoute = {
     ...operators.stationContext,
-    middleware: [requireStaffOrManagerMiddleware] as const,
+    middleware: [requireStaffOrManagerOrAgencyMiddleware] as const,
   } satisfies RouteConfig;
 
   app.openapi(stationContextRoute, OperatorController.getStationContext);

--- a/apps/server/src/http/test/e2e/operator-station-context-routing.e2e.int.test.ts
+++ b/apps/server/src/http/test/e2e/operator-station-context-routing.e2e.int.test.ts
@@ -120,6 +120,40 @@ describe("operator station context routing e2e", () => {
     expect(body.otherStations.some(station => station.id === otherStation.id)).toBe(true);
   });
 
+  it("allows agency to read station context for its assigned station", async () => {
+    const agency = await fixture.prisma.agency.create({
+      data: {
+        name: "Agency Context",
+        status: "ACTIVE",
+      },
+    });
+    const currentStation = await fixture.factories.station({
+      name: "Agency Station",
+      address: "11 Agency Street, Thu Duc, TP.HCM",
+      stationType: "AGENCY",
+      agencyId: agency.id,
+    });
+    const otherStation = await fixture.factories.station({
+      name: "Agency Other Station",
+      address: "12 Agency Street, Thu Duc, TP.HCM",
+    });
+    const agencyUser = await fixture.factories.user({ role: "AGENCY" });
+    await fixture.factories.userOrgAssignment({ userId: agencyUser.id, agencyId: agency.id });
+    const token = fixture.auth.makeAccessToken({ userId: agencyUser.id, role: "AGENCY" });
+
+    const response = await fixture.app.request("http://test/v1/operators/station-context", {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    const body = await response.json() as OperatorsContracts.OperatorStationContextResponse;
+
+    expect(response.status).toBe(200);
+    expect(body.currentStation.id).toBe(currentStation.id);
+    expect(body.otherStations.some(station => station.id === otherStation.id)).toBe(true);
+  });
+
   it("rejects regular users", async () => {
     const user = await fixture.factories.user({ role: "USER" });
     const token = fixture.auth.makeAccessToken({ userId: user.id, role: "USER" });


### PR DESCRIPTION
## Summary
- Allow agency users to read the operator station context endpoint alongside staff and managers.
- Add a dedicated agency e2e test for the station-context route.

## Verification
- pnpm tsc --noEmit
- pnpm vitest run --config vitest.int.config.ts --mode test src/http/test/e2e/operator-station-context-routing.e2e.int.test.ts