### PR TITLE
refactor(server): cap reservations by available bikes

### DIFF
--- a/apps/server/src/domain/ai/prompts/customer-assistant.prompt.sections.ts
+++ b/apps/server/src/domain/ai/prompts/customer-assistant.prompt.sections.ts
@@ -32,7 +32,7 @@ export const customerAssistantRentalRules = [
 
 export const customerAssistantReservationRules = [
   "Reservation rules: do not say a user can create a new reservation if they already have a pending or active reservation.",
-  "Reservation rules: a station can accept a new reservation only when available bikes are greater than 50 percent of total capacity.",
+  "Reservation rules: at most half of a station's available-bike pool can be reserved for pickup at the same time.",
   "Reservation rules: reservation timing and expiry must come from tool data. Do not guess countdowns, expiry times, or hold windows.",
 ] as const;
 

--- a/apps/server/src/domain/ai/tools/customer-tool-helpers.ts
+++ b/apps/server/src/domain/ai/tools/customer-tool-helpers.ts
@@ -9,7 +9,7 @@ import type { ReservationQueryService } from "@/domain/reservations";
 import type { StationQueryService } from "@/domain/stations";
 import type { WalletService } from "@/domain/wallets/services/wallet.service";
 
-import { requiredAvailableBikesForReservation, stationCanAcceptReservation } from "@/domain/reservations/services/reservation-availability-rule";
+import { requiredAvailableBikesForNextReservation, stationCanAcceptReservation } from "@/domain/reservations/services/reservation-availability-rule";
 import { toContractNearbyStation, toContractStationReadSummary } from "@/http/presenters/stations.presenter";
 
 export type CreateCustomerToolsArgs = {
@@ -189,10 +189,10 @@ export function toStationAiDetail(station: Parameters<typeof toContractStationRe
     ...toContractStationReadSummary(station),
     reservationPolicy: {
       canAcceptNewReservation: stationCanAcceptReservation({
-        totalCapacity: station.totalCapacity,
         availableBikes: station.availableBikes,
+        pendingReservations: station.reservedBikes,
       }),
-      requiredAvailableBikes: requiredAvailableBikesForReservation(station.totalCapacity),
+      requiredAvailableBikes: requiredAvailableBikesForNextReservation(station.reservedBikes),
     },
   };
 }
@@ -202,10 +202,10 @@ export function toNearbyStationAiDetail(station: Parameters<typeof toContractNea
     ...toContractNearbyStation(station),
     reservationPolicy: {
       canAcceptNewReservation: stationCanAcceptReservation({
-        totalCapacity: station.totalCapacity,
         availableBikes: station.availableBikes,
+        pendingReservations: station.reservedBikes,
       }),
-      requiredAvailableBikes: requiredAvailableBikesForReservation(station.totalCapacity),
+      requiredAvailableBikes: requiredAvailableBikesForNextReservation(station.reservedBikes),
     },
   };
 }

