### PR TITLE
Update staff station read access

### DIFF
--- a/apps/server/src/http/controllers/stations/staff.controller.ts
+++ b/apps/server/src/http/controllers/stations/staff.controller.ts
@@ -15,44 +15,15 @@ import type {
 
 import { StationErrorCodeSchema, stationErrorMessages } from "./shared";
 
-function getStationScopedRoleScope(currentUser: {
-  role: string;
-  operatorStationId?: string;
-}) {
-  if (
-    currentUser.role === "STAFF"
-    || currentUser.role === "MANAGER"
-    || currentUser.role === "TECHNICIAN"
-  ) {
-    return currentUser.operatorStationId ?? null;
-  }
-
-  return undefined;
-}
-
 const staffListStations: RouteHandler<StationsRoutes["staffListStations"]> = async (c) => {
   const query = c.req.valid("query");
-  const stationScopeId = getStationScopedRoleScope(c.var.currentUser!);
-
-  if (stationScopeId === null) {
-    return c.json<StationListResponse, 200>({
-      data: [],
-      pagination: {
-        page: query.page ?? 1,
-        pageSize: query.pageSize ?? 50,
-        total: 0,
-        totalPages: 0,
-      },
-    }, 200);
-  }
 
   const eff = withLoggedCause(
     Effect.gen(function* () {
       const service = yield* StationQueryServiceTag;
 
-      const page = yield* service.listStations(
+      return yield* service.listStations(
         {
-          id: stationScopeId!,
           name: query.name,
           address: query.address,
           stationType: query.stationType,
@@ -66,14 +37,6 @@ const staffListStations: RouteHandler<StationsRoutes["staffListStations"]> = asy
           sortDir: query.sortDir ?? "asc",
         },
       );
-
-      if (page.total > 0) {
-        return page;
-      }
-
-      yield* service.getStationById(stationScopeId!);
-
-      return page;
     }),
     "GET /v1/staff/stations",
   );
@@ -92,30 +55,18 @@ const staffListStations: RouteHandler<StationsRoutes["staffListStations"]> = asy
         },
       }, 200)),
     Match.tag("Left", () =>
-      c.json<StationErrorResponse, 404>({
-        error: stationErrorMessages.STATION_NOT_FOUND,
+      c.json<StationErrorResponse, 400>({
+        error: stationErrorMessages.INVALID_QUERY_PARAMS,
         details: {
-          code: StationErrorCodeSchema.enum.STATION_NOT_FOUND,
-          stationId: stationScopeId!,
+          code: StationErrorCodeSchema.enum.INVALID_QUERY_PARAMS,
         },
-      }, 404)),
+      }, 400)),
     Match.exhaustive,
   );
 };
 
 const staffGetStation: RouteHandler<StationsRoutes["staffGetStation"]> = async (c) => {
   const { stationId } = c.req.valid("param");
-  const stationScopeId = getStationScopedRoleScope(c.var.currentUser!);
-
-  if (stationScopeId === null || stationId !== stationScopeId) {
-    return c.json<StationErrorResponse, 404>({
-      error: stationErrorMessages.STATION_NOT_FOUND,
-      details: {
-        code: StationErrorCodeSchema.enum.STATION_NOT_FOUND,
-        stationId,
-      },
-    }, 404);
-  }
 
   const eff = withLoggedCause(
     Effect.gen(function* () {

--- a/apps/server/src/http/test/e2e/operator-stations-routing.e2e.int.test.ts
+++ b/apps/server/src/http/test/e2e/operator-stations-routing.e2e.int.test.ts
@@ -46,9 +46,9 @@ describe("operator stations routing e2e", () => {
     };
   }
 
-  it("lists only the assigned station for staff", async () => {
+  it("lists all stations for staff", async () => {
     const currentStation = await fixture.factories.station({ capacity: 5, name: "Current Station" });
-    await fixture.factories.station({ capacity: 5, name: "Hidden Station" });
+    const hiddenStation = await fixture.factories.station({ capacity: 5, name: "Hidden Station" });
     const token = await createOperatorToken("STAFF", currentStation.id);
 
     const response = await fixture.app.request("http://test/v1/staff/stations?page=1&pageSize=20", {
@@ -60,11 +60,13 @@ describe("operator stations routing e2e", () => {
     const body = await response.json() as StationsContracts.StationListResponse;
 
     expect(response.status).toBe(200);
-    expect(body.data).toHaveLength(1);
-    expect(body.data[0]?.id).toBe(currentStation.id);
+    expect(body.data.length).toBeGreaterThanOrEqual(2);
+    expect(body.data.map(station => station.id)).toEqual(
+      expect.arrayContaining([currentStation.id, hiddenStation.id]),
+    );
   });
 
-  it("returns 404 when technician requests a different station detail", async () => {
+  it("allows technician to request a different station detail", async () => {
     const currentStation = await fixture.factories.station({ capacity: 5 });
     const hiddenStation = await fixture.factories.station({ capacity: 5 });
     const token = await createOperatorToken("TECHNICIAN", currentStation.id);
@@ -75,7 +77,10 @@ describe("operator stations routing e2e", () => {
       },
     });
 
-    expect(response.status).toBe(404);
+    const body = await response.json() as StationsContracts.StationReadSummary;
+
+    expect(response.status).toBe(200);
+    expect(body.id).toBe(hiddenStation.id);
   });
 
   it("lists only the assigned station for agency", async () => {

--- a/packages/shared/src/contracts/server/routes/stations/queries.ts
+++ b/packages/shared/src/contracts/server/routes/stations/queries.ts
@@ -216,7 +216,7 @@ export const staffListStations = createRoute({
   },
   responses: {
     200: {
-      description: "List current operator station only",
+      description: "List stations for staff, manager, or technician",
       content: {
         "application/json": { schema: StationListResponseSchema },
       },
@@ -228,7 +228,7 @@ export const staffListStations = createRoute({
       },
     },
     404: {
-      description: "Assigned station not found",
+      description: "Station not found",
       content: {
         "application/json": {
           schema: StationErrorResponseSchema,
@@ -284,7 +284,7 @@ export const staffGetStation = createRoute({
   },
   responses: {
     200: {
-      description: "Get station details for current operator station",
+      description: "Get station details for staff, manager, or technician",
       content: {
         "application/json": { schema: StationReadSummarySchemaOpenApi },
       },


### PR DESCRIPTION
## Summary
- remove station-assignment scoping from staff station read endpoints while keeping the existing `/v1/staff/stations` routes and role middleware
- leave agency station routes unchanged
- update operator station e2e coverage to verify staff and technician can read across stations

## Verification
- pnpm eslint --fix apps/server/src/http/controllers/stations/staff.controller.ts apps/server/src/http/test/e2e/operator-stations-routing.e2e.int.test.ts packages/shared/src/contracts/server/routes/stations/queries.ts
- pnpm --dir ../../packages/shared build
- pnpm tsc --noEmit
- pnpm vitest run --config vitest.e2e.config.ts src/http/test/e2e/operator-stations-routing.e2e.int.test.ts