### PR TITLE
Refactor route-local auth middleware

### DIFF
--- a/apps/server/src/http/app.ts
+++ b/apps/server/src/http/app.ts
@@ -7,11 +7,7 @@ import { logger as honoLogger } from "hono/logger";
 import type { RunPromise } from "@/http/shared/runtime";
 
 import { env } from "@/config/env";
-import {
-  currentUserMiddleware,
-  requireAdminMiddleware,
-  requireAuthMiddleware,
-} from "@/http/middlewares/auth";
+import { currentUserMiddleware } from "@/http/middlewares/auth";
 import logger from "@/lib/logger";
 
 import { registerAgencyRoutes } from "./routes/agencies";
@@ -83,27 +79,6 @@ export function createHttpApp({ runPromise }: { runPromise: RunPromise }) {
     await next();
   });
   app.use("*", currentUserMiddleware);
-  app.use("/v1/rentals/*", requireAuthMiddleware);
-  app.use("/v1/users/*", requireAuthMiddleware);
-  app.use("/v1/ratings/*", requireAuthMiddleware);
-  app.use("/v1/wallets/*", requireAuthMiddleware);
-  app.use("/v1/subscriptions/*", requireAuthMiddleware);
-  app.use("/v1/fixed-slot-templates", requireAuthMiddleware);
-  app.use("/v1/fixed-slot-templates/*", requireAuthMiddleware);
-  app.use("/v1/reservations", requireAuthMiddleware);
-  app.use("/v1/reservations/*", requireAuthMiddleware);
-  app.use("/v1/stripe/*", requireAuthMiddleware);
-  app.use("/v1/redistribution-requests", requireAuthMiddleware);
-  app.use("/v1/redistribution-requests/*", requireAuthMiddleware);
-  app.use("/v1/suppliers", requireAdminMiddleware);
-  app.use("/v1/suppliers/*", requireAdminMiddleware);
-  app.use("/v1/users/manage-users/*", requireAdminMiddleware);
-  app.use("/v1/admin", requireAdminMiddleware);
-  app.use("/v1/admin/*", requireAdminMiddleware);
-  app.use("/events", requireAuthMiddleware);
-  app.use("/v1/incidents", requireAuthMiddleware);
-  app.use("/v1/incidents/*", requireAuthMiddleware);
-  app.use("/v1/ai/*", requireAuthMiddleware);
 
   app.doc("/docs/openapi.json", serverOpenApi);
   app.get(

--- a/apps/server/src/http/routes/ai.ts
+++ b/apps/server/src/http/routes/ai.ts
@@ -1,7 +1,15 @@
+import type { RouteConfig } from "@hono/zod-openapi";
+
 import { serverRoutes } from "@mebike/shared";
 
 import { AiController } from "@/http/controllers/ai";
+import { requireAuthMiddleware } from "@/http/middlewares/auth";
 
 export function registerAiRoutes(app: import("@hono/zod-openapi").OpenAPIHono) {
-  app.openapi(serverRoutes.ai.chat, AiController.chat);
+  const chatRoute = {
+    ...serverRoutes.ai.chat,
+    middleware: [requireAuthMiddleware] as const,
+  } satisfies RouteConfig;
+
+  app.openapi(chatRoute, AiController.chat);
 }

--- a/apps/server/src/http/routes/events.ts
+++ b/apps/server/src/http/routes/events.ts
@@ -2,6 +2,7 @@ import type { OpenAPIHono } from "@hono/zod-openapi";
 
 import { streamSSE } from "hono/streaming";
 
+import { requireAuthMiddleware } from "@/http/middlewares/auth";
 import { getBikeStatusEventBus } from "@/realtime/bike-status-events";
 import { getReturnSlotEventBus } from "@/realtime/return-slot-events";
 
@@ -36,7 +37,7 @@ returnSlotEventBus.on("returnSlotExpired", (payload: { userId: string }) => {
 });
 
 export function registerEventRoutes(app: OpenAPIHono) {
-  app.get("/events", (c) => {
+  app.get("/events", requireAuthMiddleware, (c) => {
     const user = c.var.currentUser!;
     c.header("Content-Type", "text/event-stream");
     c.header("Cache-Control", "no-cache");

--- a/apps/server/src/http/routes/fixed-slot-templates.ts
+++ b/apps/server/src/http/routes/fixed-slot-templates.ts
@@ -1,6 +1,9 @@
+import type { RouteConfig } from "@hono/zod-openapi";
+
 import { serverRoutes } from "@mebike/shared";
 
 import { FixedSlotTemplateMeController } from "@/http/controllers/fixed-slot-templates";
+import { requireAuthMiddleware } from "@/http/middlewares/auth";
 
 /**
  * Đăng ký toàn bộ route HTTP cho feature fixed-slot template.
@@ -10,10 +13,40 @@ import { FixedSlotTemplateMeController } from "@/http/controllers/fixed-slot-tem
 export function registerFixedSlotTemplateRoutes(app: import("@hono/zod-openapi").OpenAPIHono) {
   const fixedSlotTemplates = serverRoutes.fixedSlotTemplates;
 
-  app.openapi(fixedSlotTemplates.removeFixedSlotTemplateDate, FixedSlotTemplateMeController.removeFixedSlotTemplateDate);
-  app.openapi(fixedSlotTemplates.getFixedSlotTemplate, FixedSlotTemplateMeController.getFixedSlotTemplate);
-  app.openapi(fixedSlotTemplates.createFixedSlotTemplate, FixedSlotTemplateMeController.createFixedSlotTemplate);
-  app.openapi(fixedSlotTemplates.cancelFixedSlotTemplate, FixedSlotTemplateMeController.cancelFixedSlotTemplate);
-  app.openapi(fixedSlotTemplates.updateFixedSlotTemplate, FixedSlotTemplateMeController.updateFixedSlotTemplate);
-  app.openapi(fixedSlotTemplates.listFixedSlotTemplates, FixedSlotTemplateMeController.listFixedSlotTemplates);
+  const removeFixedSlotTemplateDateRoute = {
+    ...fixedSlotTemplates.removeFixedSlotTemplateDate,
+    middleware: [requireAuthMiddleware] as const,
+  } satisfies RouteConfig;
+
+  const getFixedSlotTemplateRoute = {
+    ...fixedSlotTemplates.getFixedSlotTemplate,
+    middleware: [requireAuthMiddleware] as const,
+  } satisfies RouteConfig;
+
+  const createFixedSlotTemplateRoute = {
+    ...fixedSlotTemplates.createFixedSlotTemplate,
+    middleware: [requireAuthMiddleware] as const,
+  } satisfies RouteConfig;
+
+  const cancelFixedSlotTemplateRoute = {
+    ...fixedSlotTemplates.cancelFixedSlotTemplate,
+    middleware: [requireAuthMiddleware] as const,
+  } satisfies RouteConfig;
+
+  const updateFixedSlotTemplateRoute = {
+    ...fixedSlotTemplates.updateFixedSlotTemplate,
+    middleware: [requireAuthMiddleware] as const,
+  } satisfies RouteConfig;
+
+  const listFixedSlotTemplatesRoute = {
+    ...fixedSlotTemplates.listFixedSlotTemplates,
+    middleware: [requireAuthMiddleware] as const,
+  } satisfies RouteConfig;
+
+  app.openapi(removeFixedSlotTemplateDateRoute, FixedSlotTemplateMeController.removeFixedSlotTemplateDate);
+  app.openapi(getFixedSlotTemplateRoute, FixedSlotTemplateMeController.getFixedSlotTemplate);
+  app.openapi(createFixedSlotTemplateRoute, FixedSlotTemplateMeController.createFixedSlotTemplate);
+  app.openapi(cancelFixedSlotTemplateRoute, FixedSlotTemplateMeController.cancelFixedSlotTemplate);
+  app.openapi(updateFixedSlotTemplateRoute, FixedSlotTemplateMeController.updateFixedSlotTemplate);
+  app.openapi(listFixedSlotTemplatesRoute, FixedSlotTemplateMeController.listFixedSlotTemplates);
 }

--- a/apps/server/src/http/routes/ratings.ts
+++ b/apps/server/src/http/routes/ratings.ts
@@ -3,12 +3,20 @@ import type { RouteConfig } from "@hono/zod-openapi";
 import { serverRoutes } from "@mebike/shared";
 
 import { RatingAdminController, RatingMeController } from "@/http/controllers/ratings";
-import { requireAdminMiddleware } from "@/http/middlewares/auth";
+import {
+  requireAdminMiddleware,
+  requireAuthMiddleware,
+} from "@/http/middlewares/auth";
 
 export function registerRatingRoutes(app: import("@hono/zod-openapi").OpenAPIHono) {
   const ratings = serverRoutes.ratings;
 
-  app.openapi(ratings.create, RatingMeController.create);
+  const createRoute = {
+    ...ratings.create,
+    middleware: [requireAuthMiddleware] as const,
+  } satisfies RouteConfig;
+
+  app.openapi(createRoute, RatingMeController.create);
   const adminListRoute = {
     ...ratings.adminList,
     middleware: [requireAdminMiddleware] as const,
@@ -23,8 +31,28 @@ export function registerRatingRoutes(app: import("@hono/zod-openapi").OpenAPIHon
 
   app.openapi(adminGetRoute, RatingAdminController.adminGetRating);
 
-  app.openapi(ratings.getReasons, RatingMeController.getReasons);
-  app.openapi(ratings.getBikeSummary, RatingMeController.getBikeSummary);
-  app.openapi(ratings.getStationSummary, RatingMeController.getStationSummary);
-  app.openapi(ratings.getByRental, RatingMeController.getByRental);
+  const getReasonsRoute = {
+    ...ratings.getReasons,
+    middleware: [requireAuthMiddleware] as const,
+  } satisfies RouteConfig;
+
+  const getBikeSummaryRoute = {
+    ...ratings.getBikeSummary,
+    middleware: [requireAuthMiddleware] as const,
+  } satisfies RouteConfig;
+
+  const getStationSummaryRoute = {
+    ...ratings.getStationSummary,
+    middleware: [requireAuthMiddleware] as const,
+  } satisfies RouteConfig;
+
+  const getByRentalRoute = {
+    ...ratings.getByRental,
+    middleware: [requireAuthMiddleware] as const,
+  } satisfies RouteConfig;
+
+  app.openapi(getReasonsRoute, RatingMeController.getReasons);
+  app.openapi(getBikeSummaryRoute, RatingMeController.getBikeSummary);
+  app.openapi(getStationSummaryRoute, RatingMeController.getStationSummary);
+  app.openapi(getByRentalRoute, RatingMeController.getByRental);
 }

--- a/apps/server/src/http/routes/rentals.ts
+++ b/apps/server/src/http/routes/rentals.ts
@@ -12,6 +12,7 @@ import {
 import {
   requireAdminMiddleware,
   requireAgencyMiddleware,
+  requireAuthMiddleware,
   requireRentalOperatorManagerMiddleware,
   requireRentalSupportMiddleware,
   requireStaffOrManagerMiddleware,
@@ -23,16 +24,36 @@ export function registerRentalRoutes(
 ) {
   const rentals = serverRoutes.rentals;
 
-  app.openapi(rentals.createRental, RentalMeController.createRental);
+  const createRentalRoute = {
+    ...rentals.createRental,
+    middleware: [requireAuthMiddleware] as const,
+  } satisfies RouteConfig;
 
-  app.openapi(rentals.getMyRentals, RentalMeController.getMyRentals);
+  const getMyRentalsRoute = {
+    ...rentals.getMyRentals,
+    middleware: [requireAuthMiddleware] as const,
+  } satisfies RouteConfig;
+
+  const getMyCurrentRentalsRoute = {
+    ...rentals.getMyCurrentRentals,
+    middleware: [requireAuthMiddleware] as const,
+  } satisfies RouteConfig;
+
+  const getMyRentalCountsRoute = {
+    ...rentals.getMyRentalCounts,
+    middleware: [requireAuthMiddleware] as const,
+  } satisfies RouteConfig;
+
+  app.openapi(createRentalRoute, RentalMeController.createRental);
+
+  app.openapi(getMyRentalsRoute, RentalMeController.getMyRentals);
 
   app.openapi(
-    rentals.getMyCurrentRentals,
+    getMyCurrentRentalsRoute,
     RentalMeController.getMyCurrentRentals,
   );
 
-  app.openapi(rentals.getMyRentalCounts, RentalMeController.getMyRentalCounts);
+  app.openapi(getMyRentalCountsRoute, RentalMeController.getMyRentalCounts);
 
   const activeByPhoneRoute = {
     ...rentals.getActiveRentalsByPhone,
@@ -264,11 +285,31 @@ export function registerRentalRoutes(
     RentalAgencyController.agencyRejectBikeSwapRequestHandler,
   );
 
-  app.openapi(rentals.getMyRental, RentalMeController.getMyRental);
+  const getMyRentalRoute = {
+    ...rentals.getMyRental,
+    middleware: [requireAuthMiddleware] as const,
+  } satisfies RouteConfig;
 
-  app.openapi(rentals.getMyCurrentReturnSlot, RentalMeController.getMyCurrentReturnSlot);
+  const getMyCurrentReturnSlotRoute = {
+    ...rentals.getMyCurrentReturnSlot,
+    middleware: [requireAuthMiddleware] as const,
+  } satisfies RouteConfig;
 
-  app.openapi(rentals.createMyReturnSlot, RentalMeController.createMyReturnSlot);
+  const createMyReturnSlotRoute = {
+    ...rentals.createMyReturnSlot,
+    middleware: [requireAuthMiddleware] as const,
+  } satisfies RouteConfig;
 
-  app.openapi(rentals.cancelMyReturnSlot, RentalMeController.cancelMyReturnSlot);
+  const cancelMyReturnSlotRoute = {
+    ...rentals.cancelMyReturnSlot,
+    middleware: [requireAuthMiddleware] as const,
+  } satisfies RouteConfig;
+
+  app.openapi(getMyRentalRoute, RentalMeController.getMyRental);
+
+  app.openapi(getMyCurrentReturnSlotRoute, RentalMeController.getMyCurrentReturnSlot);
+
+  app.openapi(createMyReturnSlotRoute, RentalMeController.createMyReturnSlot);
+
+  app.openapi(cancelMyReturnSlotRoute, RentalMeController.cancelMyReturnSlot);
 }

--- a/apps/server/src/http/routes/reservations.ts
+++ b/apps/server/src/http/routes/reservations.ts
@@ -11,17 +11,43 @@ import {
 import {
   requireAdminMiddleware,
   requireAgencyMiddleware,
+  requireAuthMiddleware,
   requireStaffOrManagerMiddleware,
 } from "@/http/middlewares/auth";
 
 export function registerReservationRoutes(app: import("@hono/zod-openapi").OpenAPIHono) {
   const reservations = serverRoutes.reservations;
 
-  app.openapi(reservations.reserveBike, ReservationMeController.reserveBike);
-  app.openapi(reservations.confirmReservation, ReservationMeController.confirmReservation);
-  app.openapi(reservations.cancelReservation, ReservationMeController.cancelReservation);
-  app.openapi(reservations.listMyReservations, ReservationMeController.listMyReservations);
-  app.openapi(reservations.getMyReservation, ReservationMeController.getMyReservation);
+  const reserveBikeRoute = {
+    ...reservations.reserveBike,
+    middleware: [requireAuthMiddleware] as const,
+  } satisfies RouteConfig;
+
+  const confirmReservationRoute = {
+    ...reservations.confirmReservation,
+    middleware: [requireAuthMiddleware] as const,
+  } satisfies RouteConfig;
+
+  const cancelReservationRoute = {
+    ...reservations.cancelReservation,
+    middleware: [requireAuthMiddleware] as const,
+  } satisfies RouteConfig;
+
+  const listMyReservationsRoute = {
+    ...reservations.listMyReservations,
+    middleware: [requireAuthMiddleware] as const,
+  } satisfies RouteConfig;
+
+  const getMyReservationRoute = {
+    ...reservations.getMyReservation,
+    middleware: [requireAuthMiddleware] as const,
+  } satisfies RouteConfig;
+
+  app.openapi(reserveBikeRoute, ReservationMeController.reserveBike);
+  app.openapi(confirmReservationRoute, ReservationMeController.confirmReservation);
+  app.openapi(cancelReservationRoute, ReservationMeController.cancelReservation);
+  app.openapi(listMyReservationsRoute, ReservationMeController.listMyReservations);
+  app.openapi(getMyReservationRoute, ReservationMeController.getMyReservation);
 
   const adminListRoute = {
     ...reservations.adminListReservations,

--- a/apps/server/src/http/routes/stripe-connect.routes.ts
+++ b/apps/server/src/http/routes/stripe-connect.routes.ts
@@ -1,8 +1,16 @@
+import type { RouteConfig } from "@hono/zod-openapi";
+
 import { serverRoutes } from "@mebike/shared";
 
 import { WalletStripeController } from "@/http/controllers/wallets";
+import { requireAuthMiddleware } from "@/http/middlewares/auth";
 
 export function registerStripeConnectRoutes(app: import("@hono/zod-openapi").OpenAPIHono) {
   const stripeRoutes = serverRoutes.stripe;
-  app.openapi(stripeRoutes.startStripeConnectOnboarding, WalletStripeController.startStripeConnectOnboarding);
+  const startStripeConnectOnboardingRoute = {
+    ...stripeRoutes.startStripeConnectOnboarding,
+    middleware: [requireAuthMiddleware] as const,
+  } satisfies RouteConfig;
+
+  app.openapi(startStripeConnectOnboardingRoute, WalletStripeController.startStripeConnectOnboarding);
 }

--- a/apps/server/src/http/routes/subscriptions.ts
+++ b/apps/server/src/http/routes/subscriptions.ts
@@ -7,7 +7,10 @@ import {
   SubscriptionMeController,
   SubscriptionPublicController,
 } from "@/http/controllers/subscriptions";
-import { requireAdminMiddleware } from "@/http/middlewares/auth";
+import {
+  requireAdminMiddleware,
+  requireAuthMiddleware,
+} from "@/http/middlewares/auth";
 
 export function registerSubscriptionRoutes(app: import("@hono/zod-openapi").OpenAPIHono) {
   const subscriptions = serverRoutes.subscriptions;
@@ -20,11 +23,36 @@ export function registerSubscriptionRoutes(app: import("@hono/zod-openapi").Open
     middleware: [requireAdminMiddleware] as const,
   } satisfies RouteConfig;
 
-  app.openapi(subscriptions.listSubscriptionPackages, SubscriptionPublicController.listSubscriptionPackages);
-  app.openapi(subscriptions.getSubscription, SubscriptionMeController.getSubscription);
-  app.openapi(subscriptions.listSubscriptions, SubscriptionMeController.listSubscriptions);
-  app.openapi(subscriptions.createSubscription, SubscriptionMeController.createSubscription);
-  app.openapi(subscriptions.activateSubscription, SubscriptionMeController.activateSubscription);
+  const listSubscriptionPackagesRoute = {
+    ...subscriptions.listSubscriptionPackages,
+    middleware: [requireAuthMiddleware] as const,
+  } satisfies RouteConfig;
+
+  const getSubscriptionRoute = {
+    ...subscriptions.getSubscription,
+    middleware: [requireAuthMiddleware] as const,
+  } satisfies RouteConfig;
+
+  const listSubscriptionsRoute = {
+    ...subscriptions.listSubscriptions,
+    middleware: [requireAuthMiddleware] as const,
+  } satisfies RouteConfig;
+
+  const createSubscriptionRoute = {
+    ...subscriptions.createSubscription,
+    middleware: [requireAuthMiddleware] as const,
+  } satisfies RouteConfig;
+
+  const activateSubscriptionRoute = {
+    ...subscriptions.activateSubscription,
+    middleware: [requireAuthMiddleware] as const,
+  } satisfies RouteConfig;
+
+  app.openapi(listSubscriptionPackagesRoute, SubscriptionPublicController.listSubscriptionPackages);
+  app.openapi(getSubscriptionRoute, SubscriptionMeController.getSubscription);
+  app.openapi(listSubscriptionsRoute, SubscriptionMeController.listSubscriptions);
+  app.openapi(createSubscriptionRoute, SubscriptionMeController.createSubscription);
+  app.openapi(activateSubscriptionRoute, SubscriptionMeController.activateSubscription);
   app.openapi(adminListSubscriptionsRoute, SubscriptionAdminController.adminListSubscriptions);
   app.openapi(adminGetSubscriptionRoute, SubscriptionAdminController.adminGetSubscription);
 }

--- a/apps/server/src/http/routes/suppliers.ts
+++ b/apps/server/src/http/routes/suppliers.ts
@@ -1,20 +1,68 @@
+import type { RouteConfig } from "@hono/zod-openapi";
+
 import { serverRoutes } from "@mebike/shared";
 
 import {
   SupplierAdminController,
   SupplierStatsController,
 } from "@/http/controllers/suppliers";
+import { requireAdminMiddleware } from "@/http/middlewares/auth";
 
 export function registerSupplierRoutes(app: import("@hono/zod-openapi").OpenAPIHono) {
   const suppliers = serverRoutes.suppliers;
 
-  app.openapi(suppliers.listSuppliers, SupplierAdminController.listSuppliers);
-  app.openapi(suppliers.createSupplier, SupplierAdminController.createSupplier);
-  app.openapi(suppliers.getAllSupplierStats, SupplierStatsController.getAllSupplierStats);
-  app.openapi(suppliers.getSupplierStatsSummary, SupplierStatsController.getSupplierStatsSummary);
-  app.openapi(suppliers.getSupplier, SupplierAdminController.getSupplier);
-  app.openapi(suppliers.getSupplierStats, SupplierStatsController.getSupplierStats);
-  app.openapi(suppliers.updateSupplier, SupplierAdminController.updateSupplier);
-  app.openapi(suppliers.updateSupplierStatus, SupplierAdminController.updateSupplierStatus);
-  app.openapi(suppliers.deleteSupplier, SupplierAdminController.deleteSupplier);
+  const listSuppliersRoute = {
+    ...suppliers.listSuppliers,
+    middleware: [requireAdminMiddleware] as const,
+  } satisfies RouteConfig;
+
+  const createSupplierRoute = {
+    ...suppliers.createSupplier,
+    middleware: [requireAdminMiddleware] as const,
+  } satisfies RouteConfig;
+
+  const getAllSupplierStatsRoute = {
+    ...suppliers.getAllSupplierStats,
+    middleware: [requireAdminMiddleware] as const,
+  } satisfies RouteConfig;
+
+  const getSupplierStatsSummaryRoute = {
+    ...suppliers.getSupplierStatsSummary,
+    middleware: [requireAdminMiddleware] as const,
+  } satisfies RouteConfig;
+
+  const getSupplierRoute = {
+    ...suppliers.getSupplier,
+    middleware: [requireAdminMiddleware] as const,
+  } satisfies RouteConfig;
+
+  const getSupplierStatsRoute = {
+    ...suppliers.getSupplierStats,
+    middleware: [requireAdminMiddleware] as const,
+  } satisfies RouteConfig;
+
+  const updateSupplierRoute = {
+    ...suppliers.updateSupplier,
+    middleware: [requireAdminMiddleware] as const,
+  } satisfies RouteConfig;
+
+  const updateSupplierStatusRoute = {
+    ...suppliers.updateSupplierStatus,
+    middleware: [requireAdminMiddleware] as const,
+  } satisfies RouteConfig;
+
+  const deleteSupplierRoute = {
+    ...suppliers.deleteSupplier,
+    middleware: [requireAdminMiddleware] as const,
+  } satisfies RouteConfig;
+
+  app.openapi(listSuppliersRoute, SupplierAdminController.listSuppliers);
+  app.openapi(createSupplierRoute, SupplierAdminController.createSupplier);
+  app.openapi(getAllSupplierStatsRoute, SupplierStatsController.getAllSupplierStats);
+  app.openapi(getSupplierStatsSummaryRoute, SupplierStatsController.getSupplierStatsSummary);
+  app.openapi(getSupplierRoute, SupplierAdminController.getSupplier);
+  app.openapi(getSupplierStatsRoute, SupplierStatsController.getSupplierStats);
+  app.openapi(updateSupplierRoute, SupplierAdminController.updateSupplier);
+  app.openapi(updateSupplierStatusRoute, SupplierAdminController.updateSupplierStatus);
+  app.openapi(deleteSupplierRoute, SupplierAdminController.deleteSupplier);
 }

--- a/apps/server/src/http/routes/users/admin-stats.ts
+++ b/apps/server/src/http/routes/users/admin-stats.ts
@@ -1,12 +1,41 @@
+import type { RouteConfig } from "@hono/zod-openapi";
+
 import { serverRoutes } from "@mebike/shared";
 
 import { AdminUserStatsController } from "@/http/controllers/users";
+import { requireAdminMiddleware } from "@/http/middlewares/auth";
 
 export function registerAdminUserStatsRoutes(app: import("@hono/zod-openapi").OpenAPIHono) {
   const users = serverRoutes.users;
-  app.openapi(users.adminStats, AdminUserStatsController.adminStats);
-  app.openapi(users.adminActiveUsers, AdminUserStatsController.adminActiveUsers);
-  app.openapi(users.adminTopRenters, AdminUserStatsController.adminTopRenters);
-  app.openapi(users.adminNewUsers, AdminUserStatsController.adminNewUsers);
-  app.openapi(users.adminDashboardStats, AdminUserStatsController.adminDashboardStats);
+
+  const adminStatsRoute = {
+    ...users.adminStats,
+    middleware: [requireAdminMiddleware] as const,
+  } satisfies RouteConfig;
+
+  const adminActiveUsersRoute = {
+    ...users.adminActiveUsers,
+    middleware: [requireAdminMiddleware] as const,
+  } satisfies RouteConfig;
+
+  const adminTopRentersRoute = {
+    ...users.adminTopRenters,
+    middleware: [requireAdminMiddleware] as const,
+  } satisfies RouteConfig;
+
+  const adminNewUsersRoute = {
+    ...users.adminNewUsers,
+    middleware: [requireAdminMiddleware] as const,
+  } satisfies RouteConfig;
+
+  const adminDashboardStatsRoute = {
+    ...users.adminDashboardStats,
+    middleware: [requireAdminMiddleware] as const,
+  } satisfies RouteConfig;
+
+  app.openapi(adminStatsRoute, AdminUserStatsController.adminStats);
+  app.openapi(adminActiveUsersRoute, AdminUserStatsController.adminActiveUsers);
+  app.openapi(adminTopRentersRoute, AdminUserStatsController.adminTopRenters);
+  app.openapi(adminNewUsersRoute, AdminUserStatsController.adminNewUsers);
+  app.openapi(adminDashboardStatsRoute, AdminUserStatsController.adminDashboardStats);
 }

--- a/apps/server/src/http/routes/users/admin.ts
+++ b/apps/server/src/http/routes/users/admin.ts
@@ -1,14 +1,53 @@
+import type { RouteConfig } from "@hono/zod-openapi";
+
 import { serverRoutes } from "@mebike/shared";
 
 import { AdminUsersController } from "@/http/controllers/users";
+import { requireAdminMiddleware } from "@/http/middlewares/auth";
 
 export function registerAdminUserRoutes(app: import("@hono/zod-openapi").OpenAPIHono) {
   const users = serverRoutes.users;
-  app.openapi(users.adminList, AdminUsersController.adminList);
-  app.openapi(users.adminSearch, AdminUsersController.adminSearch);
-  app.openapi(users.adminTechnicians, AdminUsersController.adminTechnicians);
-  app.openapi(users.adminDetail, AdminUsersController.adminDetail);
-  app.openapi(users.adminUpdate, AdminUsersController.adminUpdate);
-  app.openapi(users.adminCreate, AdminUsersController.adminCreate);
-  app.openapi(users.adminResetPassword, AdminUsersController.adminResetPassword);
+
+  const adminListRoute = {
+    ...users.adminList,
+    middleware: [requireAdminMiddleware] as const,
+  } satisfies RouteConfig;
+
+  const adminSearchRoute = {
+    ...users.adminSearch,
+    middleware: [requireAdminMiddleware] as const,
+  } satisfies RouteConfig;
+
+  const adminTechniciansRoute = {
+    ...users.adminTechnicians,
+    middleware: [requireAdminMiddleware] as const,
+  } satisfies RouteConfig;
+
+  const adminDetailRoute = {
+    ...users.adminDetail,
+    middleware: [requireAdminMiddleware] as const,
+  } satisfies RouteConfig;
+
+  const adminUpdateRoute = {
+    ...users.adminUpdate,
+    middleware: [requireAdminMiddleware] as const,
+  } satisfies RouteConfig;
+
+  const adminCreateRoute = {
+    ...users.adminCreate,
+    middleware: [requireAdminMiddleware] as const,
+  } satisfies RouteConfig;
+
+  const adminResetPasswordRoute = {
+    ...users.adminResetPassword,
+    middleware: [requireAdminMiddleware] as const,
+  } satisfies RouteConfig;
+
+  app.openapi(adminListRoute, AdminUsersController.adminList);
+  app.openapi(adminSearchRoute, AdminUsersController.adminSearch);
+  app.openapi(adminTechniciansRoute, AdminUsersController.adminTechnicians);
+  app.openapi(adminDetailRoute, AdminUsersController.adminDetail);
+  app.openapi(adminUpdateRoute, AdminUsersController.adminUpdate);
+  app.openapi(adminCreateRoute, AdminUsersController.adminCreate);
+  app.openapi(adminResetPasswordRoute, AdminUsersController.adminResetPassword);
 }

--- a/apps/server/src/http/routes/users/self.ts
+++ b/apps/server/src/http/routes/users/self.ts
@@ -1,7 +1,10 @@
+import type { RouteConfig } from "@hono/zod-openapi";
+
 import { serverRoutes, UsersContracts } from "@mebike/shared";
 import { bodyLimit } from "hono/body-limit";
 
 import { UsersController } from "@/http/controllers/users";
+import { requireAuthMiddleware } from "@/http/middlewares/auth";
 
 const AVATAR_REQUEST_MAX_BYTES = 6 * 1024 * 1024;
 
@@ -17,8 +20,29 @@ function avatarTooLargeResponse(c: import("hono").Context) {
 
 export function registerUserSelfRoutes(app: import("@hono/zod-openapi").OpenAPIHono) {
   const users = serverRoutes.users;
-  app.openapi(users.me, UsersController.me);
-  app.openapi(users.updateMe, UsersController.updateMe);
+
+  const meRoute = {
+    ...users.me,
+    middleware: [requireAuthMiddleware] as const,
+  } satisfies RouteConfig;
+
+  const updateMeRoute = {
+    ...users.updateMe,
+    middleware: [requireAuthMiddleware] as const,
+  } satisfies RouteConfig;
+
+  const uploadMyAvatarRoute = {
+    ...users.uploadMyAvatar,
+    middleware: [requireAuthMiddleware] as const,
+  } satisfies RouteConfig;
+
+  const changePasswordRoute = {
+    ...users.changePassword,
+    middleware: [requireAuthMiddleware] as const,
+  } satisfies RouteConfig;
+
+  app.openapi(meRoute, UsersController.me);
+  app.openapi(updateMeRoute, UsersController.updateMe);
   app.use(users.uploadMyAvatar.path, async (c, next) => {
     const contentLength = c.req.header("content-length");
     const parsedLength = contentLength ? Number(contentLength) : null;
@@ -33,6 +57,6 @@ export function registerUserSelfRoutes(app: import("@hono/zod-openapi").OpenAPIH
     maxSize: AVATAR_REQUEST_MAX_BYTES,
     onError: c => avatarTooLargeResponse(c),
   }));
-  app.openapi(users.uploadMyAvatar, UsersController.uploadMyAvatar);
-  app.openapi(users.changePassword, UsersController.changePassword);
+  app.openapi(uploadMyAvatarRoute, UsersController.uploadMyAvatar);
+  app.openapi(changePasswordRoute, UsersController.changePassword);
 }

--- a/apps/server/src/http/routes/wallets.ts
+++ b/apps/server/src/http/routes/wallets.ts
@@ -3,18 +3,46 @@ import type { RouteConfig } from "@hono/zod-openapi";
 import { serverRoutes } from "@mebike/shared";
 
 import { WalletAdminController, WalletMeController } from "@/http/controllers/wallets";
-import { requireAdminMiddleware } from "@/http/middlewares/auth";
+import {
+  requireAdminMiddleware,
+  requireAuthMiddleware,
+} from "@/http/middlewares/auth";
 
 export function registerWalletRoutes(app: import("@hono/zod-openapi").OpenAPIHono) {
   const wallets = serverRoutes.wallets;
 
-  app.openapi(wallets.getMyWallet, WalletMeController.getMyWallet);
-  app.openapi(wallets.listMyWalletTransactions, WalletMeController.listMyWalletTransactions);
+  const getMyWalletRoute = {
+    ...wallets.getMyWallet,
+    middleware: [requireAuthMiddleware] as const,
+  } satisfies RouteConfig;
+
+  const listMyWalletTransactionsRoute = {
+    ...wallets.listMyWalletTransactions,
+    middleware: [requireAuthMiddleware] as const,
+  } satisfies RouteConfig;
+
+  const createStripeTopupSessionRoute = {
+    ...wallets.createStripeTopupSession,
+    middleware: [requireAuthMiddleware] as const,
+  } satisfies RouteConfig;
+
+  const createStripeTopupPaymentSheetRoute = {
+    ...wallets.createStripeTopupPaymentSheet,
+    middleware: [requireAuthMiddleware] as const,
+  } satisfies RouteConfig;
+
+  const createWalletWithdrawalRoute = {
+    ...wallets.createWalletWithdrawal,
+    middleware: [requireAuthMiddleware] as const,
+  } satisfies RouteConfig;
+
+  app.openapi(getMyWalletRoute, WalletMeController.getMyWallet);
+  app.openapi(listMyWalletTransactionsRoute, WalletMeController.listMyWalletTransactions);
   // app.openapi(wallets.creditMyWallet, WalletMeController.creditMyWallet);
   // app.openapi(wallets.debitMyWallet, WalletMeController.debitMyWallet);
-  app.openapi(wallets.createStripeTopupSession, WalletMeController.createStripeTopupSession);
-  app.openapi(wallets.createStripeTopupPaymentSheet, WalletMeController.createStripeTopupPaymentSheet);
-  app.openapi(wallets.createWalletWithdrawal, WalletMeController.createWalletWithdrawal);
+  app.openapi(createStripeTopupSessionRoute, WalletMeController.createStripeTopupSession);
+  app.openapi(createStripeTopupPaymentSheetRoute, WalletMeController.createStripeTopupPaymentSheet);
+  app.openapi(createWalletWithdrawalRoute, WalletMeController.createWalletWithdrawal);
 
   const adminGetUserWalletRoute = {
     ...wallets.adminGetUserWallet,


### PR DESCRIPTION
## Summary
- move auth and admin middleware from `apps/server/src/http/app.ts` into the owning route registration modules
- keep `app.ts` focused on global bootstrap concerns while making access policy readable beside each protected endpoint
- verify the refactor with `pnpm tsc --noEmit` and focused server e2e routing tests run sequentially