### PR TITLE
feat(server): add technician team detail endpoint

### DIFF
--- a/apps/server/src/domain/technician-teams/models.ts
+++ b/apps/server/src/domain/technician-teams/models.ts
@@ -1,4 +1,4 @@
-import type { TechnicianTeamAvailability } from "generated/prisma/client";
+import type { TechnicianTeamAvailability, UserRole } from "generated/prisma/client";
 
 export const TECHNICIAN_TEAM_MEMBER_LIMIT = 3;
 
@@ -27,6 +27,17 @@ export type TechnicianTeamRow = {
   readonly memberCount: number;
   readonly createdAt: Date;
   readonly updatedAt: Date;
+};
+
+export type TechnicianTeamMemberRow = {
+  readonly userId: string;
+  readonly fullName: string;
+  readonly role: UserRole;
+};
+
+export type TechnicianTeamDetailRow = TechnicianTeamRow & {
+  readonly stationAddress: string;
+  readonly members: readonly TechnicianTeamMemberRow[];
 };
 
 export type TechnicianTeamAvailableOption = {

--- a/apps/server/src/domain/technician-teams/repository/read/technician-team.read.repository.ts
+++ b/apps/server/src/domain/technician-teams/repository/read/technician-team.read.repository.ts
@@ -5,14 +5,11 @@ import type { PrismaClient, Prisma as PrismaTypes } from "generated/prisma/clien
 import { defectOn } from "@/domain/shared";
 import { pickDefined } from "@/domain/shared/pick-defined";
 
-import type { TechnicianTeamAvailableOption, TechnicianTeamRow } from "../../models";
+import type { TechnicianTeamAvailableOption, TechnicianTeamDetailRow, TechnicianTeamRow } from "../../models";
 import type { TechnicianTeamQueryRepo } from "../technician-team.repository.types";
 
 import { TechnicianTeamRepositoryError } from "../../domain-errors";
-import {
-  TECHNICIAN_TEAM_MEMBER_LIMIT,
-
-} from "../../models";
+import { TECHNICIAN_TEAM_MEMBER_LIMIT } from "../../models";
 
 export function makeTechnicianTeamReadRepository(
   client: PrismaClient | PrismaTypes.TransactionClient,
@@ -35,6 +32,32 @@ export function makeTechnicianTeamReadRepository(
     memberCount: row._count.userAssignments,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
+  });
+
+  const mapDetailRow = (row: {
+    id: string;
+    name: string;
+    stationId: string;
+    station: { name: string; address: string };
+    availabilityStatus: import("generated/prisma/client").TechnicianTeamAvailability;
+    createdAt: Date;
+    updatedAt: Date;
+    _count: { userAssignments: number };
+    userAssignments: ReadonlyArray<{
+      user: {
+        id: string;
+        fullName: string;
+        role: import("generated/prisma/client").UserRole;
+      };
+    }>;
+  }): TechnicianTeamDetailRow => ({
+    ...mapRow(row),
+    stationAddress: row.station.address,
+    members: row.userAssignments.map(assignment => ({
+      userId: assignment.user.id,
+      fullName: assignment.user.fullName,
+      role: assignment.user.role,
+    })),
   });
 
   return {
@@ -71,6 +94,56 @@ export function makeTechnicianTeamReadRepository(
         Effect.map(row =>
           Option.fromNullable(row).pipe(
             Option.map(mapRow),
+          ),
+        ),
+        defectOn(TechnicianTeamRepositoryError),
+      ),
+
+    getDetailById: id =>
+      Effect.tryPromise({
+        try: () =>
+          client.technicianTeam.findUnique({
+            where: { id },
+            select: {
+              id: true,
+              name: true,
+              stationId: true,
+              station: {
+                select: {
+                  name: true,
+                  address: true,
+                },
+              },
+              availabilityStatus: true,
+              createdAt: true,
+              updatedAt: true,
+              _count: {
+                select: {
+                  userAssignments: true,
+                },
+              },
+              userAssignments: {
+                select: {
+                  user: {
+                    select: {
+                      id: true,
+                      fullName: true,
+                      role: true,
+                    },
+                  },
+                },
+              },
+            },
+          }),
+        catch: cause =>
+          new TechnicianTeamRepositoryError({
+            operation: "getDetailById",
+            cause,
+          }),
+      }).pipe(
+        Effect.map(row =>
+          Option.fromNullable(row).pipe(
+            Option.map(mapDetailRow),
           ),
         ),
         defectOn(TechnicianTeamRepositoryError),

--- a/apps/server/src/domain/technician-teams/repository/technician-team.repository.types.ts
+++ b/apps/server/src/domain/technician-teams/repository/technician-team.repository.types.ts
@@ -3,6 +3,7 @@ import type { Effect, Option } from "effect";
 import type {
   CreateTechnicianTeamInput,
   TechnicianTeamAvailableOption,
+  TechnicianTeamDetailRow,
   TechnicianTeamFilter,
   TechnicianTeamRow,
   UpdateTechnicianTeamInput,
@@ -12,6 +13,9 @@ export type TechnicianTeamQueryRepo = {
   readonly getById: (
     id: string,
   ) => Effect.Effect<Option.Option<TechnicianTeamRow>>;
+  readonly getDetailById: (
+    id: string,
+  ) => Effect.Effect<Option.Option<TechnicianTeamDetailRow>>;
   readonly list: (args?: TechnicianTeamFilter) => Effect.Effect<readonly TechnicianTeamRow[]>;
   readonly listAvailable: (args?: {
     readonly stationId?: string;

--- a/apps/server/src/domain/technician-teams/services/technician-team-query.service.ts
+++ b/apps/server/src/domain/technician-teams/services/technician-team-query.service.ts
@@ -1,10 +1,21 @@
+import { Effect, Option } from "effect";
+
 import type { TechnicianTeamQueryRepo } from "../repository/technician-team.repository.types";
 import type { TechnicianTeamQueryService } from "./technician-team.service.types";
+
+import { TechnicianTeamNotFound } from "../domain-errors";
 
 export function makeTechnicianTeamQueryService(
   repo: TechnicianTeamQueryRepo,
 ): TechnicianTeamQueryService {
   return {
+    getTechnicianTeamDetail: id =>
+      repo.getDetailById(id).pipe(
+        Effect.flatMap(Option.match({
+          onNone: () => Effect.fail(new TechnicianTeamNotFound({ id })),
+          onSome: Effect.succeed,
+        })),
+      ),
     listTechnicianTeams: filter => repo.list(filter),
     listAvailableTechnicianTeams: args => repo.listAvailable(args),
   };

--- a/apps/server/src/domain/technician-teams/services/technician-team.service.types.ts
+++ b/apps/server/src/domain/technician-teams/services/technician-team.service.types.ts
@@ -9,6 +9,7 @@ import type {
 import type {
   CreateTechnicianTeamInput,
   TechnicianTeamAvailableOption,
+  TechnicianTeamDetailRow,
   TechnicianTeamFilter,
   TechnicianTeamRow,
   UpdateTechnicianTeamInput,
@@ -28,6 +29,9 @@ export type TechnicianTeamCommandService = {
 };
 
 export type TechnicianTeamQueryService = {
+  getTechnicianTeamDetail: (
+    id: string,
+  ) => Effect.Effect<TechnicianTeamDetailRow, TechnicianTeamNotFound>;
   listTechnicianTeams: (
     filter?: TechnicianTeamFilter,
   ) => Effect.Effect<readonly TechnicianTeamRow[]>;

--- a/apps/server/src/http/controllers/technician-teams/admin.controller.ts
+++ b/apps/server/src/http/controllers/technician-teams/admin.controller.ts
@@ -8,11 +8,13 @@ import {
 } from "@/domain/technician-teams";
 import {
   toContractAvailableTechnicianTeam,
+  toContractTechnicianTeamDetail,
   toContractTechnicianTeamSummary,
 } from "@/http/presenters/technician-teams.presenter";
 
 import type {
   TechnicianTeamAvailableListResponse,
+  TechnicianTeamDetailResponse,
   TechnicianTeamErrorResponse,
   TechnicianTeamListResponse,
   TechnicianTeamsRoutes,
@@ -53,6 +55,35 @@ const listAvailableTechnicianTeams: RouteHandler<TechnicianTeamsRoutes["adminAva
   return c.json<TechnicianTeamAvailableListResponse, 200>({
     data: result.map(toContractAvailableTechnicianTeam),
   }, 200);
+};
+
+const getTechnicianTeam: RouteHandler<TechnicianTeamsRoutes["adminGet"]> = async (c) => {
+  const { teamId } = c.req.valid("param");
+
+  const eff = Effect.flatMap(TechnicianTeamQueryServiceTag, service =>
+    service.getTechnicianTeamDetail(teamId));
+
+  const result = await c.var.runPromise(eff.pipe(Effect.either));
+
+  if (result._tag === "Right") {
+    return c.json<TechnicianTeamDetailResponse, 200>({
+      data: toContractTechnicianTeamDetail(result.right),
+    }, 200);
+  }
+
+  return Match.value(result.left).pipe(
+    Match.tag("TechnicianTeamNotFound", ({ id }) =>
+      c.json<TechnicianTeamErrorResponse, 404>({
+        error: technicianTeamErrorMessages.TECHNICIAN_TEAM_NOT_FOUND,
+        details: {
+          code: TechnicianTeamErrorCodeSchema.enum.TECHNICIAN_TEAM_NOT_FOUND,
+          teamId: id,
+        },
+      }, 404)),
+    Match.orElse((err) => {
+      throw err;
+    }),
+  );
 };
 
 const createTechnicianTeam: RouteHandler<TechnicianTeamsRoutes["adminCreate"]> = async (c) => {
@@ -137,6 +168,7 @@ const updateTechnicianTeam: RouteHandler<TechnicianTeamsRoutes["adminUpdate"]> =
 
 export const TechnicianTeamAdminController = {
   createTechnicianTeam,
+  getTechnicianTeam,
   listAvailableTechnicianTeams,
   listTechnicianTeams,
   updateTechnicianTeam,

--- a/apps/server/src/http/controllers/technician-teams/shared.ts
+++ b/apps/server/src/http/controllers/technician-teams/shared.ts
@@ -5,6 +5,7 @@ export type TechnicianTeamsRoutes = typeof import("@mebike/shared")["serverRoute
 export const { TechnicianTeamErrorCodeSchema, technicianTeamErrorMessages } = TechnicianTeamsContracts;
 
 export type TechnicianTeamSummary = TechnicianTeamsContracts.TechnicianTeamSummary;
+export type TechnicianTeamDetailResponse = TechnicianTeamsContracts.TechnicianTeamDetailResponse;
 export type TechnicianTeamListResponse = TechnicianTeamsContracts.TechnicianTeamListResponse;
 export type TechnicianTeamAvailableListResponse = TechnicianTeamsContracts.TechnicianTeamAvailableListResponse;
 export type TechnicianTeamErrorResponse = TechnicianTeamsContracts.TechnicianTeamErrorResponse;

--- a/apps/server/src/http/presenters/technician-teams.presenter.ts
+++ b/apps/server/src/http/presenters/technician-teams.presenter.ts
@@ -2,6 +2,7 @@ import type { TechnicianTeamsContracts } from "@mebike/shared";
 
 import type {
   TechnicianTeamAvailableOption,
+  TechnicianTeamDetailRow,
   TechnicianTeamRow,
 } from "@/domain/technician-teams";
 
@@ -29,5 +30,23 @@ export function toContractAvailableTechnicianTeam(
     id: team.id,
     name: team.name,
     stationId: team.stationId,
+  };
+}
+
+export function toContractTechnicianTeamDetail(
+  team: TechnicianTeamDetailRow,
+): TechnicianTeamsContracts.TechnicianTeamDetail {
+  return {
+    ...toContractTechnicianTeamSummary(team),
+    station: {
+      id: team.stationId,
+      name: team.stationName,
+      address: team.stationAddress,
+    },
+    members: team.members.map(member => ({
+      userId: member.userId,
+      fullName: member.fullName,
+      role: member.role,
+    })),
   };
 }

--- a/apps/server/src/http/routes/technician-teams.ts
+++ b/apps/server/src/http/routes/technician-teams.ts
@@ -17,6 +17,10 @@ export function registerTechnicianTeamRoutes(
     ...technicianTeams.adminAvailable,
     middleware: [requireAdminMiddleware] as const,
   } satisfies RouteConfig;
+  const adminGetRoute = {
+    ...technicianTeams.adminGet,
+    middleware: [requireAdminMiddleware] as const,
+  } satisfies RouteConfig;
   const adminCreateRoute = {
     ...technicianTeams.adminCreate,
     middleware: [requireAdminMiddleware] as const,
@@ -27,6 +31,7 @@ export function registerTechnicianTeamRoutes(
   } satisfies RouteConfig;
 
   app.openapi(adminAvailableRoute, TechnicianTeamAdminController.listAvailableTechnicianTeams);
+  app.openapi(adminGetRoute, TechnicianTeamAdminController.getTechnicianTeam);
   app.openapi(adminListRoute, TechnicianTeamAdminController.listTechnicianTeams);
   app.openapi(adminCreateRoute, TechnicianTeamAdminController.createTechnicianTeam);
   app.openapi(adminUpdateRoute, TechnicianTeamAdminController.updateTechnicianTeam);

--- a/apps/server/src/http/test/e2e/admin-technician-teams-routing.e2e.int.test.ts
+++ b/apps/server/src/http/test/e2e/admin-technician-teams-routing.e2e.int.test.ts
@@ -86,6 +86,64 @@ describe("admin technician teams routing e2e", () => {
     expect(body.data[0]?.memberCount).toBe(1);
   });
 
+  it("gets technician team detail with station address and members", async () => {
+    const station = await fixture.factories.station({
+      name: "Detail Team Station",
+      address: "88 Detail Street, Thu Duc, TP.HCM",
+    });
+    const team = await fixture.factories.technicianTeam({
+      name: "Detail Team",
+      stationId: station.id,
+    });
+    const technician = await fixture.factories.user({
+      fullname: "Detail Technician",
+      email: "detail-technician@example.com",
+      role: "TECHNICIAN",
+    });
+
+    await fixture.factories.userOrgAssignment({
+      userId: technician.id,
+      technicianTeamId: team.id,
+    });
+
+    const response = await fixture.app.request(`http://test/v1/admin/technician-teams/${team.id}`, {
+      method: "GET",
+      headers: authHeader(),
+    });
+    const body = await response.json() as TechnicianTeamsContracts.TechnicianTeamDetailResponse;
+
+    expect(response.status).toBe(200);
+    expect(body.data).toMatchObject({
+      id: team.id,
+      name: "Detail Team",
+      station: {
+        id: station.id,
+        name: "Detail Team Station",
+        address: "88 Detail Street, Thu Duc, TP.HCM",
+      },
+      availabilityStatus: "AVAILABLE",
+      memberCount: 1,
+    });
+    expect(body.data.members).toEqual([
+      {
+        userId: technician.id,
+        fullName: "Detail Technician",
+        role: "TECHNICIAN",
+      },
+    ]);
+  });
+
+  it("returns 404 when getting missing technician team", async () => {
+    const response = await fixture.app.request(`http://test/v1/admin/technician-teams/${uuidv7()}`, {
+      method: "GET",
+      headers: authHeader(),
+    });
+    const body = await response.json() as TechnicianTeamsContracts.TechnicianTeamErrorResponse;
+
+    expect(response.status).toBe(404);
+    expect(body.details.code).toBe("TECHNICIAN_TEAM_NOT_FOUND");
+  });
+
   it("creates technician team for an existing station", async () => {
     const station = await fixture.factories.station({ name: "Create Team Station" });
 

--- a/packages/shared/src/contracts/server/routes/technician-teams/queries.ts
+++ b/packages/shared/src/contracts/server/routes/technician-teams/queries.ts
@@ -3,6 +3,10 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { forbiddenResponse, unauthorizedResponse } from "../helpers";
 import {
   TechnicianTeamAvailableListResponseSchema,
+  TechnicianTeamDetailResponseSchema,
+  TechnicianTeamErrorCodeSchema,
+  TechnicianTeamErrorResponseSchema,
+  TechnicianTeamIdParamSchema,
   TechnicianTeamListQuerySchema,
   TechnicianTeamListResponseSchema,
 } from "./shared";
@@ -53,7 +57,49 @@ export const adminAvailableTechnicianTeamsRoute = createRoute({
   },
 });
 
+export const adminGetTechnicianTeamRoute = createRoute({
+  method: "get",
+  path: "/v1/admin/technician-teams/{teamId}",
+  tags: ["Technician Teams"],
+  security: [{ bearerAuth: [] }],
+  request: {
+    params: TechnicianTeamIdParamSchema,
+  },
+  responses: {
+    200: {
+      description: "Admin technician team detail",
+      content: {
+        "application/json": {
+          schema: TechnicianTeamDetailResponseSchema,
+        },
+      },
+    },
+    404: {
+      description: "Technician team not found",
+      content: {
+        "application/json": {
+          schema: TechnicianTeamErrorResponseSchema,
+          examples: {
+            TeamNotFound: {
+              value: {
+                error: "Technician team not found",
+                details: {
+                  code: TechnicianTeamErrorCodeSchema.enum.TECHNICIAN_TEAM_NOT_FOUND,
+                  teamId: "019d1c26-9d34-7f97-ae3c-4c3f0c2d2210",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    401: unauthorizedResponse(),
+    403: forbiddenResponse("Admin"),
+  },
+});
+
 export const technicianTeamQueries = {
   adminAvailable: adminAvailableTechnicianTeamsRoute,
+  adminGet: adminGetTechnicianTeamRoute,
   adminList: adminListTechnicianTeamsRoute,
 } as const;

--- a/packages/shared/src/contracts/server/routes/technician-teams/shared.ts
+++ b/packages/shared/src/contracts/server/routes/technician-teams/shared.ts
@@ -5,6 +5,8 @@ import {
 import {
   TechnicianTeamAvailabilitySchema,
   TechnicianTeamAvailableOptionSchema,
+  TechnicianTeamDetailResponseSchema,
+  TechnicianTeamDetailSchema,
   TechnicianTeamErrorCodeSchema,
   TechnicianTeamErrorResponseSchema,
   TechnicianTeamSummarySchema,
@@ -61,6 +63,8 @@ export {
   ServerErrorResponseSchema,
   TechnicianTeamAvailabilitySchema,
   TechnicianTeamAvailableOptionSchema,
+  TechnicianTeamDetailResponseSchema,
+  TechnicianTeamDetailSchema,
   TechnicianTeamErrorCodeSchema,
   TechnicianTeamErrorResponseSchema,
   TechnicianTeamSummarySchema,

--- a/packages/shared/src/contracts/server/technician-teams/index.ts
+++ b/packages/shared/src/contracts/server/technician-teams/index.ts
@@ -1,5 +1,9 @@
 import { z } from "../../../zod";
-import { TechnicianTeamAvailableOptionSchema, TechnicianTeamSummarySchema } from "./models";
+import {
+  TechnicianTeamAvailableOptionSchema,
+  TechnicianTeamDetailSchema,
+  TechnicianTeamSummarySchema,
+} from "./models";
 
 export * from "./errors";
 export * from "./models";
@@ -12,10 +16,18 @@ export const TechnicianTeamAvailableListResponseSchema = z.object({
   data: z.array(TechnicianTeamAvailableOptionSchema),
 });
 
+export const TechnicianTeamDetailResponseSchema = z.object({
+  data: TechnicianTeamDetailSchema,
+});
+
 export type TechnicianTeamListResponse = {
   data: z.infer<typeof TechnicianTeamSummarySchema>[];
 };
 
 export type TechnicianTeamAvailableListResponse = {
   data: z.infer<typeof TechnicianTeamAvailableOptionSchema>[];
+};
+
+export type TechnicianTeamDetailResponse = {
+  data: z.infer<typeof TechnicianTeamDetailSchema>;
 };

--- a/packages/shared/src/contracts/server/technician-teams/models.ts
+++ b/packages/shared/src/contracts/server/technician-teams/models.ts
@@ -1,10 +1,21 @@
 import { z } from "../../../zod";
+import { UserRoleSchema } from "../users/schemas";
 
 export const TechnicianTeamAvailabilitySchema = z.enum(["AVAILABLE", "UNAVAILABLE"]);
 
 export const TechnicianTeamStationRefSchema = z.object({
   id: z.uuidv7(),
   name: z.string(),
+});
+
+export const TechnicianTeamDetailStationSchema = TechnicianTeamStationRefSchema.extend({
+  address: z.string(),
+});
+
+export const TechnicianTeamMemberSchema = z.object({
+  userId: z.uuidv7(),
+  fullName: z.string(),
+  role: UserRoleSchema,
 });
 
 export const TechnicianTeamSummarySchema = z.object({
@@ -17,6 +28,11 @@ export const TechnicianTeamSummarySchema = z.object({
   updatedAt: z.string().datetime(),
 });
 
+export const TechnicianTeamDetailSchema = TechnicianTeamSummarySchema.extend({
+  station: TechnicianTeamDetailStationSchema,
+  members: z.array(TechnicianTeamMemberSchema),
+});
+
 export const TechnicianTeamAvailableOptionSchema = z.object({
   id: z.uuidv7(),
   name: z.string(),
@@ -24,5 +40,7 @@ export const TechnicianTeamAvailableOptionSchema = z.object({
 });
 
 export type TechnicianTeamSummary = z.infer<typeof TechnicianTeamSummarySchema>;
+export type TechnicianTeamDetail = z.infer<typeof TechnicianTeamDetailSchema>;
+export type TechnicianTeamMember = z.infer<typeof TechnicianTeamMemberSchema>;
 export type TechnicianTeamAvailableOption = z.infer<typeof TechnicianTeamAvailableOptionSchema>;
 export type TechnicianTeamAvailability = z.infer<typeof TechnicianTeamAvailabilitySchema>;


### PR DESCRIPTION
## Summary
- Add `GET /v1/admin/technician-teams/{teamId}` for admin technician team detail.
- Include station address and team members in the detail response.
- Add e2e coverage for detail success and missing-team 404.

## Verification
- pnpm --dir ../../packages/shared build
- pnpm tsc --noEmit
- pnpm vitest run --config vitest.int.config.ts --mode test src/http/test/e2e/admin-technician-teams-routing.e2e.int.test.ts