### PR TITLE
Make return slots advisory for rental returns

### DIFF
--- a/apps/server/src/domain/rentals/services/commands/confirm-return/confirm-return.guard.ts
+++ b/apps/server/src/domain/rentals/services/commands/confirm-return/confirm-return.guard.ts
@@ -16,7 +16,6 @@ import {
   RentalRepositoryError,
   ReturnAlreadyConfirmed,
   ReturnSlotCapacityExceeded,
-  ReturnSlotStationMismatch,
   UnauthorizedRentalAccess,
 } from "../../../domain-errors";
 import { makeRentalRepository } from "../../../repository/rental.repository";
@@ -125,13 +124,6 @@ export function ensureOperatorCanConfirmReturnInTx(args: {
       return yield* Effect.fail(makeOvernightOperationsClosedError(now));
     }
 
-    if (operator?.role === "STAFF" && operator.stationId !== input.stationId) {
-      return yield* Effect.fail(new UnauthorizedRentalAccess({
-        rentalId: rental.id,
-        userId: input.confirmedByUserId,
-      }));
-    }
-
     if (operator?.role !== "AGENCY") {
       return;
     }
@@ -161,14 +153,15 @@ export function ensureOperatorCanConfirmReturnInTx(args: {
 /**
  * Xác nhận rằng station trả xe hiện tại vẫn hợp lệ cho rental này.
  *
- * Nếu user đã giữ return slot, station phải trùng với slot đó.
- * Nếu chưa có slot, station phải còn chỗ vật lý để nhận xe.
+ * Return slot chỉ giữ chỗ tại station đó. Nếu trả đúng station đã giữ, bỏ qua
+ * capacity check. Nếu trả station khác, slot sẽ được hủy khi hoàn tất trả xe
+ * và station nhận xe vẫn phải còn chỗ vật lý.
  */
 export function ensureReturnDestinationReadyInTx(args: {
   readonly tx: PrismaTypes.TransactionClient;
   readonly input: ConfirmRentalReturnInput;
   readonly rental: RentalRow;
-}): Effect.Effect<void, ReturnSlotStationMismatch | ReturnSlotCapacityExceeded | StationNotFound> {
+}): Effect.Effect<void, ReturnSlotCapacityExceeded | StationNotFound> {
   return Effect.gen(function* () {
     const txReturnSlotRepo = makeReturnSlotRepository(args.tx);
     const activeReturnSlotOpt = yield* txReturnSlotRepo.findActiveByRentalId(args.rental.id);
@@ -176,15 +169,15 @@ export function ensureReturnDestinationReadyInTx(args: {
     if (Option.isSome(activeReturnSlotOpt)) {
       const activeReturnSlot = activeReturnSlotOpt.value;
 
-      if (activeReturnSlot.stationId !== args.input.stationId) {
-        return yield* Effect.fail(new ReturnSlotStationMismatch({
-          rentalId: args.rental.id,
-          returnSlotStationId: activeReturnSlot.stationId,
-          attemptedEndStationId: args.input.stationId,
-        }));
+      if (activeReturnSlot.stationId === args.input.stationId) {
+        return;
       }
 
-      return;
+      yield* txReturnSlotRepo.finalizeActiveByRentalId(
+        args.rental.id,
+        "CANCELLED",
+        args.input.confirmedAt,
+      );
     }
 
     const stationSnapshotOpt = yield* txReturnSlotRepo.getStationCapacitySnapshot(args.input.stationId);

--- a/apps/server/src/domain/rentals/services/test/return-slot.int.test.ts
+++ b/apps/server/src/domain/rentals/services/test/return-slot.int.test.ts
@@ -561,7 +561,7 @@ describe("return slot integration", () => {
     expectLeftTag(result, "ReturnSlotCapacityExceeded");
   });
 
-  it("fails to confirm a rental return at a different station than the active return slot", async () => {
+  it("allows confirming a rental return at a different station than the active return slot", async () => {
     const { user, rental } = await givenActiveRental(fixture, {
       wallet: { balance: 5000n },
       rental: { startTime: SAFE_RENTAL_START_TIME },
@@ -585,7 +585,14 @@ describe("return slot integration", () => {
       confirmedAt: SAFE_RETURN_CONFIRMED_AT,
     });
 
-    expectLeftTag(result, "ReturnSlotStationMismatch");
+    const completed = expectRight(result);
+    expect(completed.status).toBe("COMPLETED");
+    expect(completed.endStationId).toBe(attemptedStation.id);
+
+    const slot = await fixture.prisma.returnSlotReservation.findFirst({
+      where: { rentalId: rental.id },
+    });
+    expect(slot?.status).toBe("CANCELLED");
   });
 
   it("fails when the rental return is already confirmed", async () => {
@@ -628,7 +635,7 @@ describe("return slot integration", () => {
     expectLeftTag(result, "ReturnAlreadyConfirmed");
   });
 
-  it("fails when a staff operator is not assigned to the return station", async () => {
+  it("allows a staff operator to confirm return outside their assigned station", async () => {
     const { user, rental } = await givenActiveRental(fixture, {
       wallet: { balance: 5000n },
     });
@@ -651,6 +658,8 @@ describe("return slot integration", () => {
       confirmedAt: new Date(Date.now() + 30 * 60 * 1000),
     });
 
-    expectLeftTag(result, "UnauthorizedRentalAccess");
+    const completed = expectRight(result);
+    expect(completed.status).toBe("COMPLETED");
+    expect(completed.endStationId).toBe(reservedStation.id);
   });
 });

--- a/apps/server/src/http/test/e2e/rentals-end-routing.e2e.int.test.ts
+++ b/apps/server/src/http/test/e2e/rentals-end-routing.e2e.int.test.ts
@@ -488,7 +488,7 @@ describe("rentals end routing e2e", () => {
     expect(body.pagination.page).toBe(1);
   });
 
-  it("rejects operator confirmation at a station different from the active return slot", async () => {
+  it("allows operator confirmation at a station different from the active return slot", async () => {
     const { user, rental } = await createActiveRentalGraph();
     const userToken = fixture.auth.makeAccessToken({ userId: user.id, role: "USER" });
     const reservedStation = await fixture.factories.station({ capacity: 5 });
@@ -507,13 +507,18 @@ describe("rentals end routing e2e", () => {
       body: JSON.stringify({ stationId: attemptedStation.id, confirmationMethod: "MANUAL" }),
     });
 
-    const body = await response.json() as RentalsContracts.RentalErrorResponse;
+    const body = await response.json() as RentalsContracts.RentalDetail;
 
-    expect(response.status).toBe(400);
-    expect(body.details?.code).toBe("RETURN_SLOT_STATION_MISMATCH");
-    expect(body.details?.rentalId).toBe(rental.id);
-    expect(body.details?.returnSlotStationId).toBe(reservedStation.id);
-    expect(body.details?.endStationId).toBe(attemptedStation.id);
+    expect(response.status).toBe(200);
+    expect(body.id).toBe(rental.id);
+    expect(body.status).toBe("COMPLETED");
+    expect(body.endStation?.id).toBe(attemptedStation.id);
+
+    const persistedSlot = await fixture.prisma.returnSlotReservation.findFirst({
+      where: { rentalId: rental.id },
+    });
+    expect(persistedSlot?.stationId).toBe(reservedStation.id);
+    expect(persistedSlot?.status).toBe("CANCELLED");
   });
 
   it("confirms a rental return successfully when the active return slot matches the target station", async () => {
@@ -641,7 +646,7 @@ describe("rentals end routing e2e", () => {
     expect(billingRecord?.totalAmount.toString()).toBe("6000");
   });
 
-  it("rejects staff confirmation when the staff assignment does not match the reserved return station", async () => {
+  it("allows staff confirmation when the staff assignment does not match the reserved return station", async () => {
     const { user, rental } = await createActiveRentalGraph();
     const userToken = fixture.auth.makeAccessToken({ userId: user.id, role: "USER" });
     const reservedStation = await fixture.factories.station({ capacity: 5 });
@@ -660,11 +665,12 @@ describe("rentals end routing e2e", () => {
       body: JSON.stringify({ stationId: reservedStation.id, confirmationMethod: "MANUAL" }),
     });
 
-    const body = await response.json() as RentalsContracts.RentalErrorResponse;
+    const body = await response.json() as RentalsContracts.RentalDetail;
 
-    expect(response.status).toBe(403);
-    expect(body.details?.code).toBe("ACCESS_DENIED");
-    expect(body.details?.stationId).toBe(reservedStation.id);
+    expect(response.status).toBe(200);
+    expect(body.id).toBe(rental.id);
+    expect(body.status).toBe("COMPLETED");
+    expect(body.endStation?.id).toBe(reservedStation.id);
   });
 
   it("allows staff confirmation when the staff assignment matches the reserved return station", async () => {


### PR DESCRIPTION
## Summary
- Allow staff to confirm rental returns regardless of their assigned station.
- Treat return slots as advisory: matching slots are used, mismatched active slots are cancelled and the actual return station must have physical capacity.
- Update service and HTTP e2e coverage for advisory return-slot behavior.

## Verification
- pnpm eslint src/domain/rentals/services/commands/confirm-return/confirm-return.guard.ts src/domain/rentals/services/test/return-slot.int.test.ts src/http/test/e2e/rentals-end-routing.e2e.int.test.ts
- pnpm vitest run --config vitest.int.config.ts --mode test src/domain/rentals/services/test/return-slot.int.test.ts src/http/test/e2e/rentals-end-routing.e2e.int.test.ts