### PR TITLE
Fix admin user management guardrails

### DIFF
--- a/apps/server/src/domain/users/services/test/user-org-assignment.validation.test.ts
+++ b/apps/server/src/domain/users/services/test/user-org-assignment.validation.test.ts
@@ -82,16 +82,68 @@ describe("makeValidateOrgAssignmentTargetsExist", () => {
     }
   });
 
+  it("fails when staff or manager assignment points to an agency station", async () => {
+    const validate = makeValidateOrgAssignmentTargetsExist({
+      agencyRepo: {
+        getById: () => Effect.succeed(Option.some({} as never)),
+      },
+      stationRepo: {
+        getById: () => Effect.succeed(Option.some({ stationType: "AGENCY", agencyId: "agency-1" } as never)),
+      },
+      technicianTeamQueryRepo: {
+        getById: () => Effect.succeed(Option.some({ stationId: "station-1" } as never)),
+      },
+    });
+
+    const result = await Effect.runPromise(validate({
+      role: "STAFF",
+      stationId: "019d1c26-9d34-7f97-ae3c-4c3f0c2d2210",
+      technicianTeamId: null,
+      agencyId: null,
+    }).pipe(Effect.either));
+
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left._tag).toBe("InvalidOrgAssignment");
+    }
+  });
+
+  it("fails when technician assignment points to a team under an agency station", async () => {
+    const validate = makeValidateOrgAssignmentTargetsExist({
+      agencyRepo: {
+        getById: () => Effect.succeed(Option.some({} as never)),
+      },
+      stationRepo: {
+        getById: () => Effect.succeed(Option.some({ stationType: "AGENCY", agencyId: "agency-1" } as never)),
+      },
+      technicianTeamQueryRepo: {
+        getById: () => Effect.succeed(Option.some({ stationId: "station-1" } as never)),
+      },
+    });
+
+    const result = await Effect.runPromise(validate({
+      role: "TECHNICIAN",
+      stationId: null,
+      technicianTeamId: "019d4781-6843-75e0-a223-16279751efab",
+      agencyId: null,
+    }).pipe(Effect.either));
+
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left._tag).toBe("InvalidOrgAssignment");
+    }
+  });
+
   it("passes when referenced org assignment targets exist", async () => {
     const validate = makeValidateOrgAssignmentTargetsExist({
       agencyRepo: {
         getById: () => Effect.succeed(Option.some({} as never)),
       },
       stationRepo: {
-        getById: () => Effect.succeed(Option.some({} as never)),
+        getById: () => Effect.succeed(Option.some({ stationType: "INTERNAL", agencyId: null } as never)),
       },
       technicianTeamQueryRepo: {
-        getById: () => Effect.succeed(Option.some({} as never)),
+        getById: () => Effect.succeed(Option.some({ stationId: "station-1" } as never)),
       },
     });
 

--- a/apps/server/src/domain/users/services/user-org-assignment.validation.ts
+++ b/apps/server/src/domain/users/services/user-org-assignment.validation.ts
@@ -22,6 +22,27 @@ import {
   TechnicianTeamMemberLimitExceeded as TechnicianTeamMemberLimitExceededError,
 } from "../domain-errors";
 
+function invalidOrgAssignment(args: {
+  stationId: string | null;
+  technicianTeamId: string | null;
+  role: UserRow["role"];
+  agencyId?: string | null;
+}) {
+  return Effect.fail(new InvalidOrgAssignmentError({
+    role: args.role,
+    stationId: args.stationId,
+    agencyId: args.agencyId ?? null,
+    technicianTeamId: args.technicianTeamId,
+  }));
+}
+
+function isAgencyOwnedStation(station: {
+  stationType: "INTERNAL" | "AGENCY";
+  agencyId: string | null;
+}) {
+  return station.stationType === "AGENCY" || station.agencyId !== null;
+}
+
 export function makeValidateOrgAssignmentTargetsExist(deps: {
   agencyRepo: Pick<AgencyRepo, "getById">;
   stationRepo: Pick<StationQueryRepo, "getById">;
@@ -37,12 +58,14 @@ export function makeValidateOrgAssignmentTargetsExist(deps: {
       if (args.stationId) {
         const station = yield* deps.stationRepo.getById(args.stationId);
         if (Option.isNone(station)) {
-          return yield* Effect.fail(new InvalidOrgAssignmentError({
-            role: args.role,
-            stationId: args.stationId,
-            agencyId: args.agencyId ?? null,
-            technicianTeamId: args.technicianTeamId,
-          }));
+          return yield* invalidOrgAssignment(args);
+        }
+
+        if (
+          (args.role === "STAFF" || args.role === "MANAGER")
+          && isAgencyOwnedStation(station.value)
+        ) {
+          return yield* invalidOrgAssignment(args);
         }
       }
 
@@ -51,24 +74,21 @@ export function makeValidateOrgAssignmentTargetsExist(deps: {
           defectOn(AgencyRepositoryError),
         );
         if (Option.isNone(agency)) {
-          return yield* Effect.fail(new InvalidOrgAssignmentError({
-            role: args.role,
-            stationId: args.stationId,
-            agencyId: args.agencyId,
-            technicianTeamId: args.technicianTeamId,
-          }));
+          return yield* invalidOrgAssignment(args);
         }
       }
 
       if (args.technicianTeamId) {
         const technicianTeam = yield* deps.technicianTeamQueryRepo.getById(args.technicianTeamId);
         if (Option.isNone(technicianTeam)) {
-          return yield* Effect.fail(new InvalidOrgAssignmentError({
-            role: args.role,
-            stationId: args.stationId,
-            agencyId: args.agencyId ?? null,
-            technicianTeamId: args.technicianTeamId,
-          }));
+          return yield* invalidOrgAssignment(args);
+        }
+
+        if (args.role === "TECHNICIAN") {
+          const station = yield* deps.stationRepo.getById(technicianTeam.value.stationId);
+          if (Option.isNone(station) || isAgencyOwnedStation(station.value)) {
+            return yield* invalidOrgAssignment(args);
+          }
         }
       }
     });

--- a/apps/server/src/http/app.ts
+++ b/apps/server/src/http/app.ts
@@ -11,7 +11,6 @@ import {
   currentUserMiddleware,
   requireAdminMiddleware,
   requireAuthMiddleware,
-  requireBackofficeMiddleware,
 } from "@/http/middlewares/auth";
 import logger from "@/lib/logger";
 
@@ -98,12 +97,14 @@ export function createHttpApp({ runPromise }: { runPromise: RunPromise }) {
   app.use("/v1/redistribution-requests/*", requireAuthMiddleware);
   app.use("/v1/suppliers", requireAdminMiddleware);
   app.use("/v1/suppliers/*", requireAdminMiddleware);
-  app.use("/v1/users/manage-users/*", requireBackofficeMiddleware);
+  app.use("/v1/users/manage-users/*", requireAdminMiddleware);
   app.use("/v1/users/manage-users/create", requireAdminMiddleware);
   app.use(
     "/v1/users/manage-users/admin-reset-password/*",
     requireAdminMiddleware,
   );
+  app.use("/v1/admin", requireAdminMiddleware);
+  app.use("/v1/admin/*", requireAdminMiddleware);
   app.use("/v1/admin/rentals", requireAdminMiddleware);
   app.use("/v1/admin/rentals/*", requireAdminMiddleware);
   app.use("/events", requireAuthMiddleware);

--- a/apps/server/src/http/app.ts
+++ b/apps/server/src/http/app.ts
@@ -98,15 +98,8 @@ export function createHttpApp({ runPromise }: { runPromise: RunPromise }) {
   app.use("/v1/suppliers", requireAdminMiddleware);
   app.use("/v1/suppliers/*", requireAdminMiddleware);
   app.use("/v1/users/manage-users/*", requireAdminMiddleware);
-  app.use("/v1/users/manage-users/create", requireAdminMiddleware);
-  app.use(
-    "/v1/users/manage-users/admin-reset-password/*",
-    requireAdminMiddleware,
-  );
   app.use("/v1/admin", requireAdminMiddleware);
   app.use("/v1/admin/*", requireAdminMiddleware);
-  app.use("/v1/admin/rentals", requireAdminMiddleware);
-  app.use("/v1/admin/rentals/*", requireAdminMiddleware);
   app.use("/events", requireAuthMiddleware);
   app.use("/v1/incidents", requireAuthMiddleware);
   app.use("/v1/incidents/*", requireAuthMiddleware);

--- a/apps/server/src/http/test/e2e/manage-users-org-assignment.e2e.int.test.ts
+++ b/apps/server/src/http/test/e2e/manage-users-org-assignment.e2e.int.test.ts
@@ -294,6 +294,76 @@ describe("manage-users org assignment e2e", () => {
     expect(technicianBody.details.code).toBe("INVALID_ORG_ASSIGNMENT");
   });
 
+  it("returns INVALID_ORG_ASSIGNMENT when create assigns internal roles to agency-owned stations", async () => {
+    const agency = await fixture.prisma.agency.create({
+      data: {
+        id: uuidv7(),
+        name: "Agency Create Guard",
+      },
+      select: { id: true },
+    });
+    const agencyStation = await fixture.factories.station({
+      name: "Agency Station Create Guard",
+      stationType: "AGENCY",
+      agencyId: agency.id,
+    });
+    const agencyTeam = await fixture.factories.technicianTeam({
+      stationId: agencyStation.id,
+      name: "Agency Team Create Guard",
+    });
+
+    const staffResponse = await fixture.app.request("http://test/v1/users/manage-users/create", {
+      method: "POST",
+      headers: adminAuthHeader(),
+      body: JSON.stringify({
+        fullname: "Agency Staff Create",
+        email: "agency-staff-create@example.com",
+        password: "password123",
+        role: "STAFF",
+        orgAssignment: {
+          stationId: agencyStation.id,
+        },
+      }),
+    });
+    const managerResponse = await fixture.app.request("http://test/v1/users/manage-users/create", {
+      method: "POST",
+      headers: adminAuthHeader(),
+      body: JSON.stringify({
+        fullname: "Agency Manager Create",
+        email: "agency-manager-create@example.com",
+        password: "password123",
+        role: "MANAGER",
+        orgAssignment: {
+          stationId: agencyStation.id,
+        },
+      }),
+    });
+    const technicianResponse = await fixture.app.request("http://test/v1/users/manage-users/create", {
+      method: "POST",
+      headers: adminAuthHeader(),
+      body: JSON.stringify({
+        fullname: "Agency Technician Create",
+        email: "agency-technician-create@example.com",
+        password: "password123",
+        role: "TECHNICIAN",
+        orgAssignment: {
+          technicianTeamId: agencyTeam.id,
+        },
+      }),
+    });
+
+    const staffBody = await staffResponse.json() as UsersContracts.UserErrorResponse;
+    const managerBody = await managerResponse.json() as UsersContracts.UserErrorResponse;
+    const technicianBody = await technicianResponse.json() as UsersContracts.UserErrorResponse;
+
+    expect(staffResponse.status).toBe(400);
+    expect(staffBody.details.code).toBe("INVALID_ORG_ASSIGNMENT");
+    expect(managerResponse.status).toBe(400);
+    expect(managerBody.details.code).toBe("INVALID_ORG_ASSIGNMENT");
+    expect(technicianResponse.status).toBe(400);
+    expect(technicianBody.details.code).toBe("INVALID_ORG_ASSIGNMENT");
+  });
+
   it("returns station role limit error when creating a second staff for the same station", async () => {
     const station = await fixture.factories.station({ name: "Station Staff Limit Create" });
 
@@ -804,6 +874,88 @@ describe("manage-users org assignment e2e", () => {
     const managerBody = await managerResponse.json() as UsersContracts.UserErrorResponse;
     const technicianBody = await technicianResponse.json() as UsersContracts.UserErrorResponse;
 
+    expect(managerResponse.status).toBe(400);
+    expect(managerBody.details.code).toBe("INVALID_ORG_ASSIGNMENT");
+    expect(technicianResponse.status).toBe(400);
+    expect(technicianBody.details.code).toBe("INVALID_ORG_ASSIGNMENT");
+  });
+
+  it("returns INVALID_ORG_ASSIGNMENT when update assigns internal roles to agency-owned stations", async () => {
+    const agency = await fixture.prisma.agency.create({
+      data: {
+        id: uuidv7(),
+        name: "Agency Update Guard",
+      },
+      select: { id: true },
+    });
+    const agencyStation = await fixture.factories.station({
+      name: "Agency Station Update Guard",
+      stationType: "AGENCY",
+      agencyId: agency.id,
+    });
+    const agencyTeam = await fixture.factories.technicianTeam({
+      stationId: agencyStation.id,
+      name: "Agency Team Update Guard",
+    });
+    const staffTarget = await fixture.factories.user({
+      role: "STAFF",
+      email: "agency-staff-update-target@example.com",
+    });
+    const managerTarget = await fixture.factories.user({
+      role: "MANAGER",
+      email: "agency-manager-update-target@example.com",
+    });
+    const technicianTarget = await fixture.factories.user({
+      role: "TECHNICIAN",
+      email: "agency-technician-update-target@example.com",
+    });
+
+    const staffResponse = await fixture.app.request(
+      `http://test/v1/users/manage-users/${staffTarget.id}`,
+      {
+        method: "PATCH",
+        headers: adminAuthHeader(),
+        body: JSON.stringify({
+          role: "STAFF",
+          orgAssignment: {
+            stationId: agencyStation.id,
+          },
+        }),
+      },
+    );
+    const managerResponse = await fixture.app.request(
+      `http://test/v1/users/manage-users/${managerTarget.id}`,
+      {
+        method: "PATCH",
+        headers: adminAuthHeader(),
+        body: JSON.stringify({
+          role: "MANAGER",
+          orgAssignment: {
+            stationId: agencyStation.id,
+          },
+        }),
+      },
+    );
+    const technicianResponse = await fixture.app.request(
+      `http://test/v1/users/manage-users/${technicianTarget.id}`,
+      {
+        method: "PATCH",
+        headers: adminAuthHeader(),
+        body: JSON.stringify({
+          role: "TECHNICIAN",
+          orgAssignment: {
+            technicianTeamId: agencyTeam.id,
+          },
+        }),
+      },
+    );
+
+    const staffBody = await staffResponse.json() as UsersContracts.UserErrorResponse;
+    const managerBody = await managerResponse.json() as UsersContracts.UserErrorResponse;
+    const technicianBody = await technicianResponse.json() as UsersContracts.UserErrorResponse;
+
+    expect(staffResponse.status).toBe(400);
+    expect(staffBody.details.code).toBe("INVALID_ORG_ASSIGNMENT");
     expect(managerResponse.status).toBe(400);
     expect(managerBody.details.code).toBe("INVALID_ORG_ASSIGNMENT");
     expect(technicianResponse.status).toBe(400);

--- a/apps/server/src/http/test/e2e/manage-users-routing.e2e.int.test.ts
+++ b/apps/server/src/http/test/e2e/manage-users-routing.e2e.int.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import { setupHttpE2eFixture } from "@/test/http/e2e-fixture";
 
 const ADMIN_USER_ID = "018d4529-6880-77a8-8e6f-4d2c88d22309";
+const STAFF_USER_ID = "018d4529-6880-77a8-8e6f-4d2c88d22310";
 
 describe("manage-users route ordering e2e", () => {
   const fixture = setupHttpE2eFixture({
@@ -34,7 +35,52 @@ describe("manage-users route ordering e2e", () => {
           verifyStatus: "VERIFIED",
         },
       });
+      await prisma.user.create({
+        data: {
+          id: STAFF_USER_ID,
+          fullName: "Route Staff",
+          email: "route-staff@example.com",
+          passwordHash: "hash123",
+          phoneNumber: null,
+          username: null,
+          avatarUrl: null,
+          locationText: null,
+          nfcCardUid: null,
+          role: "STAFF",
+          accountStatus: "ACTIVE",
+          verifyStatus: "VERIFIED",
+        },
+      });
     },
+  });
+
+  it("forbids staff from manage-users admin routes", async () => {
+    const response = await fixture.app.request("http://test/v1/users/manage-users/stats", {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${fixture.auth.makeAccessToken({ userId: STAFF_USER_ID, role: "STAFF" })}`,
+      },
+    });
+
+    expect(response.status).toBe(403);
+  });
+
+  it("forbids staff from changing managed user roles", async () => {
+    const target = await fixture.factories.user({
+      role: "USER",
+      email: "staff-cannot-promote@example.com",
+    });
+
+    const response = await fixture.app.request(`http://test/v1/users/manage-users/${target.id}`, {
+      method: "PATCH",
+      headers: {
+        "Authorization": `Bearer ${fixture.auth.makeAccessToken({ userId: STAFF_USER_ID, role: "STAFF" })}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ role: "ADMIN" }),
+    });
+
+    expect(response.status).toBe(403);
   });
 
   it("get /v1/users/manage-users/stats does not get swallowed by {userId}", async () => {


### PR DESCRIPTION
## Summary
- restrict admin user-management endpoints to admins and add a global `/v1/admin/*` admin guard
- reject assigning internal staff, managers, or technician teams to agency-owned stations during admin create/update flows
- add regression coverage for staff-forbidden manage-users access and invalid agency-station assignments

## Verification
- pnpm eslint --fix src/domain/users/services/user-org-assignment.validation.ts src/domain/users/services/test/user-org-assignment.validation.test.ts src/http/test/e2e/manage-users-org-assignment.e2e.int.test.ts src/http/app.ts src/http/test/e2e/manage-users-routing.e2e.int.test.ts
- pnpm vitest run src/domain/users/services/test/user-org-assignment.validation.test.ts
- pnpm vitest run --config vitest.e2e.config.ts --mode test src/http/test/e2e/manage-users-routing.e2e.int.test.ts src/http/test/e2e/manage-users-org-assignment.e2e.int.test.ts
- pnpm tsc --noEmit