### PR TITLE
Fix Mosquitto password file restart

### DIFF
--- a/compose.coolify.yaml
+++ b/compose.coolify.yaml
@@ -57,6 +57,7 @@ services:
           'persistence_location /mosquitto/data/' \
           'log_dest stdout' \
           > /mosquitto/config/mosquitto.conf
+        rm -f /mosquitto/config/passwords
         mosquitto_passwd -b -c /mosquitto/config/passwords "$${IOT_MQTT_USERNAME}" "$${IOT_MQTT_PASSWORD}"
         exec mosquitto -c /mosquitto/config/mosquitto.conf
     ports:


### PR DESCRIPTION
## Summary
- Remove the generated Mosquitto password file before recreating it on container startup.
- Prevent restart loops caused by `mosquitto_passwd -c` failing when the file already exists.

## Verification
- `docker compose -f compose.coolify.yaml config`