--- a/apps/server/src/domain/reservations/services/commands/reserve-bike/reserve-bike.validation.ts
+++ b/apps/server/src/domain/reservations/services/commands/reserve-bike/reserve-bike.validation.ts
@@ -27,7 +27,7 @@ import {
 import { makeReservationQueryRepository } from "../../../repository/reservation-query.repository";
 import {
   lockStationForReservationCheck,
-  requiredAvailableBikesForReservation,
+  requiredAvailableBikesForNextReservation,
   stationCanAcceptReservation,
 } from "../../reservation-availability-rule";
 
@@ -127,14 +127,15 @@ export function prepareReserveBikeInTx(
 
     yield* lockStationForReservationCheck(tx, input.stationId);
 
-    const availableBikes = yield* txBikeRepo.countAvailableByStation(input.stationId);
-    const requiredAvailableBikes = requiredAvailableBikesForReservation(
-      stationOpt.value.totalCapacity,
-    );
+    const [availableBikes, pendingReservations] = yield* Effect.all([
+      txBikeRepo.countAvailableByStation(input.stationId),
+      txReservationQueryRepo.countPendingByStationId(input.stationId),
+    ]);
+    const requiredAvailableBikes = requiredAvailableBikesForNextReservation(pendingReservations);
 
     if (!stationCanAcceptReservation({
-      totalCapacity: stationOpt.value.totalCapacity,
       availableBikes,
+      pendingReservations,
     })) {
       return yield* Effect.fail(new StationReservationAvailabilityTooLow({
         stationId: input.stationId,

--- a/apps/server/src/domain/reservations/services/fixed-slot/fixed-slot.assignment.ts
+++ b/apps/server/src/domain/reservations/services/fixed-slot/fixed-slot.assignment.ts
@@ -233,10 +233,13 @@ async function runFixedSlotAssignmentTransaction(
 
       yield* lockStationForReservationCheck(tx, template.stationId);
 
-      const availableBikes = yield* bikeRepo.countAvailableByStation(template.stationId);
+      const [availableBikes, pendingReservations] = yield* Effect.all([
+        bikeRepo.countAvailableByStation(template.stationId),
+        txReservationQueryRepo.countPendingByStationId(template.stationId),
+      ]);
       if (!stationCanAcceptReservation({
-        totalCapacity: template.station.totalCapacity,
         availableBikes,
+        pendingReservations,
       })) {
         yield* enqueueNoBikeEmail(tx, template, labels, context);
         return "NO_BIKE" as const;

--- a/apps/server/src/domain/reservations/services/reservation-availability-rule.ts
+++ b/apps/server/src/domain/reservations/services/reservation-availability-rule.ts
@@ -3,30 +3,41 @@ import { Effect } from "effect";
 import type { Prisma as PrismaTypes } from "generated/prisma/client";
 
 /**
- * Tinh nguong xe AVAILABLE toi thieu de tram duoc phep nhan reservation moi.
+ * Tinh so luong reservation pickup toi da cho pool xe kha dung ban dau.
  *
- * Rule theo spec: so xe kha dung phai lon hon 50% tong suc chua.
+ * Rule theo spec: chi toi da mot nua so xe AVAILABLE duoc phep dat truoc.
  *
- * @param totalCapacity Tong suc chua cua tram.
- * @returns So xe AVAILABLE toi thieu can co tai thoi diem kiem tra.
+ * @param availableBikePool Tong so xe AVAILABLE ban dau, tinh ca xe da bi giu boi pending reservation.
+ * @returns So reservation pickup toi da duoc phep ton tai cung luc.
  */
-export function requiredAvailableBikesForReservation(totalCapacity: number): number {
-  return Math.floor(totalCapacity / 2) + 1;
+export function maxReservableBikesForAvailablePool(availableBikePool: number): number {
+  return Math.floor(availableBikePool / 2);
+}
+
+/**
+ * Tinh so xe AVAILABLE toi thieu can co de tao them mot reservation.
+ *
+ * @param pendingReservations So pending reservation hien tai tai tram.
+ * @returns So xe AVAILABLE toi thieu de pendingReservations + 1 khong vuot qua cap.
+ */
+export function requiredAvailableBikesForNextReservation(pendingReservations: number): number {
+  return pendingReservations + 2;
 }
 
 /**
  * Kiem tra tram con du dieu kien tao reservation moi hay khong.
  *
- * @param args Tong suc chua va so xe AVAILABLE hien tai.
- * @param args.totalCapacity Tong suc chua cua tram.
+ * @param args So xe AVAILABLE hien tai va so reservation dang giu xe tai tram.
  * @param args.availableBikes So xe AVAILABLE hien tai.
- * @returns `true` neu tram con vuot nguong availability cho reservation.
+ * @param args.pendingReservations So pending reservation hien tai tai tram.
+ * @returns `true` neu tao them reservation khong vuot qua mot nua pool xe kha dung.
  */
 export function stationCanAcceptReservation(args: {
-  totalCapacity: number;
   availableBikes: number;
+  pendingReservations: number;
 }): boolean {
-  return args.availableBikes >= requiredAvailableBikesForReservation(args.totalCapacity);
+  const availableBikePool = args.availableBikes + args.pendingReservations;
+  return args.pendingReservations < maxReservableBikesForAvailablePool(availableBikePool);
 }
 
 /**

--- a/apps/server/src/domain/reservations/services/test/fixed-slot.service.int.test.ts
+++ b/apps/server/src/domain/reservations/services/test/fixed-slot.service.int.test.ts
@@ -25,8 +25,9 @@ describe("assignFixedSlotReservations integration", () => {
     const slotStart = new Date(Date.UTC(2000, 0, 1, 9, 0, 0));
     const user = await fixture.factories.user({ fullname: "Fixed Slot User" });
     await fixture.factories.wallet({ userId: user.id, balance: 10000n });
-    const station = await fixture.factories.station({ name: "Fixed Slot Station", capacity: 1 });
+    const station = await fixture.factories.station({ name: "Fixed Slot Station", capacity: 2 });
     const bike = await fixture.factories.bike({ stationId: station.id, status: "AVAILABLE" });
+    await fixture.factories.bike({ stationId: station.id, status: "AVAILABLE" });
 
     const template = await fixture.prisma.fixedSlotTemplate.create({
       data: {
@@ -90,7 +91,8 @@ describe("assignFixedSlotReservations integration", () => {
     const slotStart = new Date(Date.UTC(2000, 0, 1, 9, 30, 0));
     const user = await fixture.factories.user({ fullname: "Fixed Slot Timezone User" });
     await fixture.factories.wallet({ userId: user.id, balance: 10000n });
-    const station = await fixture.factories.station({ name: "Fixed Slot Timezone Station", capacity: 1 });
+    const station = await fixture.factories.station({ name: "Fixed Slot Timezone Station", capacity: 2 });
+    await fixture.factories.bike({ stationId: station.id, status: "AVAILABLE" });
     await fixture.factories.bike({ stationId: station.id, status: "AVAILABLE" });
 
     const template = await fixture.prisma.fixedSlotTemplate.create({
@@ -130,7 +132,8 @@ describe("assignFixedSlotReservations integration", () => {
     const slotStart = new Date(Date.UTC(2000, 0, 1, 10, 30, 0));
     const user = await fixture.factories.user({ fullname: "Fixed Slot Rerun User" });
     await fixture.factories.wallet({ userId: user.id, balance: 10000n });
-    const station = await fixture.factories.station({ name: "Fixed Slot Rerun Station", capacity: 1 });
+    const station = await fixture.factories.station({ name: "Fixed Slot Rerun Station", capacity: 2 });
+    await fixture.factories.bike({ stationId: station.id, status: "AVAILABLE" });
     await fixture.factories.bike({ stationId: station.id, status: "AVAILABLE" });
 
     const template = await fixture.prisma.fixedSlotTemplate.create({
@@ -191,7 +194,8 @@ describe("assignFixedSlotReservations integration", () => {
       maxUsages: 3,
       usageCount: 1,
     });
-    const station = await fixture.factories.station({ name: "Fixed Slot Subscription Station", capacity: 1 });
+    const station = await fixture.factories.station({ name: "Fixed Slot Subscription Station", capacity: 2 });
+    await fixture.factories.bike({ stationId: station.id, status: "AVAILABLE" });
     await fixture.factories.bike({ stationId: station.id, status: "AVAILABLE" });
 
     const template = await fixture.prisma.fixedSlotTemplate.create({
@@ -243,8 +247,9 @@ describe("assignFixedSlotReservations integration", () => {
     const slotStart = new Date(Date.UTC(2000, 0, 1, 7, 30, 0));
     const user = await fixture.factories.user({ fullname: "Fixed Slot Low Balance User" });
     await fixture.factories.wallet({ userId: user.id, balance: 1000n });
-    const station = await fixture.factories.station({ name: "Fixed Slot Low Balance Station", capacity: 1 });
+    const station = await fixture.factories.station({ name: "Fixed Slot Low Balance Station", capacity: 2 });
     const bike = await fixture.factories.bike({ stationId: station.id, status: "AVAILABLE" });
+    await fixture.factories.bike({ stationId: station.id, status: "AVAILABLE" });
 
     const template = await fixture.prisma.fixedSlotTemplate.create({
       data: {

--- a/apps/server/src/domain/reservations/services/test/reservation.use-cases.int.test.ts
+++ b/apps/server/src/domain/reservations/services/test/reservation.use-cases.int.test.ts
@@ -28,8 +28,9 @@ describe("reservation use-cases integration", () => {
       wallet: { balance: 50000n },
     });
     const { station, bike } = await givenStationWithAvailableBike(fixture, {
-      station: { capacity: 1 },
+      station: { capacity: 2 },
     });
+    await fixture.factories.bike({ stationId: station.id, status: "AVAILABLE" });
 
     const now = new Date("2025-01-01T10:00:00.000Z");
     const startTime = new Date("2025-01-01T10:00:00.000Z");
@@ -93,8 +94,9 @@ describe("reservation use-cases integration", () => {
       wallet: { balance: 600000n },
     });
     const { station, bike } = await givenStationWithAvailableBike(fixture, {
-      station: { capacity: 1 },
+      station: { capacity: 2 },
     });
+    await fixture.factories.bike({ stationId: station.id, status: "AVAILABLE" });
 
     const now = new Date("2025-01-01T12:00:00.000Z");
 
@@ -150,8 +152,9 @@ describe("reservation use-cases integration", () => {
       wallet: { balance: initialBalance },
     });
     const { station, bike } = await givenStationWithAvailableBike(fixture, {
-      station: { capacity: 1 },
+      station: { capacity: 2 },
     });
+    await fixture.factories.bike({ stationId: station.id, status: "AVAILABLE" });
 
     const now = new Date("2025-01-01T13:00:00.000Z");
 
@@ -215,8 +218,9 @@ describe("reservation use-cases integration", () => {
       wallet: { balance: 50000n },
     });
     const { station, bike } = await givenStationWithAvailableBike(fixture, {
-      station: { capacity: 1 },
+      station: { capacity: 2 },
     });
+    await fixture.factories.bike({ stationId: station.id, status: "AVAILABLE" });
 
     const blockedNow = new Date("2026-04-20T16:00:00.000Z");
     const result = await runReserve({
@@ -235,8 +239,9 @@ describe("reservation use-cases integration", () => {
       wallet: { balance: 600000n },
     });
     const { station, bike } = await givenStationWithAvailableBike(fixture, {
-      station: { capacity: 1 },
+      station: { capacity: 2 },
     });
+    await fixture.factories.bike({ stationId: station.id, status: "AVAILABLE" });
 
     const allowedNow = new Date("2026-04-20T10:00:00.000Z");
     const reserveResult = await runReserve({

--- a/apps/server/src/domain/reservations/services/test/reservation.use-cases.unhappy.int.test.ts
+++ b/apps/server/src/domain/reservations/services/test/reservation.use-cases.unhappy.int.test.ts
@@ -83,8 +83,9 @@ describe("reservation use-cases unhappy paths", () => {
   it("reserveBikeUseCase fails with WalletNotFound when user has no wallet", async () => {
     const user = await fixture.factories.user();
     const { station, bike } = await givenStationWithAvailableBike(fixture, {
-      station: { capacity: 1 },
+      station: { capacity: 2 },
     });
+    await fixture.factories.bike({ stationId: station.id, status: "AVAILABLE" });
 
     const now = new Date();
     const result = await runReserve({ userId: user.id, bikeId: bike.id, stationId: station.id, startTime: now, now });
@@ -94,23 +95,34 @@ describe("reservation use-cases unhappy paths", () => {
   it("reserveBikeUseCase fails with InsufficientWalletBalance when balance too low", async () => {
     const { user } = await givenUserWithWallet(fixture, { wallet: { balance: 0n } });
     const { station, bike } = await givenStationWithAvailableBike(fixture, {
-      station: { capacity: 1 },
+      station: { capacity: 2 },
     });
+    await fixture.factories.bike({ stationId: station.id, status: "AVAILABLE" });
 
     const now = new Date();
     const result = await runReserve({ userId: user.id, bikeId: bike.id, stationId: station.id, startTime: now, now });
     expectLeftTag(result, "InsufficientWalletBalance");
   });
 
-  it("reserveBikeUseCase fails when station availability drops to 50 percent or less", async () => {
+  it("reserveBikeUseCase fails when station reaches half-available reservation cap", async () => {
     const { user } = await givenUserWithWallet(fixture, { wallet: { balance: 50000n } });
     const station = await fixture.factories.station({
-      capacity: 10,
-      returnSlotLimit: 10,
+      capacity: 4,
+      returnSlotLimit: 4,
     });
-    for (let index = 0; index < 4; index++) {
-      await fixture.factories.bike({ stationId: station.id, status: "AVAILABLE" });
+
+    for (let index = 0; index < 2; index++) {
+      const reservedBike = await fixture.factories.bike({ stationId: station.id, status: "RESERVED" });
+      const reservedUser = await fixture.factories.user();
+      await fixture.factories.reservation({
+        userId: reservedUser.id,
+        bikeId: reservedBike.id,
+        stationId: station.id,
+        status: "PENDING",
+      });
     }
+
+    await fixture.factories.bike({ stationId: station.id, status: "AVAILABLE" });
     const bike = await fixture.factories.bike({ stationId: station.id, status: "AVAILABLE" });
 
     const now = new Date();
@@ -129,13 +141,9 @@ describe("reservation use-cases unhappy paths", () => {
     const first = await givenUserWithWallet(fixture, { wallet: { balance: 50000n } });
     const second = await givenUserWithWallet(fixture, { wallet: { balance: 50000n } });
     const station = await fixture.factories.station({
-      capacity: 10,
-      returnSlotLimit: 10,
+      capacity: 2,
+      returnSlotLimit: 2,
     });
-
-    for (let index = 0; index < 4; index++) {
-      await fixture.factories.bike({ stationId: station.id, status: "AVAILABLE" });
-    }
 
     const bikeA = await fixture.factories.bike({ stationId: station.id, status: "AVAILABLE" });
     const bikeB = await fixture.factories.bike({ stationId: station.id, status: "AVAILABLE" });
@@ -172,8 +180,9 @@ describe("reservation use-cases unhappy paths", () => {
   it("reserveBikeUseCase fails with SubscriptionRequired when subscription option missing id", async () => {
     const { user } = await givenUserWithWallet(fixture, { wallet: { balance: 50000n } });
     const { station, bike } = await givenStationWithAvailableBike(fixture, {
-      station: { capacity: 1 },
+      station: { capacity: 2 },
     });
+    await fixture.factories.bike({ stationId: station.id, status: "AVAILABLE" });
 
     const now = new Date();
     const result = await runReserve({
@@ -191,8 +200,9 @@ describe("reservation use-cases unhappy paths", () => {
     const { user } = await givenUserWithWallet(fixture, { wallet: { balance: 50000n } });
     const otherUser = await fixture.factories.user();
     const { station, bike } = await givenStationWithAvailableBike(fixture, {
-      station: { capacity: 1 },
+      station: { capacity: 2 },
     });
+    await fixture.factories.bike({ stationId: station.id, status: "AVAILABLE" });
     const subscription = await fixture.factories.subscription({ userId: otherUser.id, status: "ACTIVE" });
 
     const now = new Date();
@@ -211,8 +221,9 @@ describe("reservation use-cases unhappy paths", () => {
   it("reserveBikeUseCase fails with SubscriptionUsageExceeded when max usage reached", async () => {
     const { user } = await givenUserWithWallet(fixture, { wallet: { balance: 50000n } });
     const { station, bike } = await givenStationWithAvailableBike(fixture, {
-      station: { capacity: 1 },
+      station: { capacity: 2 },
     });
+    await fixture.factories.bike({ stationId: station.id, status: "AVAILABLE" });
     const subscription = await fixture.factories.subscription({
       userId: user.id,
       status: "ACTIVE",
@@ -368,8 +379,9 @@ describe("reservation use-cases unhappy paths", () => {
   it("confirmReservationUseCase fails when wallet balance falls below the required deposit threshold", async () => {
     const { user } = await givenUserWithWallet(fixture, { wallet: { balance: 3000n } });
     const { station, bike } = await givenStationWithAvailableBike(fixture, {
-      station: { capacity: 1 },
+      station: { capacity: 2 },
     });
+    await fixture.factories.bike({ stationId: station.id, status: "AVAILABLE" });
 
     const now = new Date();
     const reserveResult = await runReserve({


### PR DESCRIPTION
## Summary
- Replace the old total-capacity reservation threshold with a cap based on half of the station's available-bike pool.
- Apply the cap to manual reservation and fixed-slot assignment flows.
- Update AI reservation-policy text/helpers and focused integration coverage.

## Verification
- pnpm eslint src/domain/reservations/services/reservation-availability-rule.ts src/domain/reservations/services/commands/reserve-bike/reserve-bike.validation.ts src/domain/reservations/services/fixed-slot/fixed-slot.assignment.ts src/domain/ai/tools/customer-tool-helpers.ts src/domain/ai/prompts/customer-assistant.prompt.sections.ts src/domain/reservations/services/test/fixed-slot.service.int.test.ts src/domain/reservations/services/test/reservation.use-cases.int.test.ts src/domain/reservations/services/test/reservation.use-cases.unhappy.int.test.ts
- pnpm tsc --noEmit
- pnpm vitest run --config vitest.int.config.ts --mode test src/domain/reservations/services/test/reservation.use-cases.int.test.ts src/domain/reservations/services/test/reservation.use-cases.unhappy.int.test.ts src/domain/reservations/services/test/fixed-slot.service.int.test.ts