### PR TITLE
Refine wallet transaction detail sheet

### DIFF
--- a/apps/mobile/screen/my-wallet/modals/transaction-detail-modal/detail-row.tsx
+++ b/apps/mobile/screen/my-wallet/modals/transaction-detail-modal/detail-row.tsx
@@ -34,6 +34,7 @@ export function DetailRow({
       <View style={styles.valueGroup}>
         <AppText
           numberOfLines={expanded ? undefined : 1}
+          selectable
           style={[
             styles.value,
             valueTone === "success" ? styles.valueSuccess : null,
@@ -47,7 +48,7 @@ export function DetailRow({
 
         {showToggle && onToggle
           ? (
-              <Pressable onPress={onToggle} style={({ pressed }) => [styles.copyButton, pressed ? styles.copyButtonPressed : null]}>
+              <Pressable hitSlop={12} onPress={onToggle} style={({ pressed }) => [styles.copyButton, pressed ? styles.copyButtonPressed : null]}>
                 <IconSymbol color={copyIconColor} name="copy" size="sm" />
               </Pressable>
             )

--- a/apps/mobile/screen/my-wallet/modals/transaction-detail-modal/detail-row.tsx
+++ b/apps/mobile/screen/my-wallet/modals/transaction-detail-modal/detail-row.tsx
@@ -1,0 +1,58 @@
+import { IconSymbol } from "@components/IconSymbol";
+import { AppText } from "@ui/primitives/app-text";
+import { Pressable, View } from "react-native";
+
+import type { createTransactionDetailModalStyles } from "./styles";
+
+type DetailRowProps = {
+  label: string;
+  value: string;
+  valueTone?: "success" | "warning" | "danger" | "default";
+  showToggle?: boolean;
+  expanded?: boolean;
+  onToggle?: () => void;
+  styles: ReturnType<typeof createTransactionDetailModalStyles>;
+  copyIconColor: string;
+};
+
+export function DetailRow({
+  label,
+  value,
+  valueTone = "default",
+  showToggle = false,
+  expanded = false,
+  onToggle,
+  styles,
+  copyIconColor,
+}: DetailRowProps) {
+  return (
+    <View style={styles.row}>
+      <AppText style={styles.label} variant="body">
+        {label}
+      </AppText>
+
+      <View style={styles.valueGroup}>
+        <AppText
+          numberOfLines={expanded ? undefined : 1}
+          style={[
+            styles.value,
+            valueTone === "success" ? styles.valueSuccess : null,
+            valueTone === "warning" ? styles.valueWarning : null,
+            valueTone === "danger" ? styles.valueDanger : null,
+          ]}
+          variant="body"
+        >
+          {value}
+        </AppText>
+
+        {showToggle && onToggle
+          ? (
+              <Pressable onPress={onToggle} style={({ pressed }) => [styles.copyButton, pressed ? styles.copyButtonPressed : null]}>
+                <IconSymbol color={copyIconColor} name="copy" size="sm" />
+              </Pressable>
+            )
+          : null}
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/screen/my-wallet/modals/transaction-detail-modal/helpers.ts
+++ b/apps/mobile/screen/my-wallet/modals/transaction-detail-modal/helpers.ts
@@ -1,0 +1,81 @@
+import { formatAbsoluteCurrency, formatDate, formatTransactionTitle } from "@utils/wallet/formatters";
+
+import type { Transaction } from "./types";
+
+export function toShortReference(transaction: Transaction, expanded = false) {
+  const reference = transaction.id || transaction.hash;
+  if (!reference) {
+    return "--";
+  }
+
+  if (expanded || reference.length <= 24) {
+    return reference;
+  }
+
+  return `${reference.slice(0, 14)}...${reference.slice(-6)}`;
+}
+
+export function formatDetailDate(dateString: string): string {
+  const formatted = formatDate(dateString);
+  const [date, time] = formatted.split(" ");
+
+  if (!date || !time) {
+    return formatted;
+  }
+
+  return `${time} - ${date}`;
+}
+
+function getReferenceSuffix(transaction: Transaction): string | null {
+  const source = `${transaction.description ?? ""} ${transaction.hash ?? ""} ${transaction.id}`;
+  const uuid = source.match(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i)?.[0];
+  const reference = uuid ?? transaction.id;
+
+  if (!reference) {
+    return null;
+  }
+
+  return reference.slice(-6).toUpperCase();
+}
+
+export function humanizeTransactionTitle(transaction: Transaction): string {
+  const title = formatTransactionTitle(transaction.type, transaction.description);
+  const normalizedSource = `${transaction.description ?? ""} ${transaction.hash ?? ""}`.toLowerCase();
+  const suffix = getReferenceSuffix(transaction);
+
+  if (!suffix) {
+    return title;
+  }
+
+  if (normalizedSource.includes("return-slot") || normalizedSource.includes("return slot")) {
+    return `Phí đặt điểm trả xe #${suffix}`;
+  }
+
+  if (title === "Thanh toán chuyến đi") {
+    return `${title} #${suffix}`;
+  }
+
+  return title;
+}
+
+export function getStatusTone(status: string): "success" | "warning" | "danger" | "default" {
+  switch (status.toUpperCase()) {
+    case "SUCCESS":
+      return "success";
+    case "PENDING":
+      return "warning";
+    case "FAILED":
+      return "danger";
+    default:
+      return "default";
+  }
+}
+
+export function formatDisplayAmount(transaction: Transaction): string {
+  const rawAmount = Number(transaction.amount);
+  const isSignedNegative = rawAmount < 0;
+  const isMoneyOut = transaction.type.toUpperCase() === "DEBIT";
+  const sign = isSignedNegative || isMoneyOut ? "-" : "+";
+
+  return `${sign}${formatAbsoluteCurrency(transaction.amount)}`;
+}

--- a/apps/mobile/screen/my-wallet/modals/transaction-detail-modal/index.tsx
+++ b/apps/mobile/screen/my-wallet/modals/transaction-detail-modal/index.tsx
@@ -152,7 +152,7 @@ export function TransactionDetailModal({
           </View>
 
           <View style={styles.heroBlock}>
-            <AppText align="center" style={styles.heroAmount}>
+            <AppText adjustsFontSizeToFit align="center" numberOfLines={1} style={styles.heroAmount}>
               {amountText}
             </AppText>
 

--- a/apps/mobile/screen/my-wallet/modals/transaction-detail-modal/index.tsx
+++ b/apps/mobile/screen/my-wallet/modals/transaction-detail-modal/index.tsx
@@ -1,11 +1,6 @@
 import { IconSymbol } from "@components/IconSymbol";
 import { AppText } from "@ui/primitives/app-text";
-import {
-  formatCurrency,
-  formatDate,
-  formatTransactionStatus,
-  formatTransactionType,
-} from "@utils/wallet/formatters";
+import { formatTransactionStatus } from "@utils/wallet/formatters";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Modal, Pressable, View } from "react-native";
 import Animated, {
@@ -16,17 +11,17 @@ import Animated, {
 } from "react-native-reanimated";
 import { useTheme } from "tamagui";
 
-import { createTransactionDetailModalStyles } from "./styles";
+import type { Transaction } from "./types";
 
-type Transaction = {
-  id: string;
-  amount: string;
-  description?: string | null;
-  type: string;
-  status: string;
-  createdAt: string;
-  hash?: string | null;
-};
+import { DetailRow } from "./detail-row";
+import {
+  formatDetailDate,
+  formatDisplayAmount,
+  getStatusTone,
+  humanizeTransactionTitle,
+  toShortReference,
+} from "./helpers";
+import { createTransactionDetailModalStyles } from "./styles";
 
 type TransactionDetailModalProps = {
   visible: boolean;
@@ -36,83 +31,6 @@ type TransactionDetailModalProps = {
 
 const SHEET_OPEN_DURATION = 260;
 const SHEET_CLOSE_DURATION = 220;
-
-function toShortReference(transaction: Transaction) {
-  const reference = transaction.hash || transaction.id;
-  if (!reference) {
-    return "--";
-  }
-
-  if (reference.length <= 16) {
-    return reference;
-  }
-
-  return `${reference.slice(0, 8)}...${reference.slice(-6)}`;
-}
-
-function getStatusTone(status: string): "success" | "warning" | "danger" | "default" {
-  switch (status.toUpperCase()) {
-    case "SUCCESS":
-      return "success";
-    case "PENDING":
-      return "warning";
-    case "FAILED":
-      return "danger";
-    default:
-      return "default";
-  }
-}
-
-function DetailRow({
-  label,
-  value,
-  valueTone = "default",
-  strong = false,
-  showToggle = false,
-  onToggle,
-  styles,
-  copyIconColor,
-}: {
-  label: string;
-  value: string;
-  valueTone?: "success" | "warning" | "danger" | "default";
-  strong?: boolean;
-  showToggle?: boolean;
-  onToggle?: () => void;
-  styles: ReturnType<typeof createTransactionDetailModalStyles>;
-  copyIconColor: string;
-}) {
-  return (
-    <View style={styles.row}>
-      <AppText style={styles.label} variant="body">
-        {label}
-      </AppText>
-
-      <View style={styles.valueGroup}>
-        <AppText
-          style={[
-            styles.value,
-            strong ? styles.valueStrong : null,
-            valueTone === "success" ? styles.valueSuccess : null,
-            valueTone === "warning" ? styles.valueWarning : null,
-            valueTone === "danger" ? styles.valueDanger : null,
-          ]}
-          variant="body"
-        >
-          {value}
-        </AppText>
-
-        {showToggle && onToggle
-          ? (
-              <Pressable onPress={onToggle} style={({ pressed }) => [styles.copyButton, pressed ? styles.copyButtonPressed : null]}>
-                <IconSymbol color={copyIconColor} name="copy" size="sm" />
-              </Pressable>
-            )
-          : null}
-      </View>
-    </View>
-  );
-}
 
 export function TransactionDetailModal({
   visible,
@@ -205,11 +123,10 @@ export function TransactionDetailModal({
     return null;
   }
 
-  const typeUpper = transaction.type.toUpperCase();
-  const isMoneyOut = typeUpper === "DEBIT";
-  const amountPrefix = isMoneyOut ? "-" : "+";
   const statusTone = getStatusTone(transaction.status);
-  const shortReference = toShortReference(transaction);
+  const shortReference = toShortReference(transaction, showFullReference);
+  const detailTitle = humanizeTransactionTitle(transaction);
+  const amountText = formatDisplayAmount(transaction);
 
   return (
     <Modal
@@ -234,47 +151,48 @@ export function TransactionDetailModal({
             </Pressable>
           </View>
 
+          <View style={styles.heroBlock}>
+            <AppText align="center" style={styles.heroAmount}>
+              {amountText}
+            </AppText>
+
+            <AppText align="center" numberOfLines={2} style={styles.heroTitle}>
+              {detailTitle}
+            </AppText>
+          </View>
+
           <View style={styles.block}>
+            <View style={styles.divider} />
+
             <DetailRow
               copyIconColor={theme.textTertiary.val}
-              label="Mã tham chiếu:"
+              label="Trạng thái"
+              styles={styles}
+              value={formatTransactionStatus(transaction.status)}
+              valueTone={statusTone}
+            />
+
+            <View style={styles.rowDivider} />
+
+            <DetailRow copyIconColor={theme.textTertiary.val} label="Thời gian" styles={styles} value={formatDetailDate(transaction.createdAt)} />
+
+            <View style={styles.rowDivider} />
+
+            <DetailRow copyIconColor={theme.textTertiary.val} label="Nguồn tiền" styles={styles} value="Ví MeBike" />
+
+            <View style={styles.rowDivider} />
+
+            <DetailRow
+              copyIconColor={theme.textTertiary.val}
+              expanded={showFullReference}
+              label="Mã giao dịch"
               onToggle={() => setShowFullReference(value => !value)}
               showToggle
               styles={styles}
               value={shortReference}
             />
 
-            {showFullReference
-              ? (
-                  <View style={styles.fullReferenceCard}>
-                    <AppText style={styles.fullReferenceText} selectable variant="bodySmall">
-                      {transaction.id}
-                    </AppText>
-                  </View>
-                )
-              : null}
-
-            <View style={styles.divider} />
-
-            <DetailRow copyIconColor={theme.textTertiary.val} label="Loại:" styles={styles} value={formatTransactionType(transaction.type)} />
-            <DetailRow
-              copyIconColor={theme.textTertiary.val}
-              label="Số tiền:"
-              styles={styles}
-              strong
-              value={`${amountPrefix}${formatCurrency(transaction.amount)}`}
-              valueTone={isMoneyOut ? "default" : "success"}
-            />
-            <DetailRow
-              copyIconColor={theme.textTertiary.val}
-              label="Trạng thái:"
-              styles={styles}
-              strong
-              value={formatTransactionStatus(transaction.status)}
-              valueTone={statusTone}
-            />
-            <DetailRow copyIconColor={theme.textTertiary.val} label="Thời gian:" styles={styles} value={formatDate(transaction.createdAt)} />
-            <DetailRow copyIconColor={theme.textTertiary.val} label="Mô tả:" styles={styles} value={transaction.description || "--"} />
+            <View style={styles.rowDivider} />
           </View>
         </Animated.View>
       </View>

--- a/apps/mobile/screen/my-wallet/modals/transaction-detail-modal/styles.ts
+++ b/apps/mobile/screen/my-wallet/modals/transaction-detail-modal/styles.ts
@@ -1,7 +1,6 @@
-import { StyleSheet } from "react-native";
-
-import { borderWidths, elevations, radii, spaceScale } from "@theme/metrics";
+import { elevations, radii, spaceScale } from "@theme/metrics";
 import { fontSizes, fontWeights, lineHeights } from "@theme/typography";
+import { StyleSheet } from "react-native";
 
 export type TransactionDetailModalThemePalette = {
   overlayScrim: string;
@@ -29,16 +28,13 @@ export function createTransactionDetailModalStyles(theme: TransactionDetailModal
     backdropPressable: {
       flex: 1,
     },
-    sheetHost: {
-      justifyContent: "flex-end",
-    },
     sheet: {
       backgroundColor: theme.surfaceDefault,
       borderTopLeftRadius: 32,
       borderTopRightRadius: 32,
-      paddingHorizontal: spaceScale[6],
+      paddingHorizontal: spaceScale[7],
       paddingTop: spaceScale[3],
-      paddingBottom: spaceScale[7],
+      paddingBottom: spaceScale[8],
       ...elevations.medium,
       shadowColor: theme.shadowColor,
     },
@@ -55,7 +51,7 @@ export function createTransactionDetailModalStyles(theme: TransactionDetailModal
       alignItems: "center",
       justifyContent: "space-between",
       gap: spaceScale[3],
-      marginBottom: spaceScale[5],
+      marginBottom: spaceScale[8],
     },
     closeButton: {
       width: 44,
@@ -68,44 +64,70 @@ export function createTransactionDetailModalStyles(theme: TransactionDetailModal
     closeButtonPressed: {
       opacity: 0.88,
     },
+    heroBlock: {
+      alignItems: "center",
+      paddingBottom: spaceScale[8],
+      paddingHorizontal: spaceScale[2],
+    },
+    heroAmount: {
+      fontSize: 44,
+      lineHeight: 50,
+      letterSpacing: -0.9,
+      color: theme.textPrimary,
+      fontWeight: fontWeights.bold,
+      fontVariant: ["tabular-nums"],
+      marginBottom: spaceScale[2],
+    },
+    heroTitle: {
+      fontSize: fontSizes.base,
+      lineHeight: lineHeights.base,
+      color: theme.textSecondary,
+      fontWeight: fontWeights.medium,
+    },
     block: {
-      gap: spaceScale[3],
+      gap: 0,
     },
     divider: {
       height: 1,
       backgroundColor: theme.borderDefault,
-      marginVertical: spaceScale[1],
+      marginHorizontal: -spaceScale[7],
+      marginBottom: spaceScale[4],
+      opacity: 0.22,
+    },
+    rowDivider: {
+      height: 1,
+      backgroundColor: theme.borderDefault,
+      marginHorizontal: -spaceScale[7],
+      opacity: 0.08,
     },
     row: {
       flexDirection: "row",
-      alignItems: "flex-start",
+      alignItems: "center",
       justifyContent: "space-between",
       gap: spaceScale[4],
+      minHeight: 52,
     },
     label: {
-      width: 102,
+      flexShrink: 0,
       fontSize: fontSizes.md,
       lineHeight: lineHeights.md,
       color: theme.textSecondary,
-      fontWeight: fontWeights.medium,
+      fontWeight: fontWeights.regular,
     },
     valueGroup: {
       flex: 1,
       flexDirection: "row",
       justifyContent: "flex-end",
-      alignItems: "flex-start",
+      alignItems: "center",
       gap: spaceScale[2],
     },
     value: {
       flex: 1,
-      fontSize: 17,
-      lineHeight: 26,
+      fontSize: fontSizes.md,
+      lineHeight: lineHeights.md,
       color: theme.textPrimary,
       textAlign: "right",
-      fontWeight: fontWeights.regular,
-    },
-    valueStrong: {
-      fontWeight: fontWeights.bold,
+      fontWeight: fontWeights.semibold,
     },
     valueSuccess: {
       color: theme.statusSuccess,
@@ -117,27 +139,13 @@ export function createTransactionDetailModalStyles(theme: TransactionDetailModal
       color: theme.statusDanger,
     },
     copyButton: {
-      width: 22,
-      height: 22,
+      width: 24,
+      height: 24,
       alignItems: "center",
       justifyContent: "center",
-      marginTop: 1,
     },
     copyButtonPressed: {
       opacity: 0.72,
-    },
-    fullReferenceCard: {
-      backgroundColor: theme.surfaceMuted,
-      borderWidth: borderWidths.subtle,
-      borderColor: theme.borderDefault,
-      borderRadius: radii.lg,
-      padding: spaceScale[4],
-    },
-    fullReferenceText: {
-      fontSize: fontSizes.base,
-      lineHeight: lineHeights.base,
-      color: theme.textPrimary,
-      fontWeight: fontWeights.medium,
     },
   });
 }

--- a/apps/mobile/screen/my-wallet/modals/transaction-detail-modal/types.ts
+++ b/apps/mobile/screen/my-wallet/modals/transaction-detail-modal/types.ts
@@ -1,0 +1,9 @@
+export type Transaction = {
+  id: string;
+  amount: string;
+  description?: string | null;
+  type: string;
+  status: string;
+  createdAt: string;
+  hash?: string | null;
+};

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mebike",
   "type": "module",
   "version": "1.0.0",
-  "packageManager": "pnpm@10.27.0",
+  "packageManager": "pnpm@10.33.2",
   "description": "Project for  MeBike",
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
## Summary
- Redesign the wallet transaction detail bottom sheet to match the cleaner prototype: amount hero, concise transaction title, softer full-bleed separators, and compact detail rows.
- Split modal helpers, row rendering, and types into focused files to keep the sheet component small.
- Preserve pseudo-copy behavior by toggling full/truncated transaction ID without adding a clipboard dependency.

## Verification
- pnpm exec eslint apps/mobile/screen/my-wallet/modals/transaction-detail-modal/index.tsx apps/mobile/screen/my-wallet/modals/transaction-detail-modal/styles.ts apps/mobile/screen/my-wallet/modals/transaction-detail-modal/detail-row.tsx apps/mobile/screen/my-wallet/modals/transaction-detail-modal/helpers.ts apps/mobile/screen/my-wallet/modals/transaction-detail-modal/types.ts

## Notes
- Mobile typecheck still fails on existing unrelated `screen/environment/hooks/use-environment-impact-screen.ts` `pageParam` issue.
- Unrelated local `package.json`, `ops/`, and `scripts/` changes are not included.