### PR TITLE
Paginate admin technician team list

### DIFF
--- a/apps/server/src/domain/technician-teams/repository/read/technician-team.read.repository.ts
+++ b/apps/server/src/domain/technician-teams/repository/read/technician-team.read.repository.ts
@@ -3,6 +3,7 @@ import { Effect, Option } from "effect";
 import type { PrismaClient, Prisma as PrismaTypes } from "generated/prisma/client";
 
 import { defectOn } from "@/domain/shared";
+import { makePageResult, normalizedPage } from "@/domain/shared/pagination";
 import { pickDefined } from "@/domain/shared/pick-defined";
 
 import type { TechnicianTeamAvailableOption, TechnicianTeamDetailRow, TechnicianTeamRow } from "../../models";
@@ -149,45 +150,64 @@ export function makeTechnicianTeamReadRepository(
         defectOn(TechnicianTeamRepositoryError),
       ),
 
-    list: args =>
-      Effect.tryPromise({
-        try: () =>
-          client.technicianTeam.findMany({
-            where: pickDefined({
-              stationId: args?.stationId,
-              availabilityStatus: args?.availabilityStatus,
-            }),
-            orderBy: {
-              name: "asc",
-            },
-            select: {
-              id: true,
-              name: true,
-              stationId: true,
-              station: {
+    list: (filter, pageReq) =>
+      Effect.gen(function* () {
+        const { page, pageSize, skip, take } = normalizedPage(pageReq);
+        const where = pickDefined({
+          stationId: filter.stationId,
+          availabilityStatus: filter.availabilityStatus,
+        });
+
+        const [total, rows] = yield* Effect.all([
+          Effect.tryPromise({
+            try: () =>
+              client.technicianTeam.count({
+                where,
+              }),
+            catch: cause =>
+              new TechnicianTeamRepositoryError({
+                operation: "list.count",
+                cause,
+              }),
+          }),
+          Effect.tryPromise({
+            try: () =>
+              client.technicianTeam.findMany({
+                where,
+                skip,
+                take,
+                orderBy: {
+                  name: "asc",
+                },
                 select: {
+                  id: true,
                   name: true,
+                  stationId: true,
+                  station: {
+                    select: {
+                      name: true,
+                    },
+                  },
+                  availabilityStatus: true,
+                  createdAt: true,
+                  updatedAt: true,
+                  _count: {
+                    select: {
+                      userAssignments: true,
+                    },
+                  },
                 },
-              },
-              availabilityStatus: true,
-              createdAt: true,
-              updatedAt: true,
-              _count: {
-                select: {
-                  userAssignments: true,
-                },
-              },
-            },
+              }),
+            catch: cause =>
+              new TechnicianTeamRepositoryError({
+                operation: "list.findMany",
+                cause,
+              }),
           }),
-        catch: cause =>
-          new TechnicianTeamRepositoryError({
-            operation: "list",
-            cause,
-          }),
-      }).pipe(
-        Effect.map(rows => rows.map(mapRow)),
-        defectOn(TechnicianTeamRepositoryError),
-      ),
+        ]);
+
+        return makePageResult(rows.map(mapRow), total, page, pageSize);
+      }).pipe(defectOn(TechnicianTeamRepositoryError)),
 
     listAvailable: args =>
       Effect.tryPromise({

--- a/apps/server/src/domain/technician-teams/repository/technician-team.repository.types.ts
+++ b/apps/server/src/domain/technician-teams/repository/technician-team.repository.types.ts
@@ -1,5 +1,7 @@
 import type { Effect, Option } from "effect";
 
+import type { PageRequest, PageResult } from "@/domain/shared/pagination";
+
 import type {
   CreateTechnicianTeamInput,
   TechnicianTeamAvailableOption,
@@ -16,7 +18,10 @@ export type TechnicianTeamQueryRepo = {
   readonly getDetailById: (
     id: string,
   ) => Effect.Effect<Option.Option<TechnicianTeamDetailRow>>;
-  readonly list: (args?: TechnicianTeamFilter) => Effect.Effect<readonly TechnicianTeamRow[]>;
+  readonly list: (
+    filter: TechnicianTeamFilter,
+    pageReq: PageRequest,
+  ) => Effect.Effect<PageResult<TechnicianTeamRow>>;
   readonly listAvailable: (args?: {
     readonly stationId?: string;
   }) => Effect.Effect<readonly TechnicianTeamAvailableOption[]>;

--- a/apps/server/src/domain/technician-teams/repository/test/read/technician-team.read.repository.int.test.ts
+++ b/apps/server/src/domain/technician-teams/repository/test/read/technician-team.read.repository.int.test.ts
@@ -62,7 +62,7 @@ describe("technicianTeamReadRepository Integration", () => {
     expect(excludedCount).toBe(1);
   });
 
-  it("list returns technician teams with filters and member counts", async () => {
+  it("list returns paginated technician teams with filters and member counts", async () => {
     const stationA = await fixture.factories.station({ name: "List Team Station A" });
     const stationB = await fixture.factories.station({ name: "List Team Station B" });
     const availableTeam = await fixture.factories.technicianTeam({
@@ -85,16 +85,28 @@ describe("technicianTeamReadRepository Integration", () => {
       technicianTeamId: availableTeam.id,
     });
 
-    const rows = await runEffect(repo.list({
-      stationId: stationA.id,
-      availabilityStatus: "AVAILABLE",
-    }));
+    const page = await runEffect(repo.list(
+      {
+        stationId: stationA.id,
+        availabilityStatus: "AVAILABLE",
+      },
+      {
+        page: 1,
+        pageSize: 10,
+      },
+    ));
 
-    expect(rows).toHaveLength(1);
-    expect(rows[0]?.id).toBe(availableTeam.id);
-    expect(rows[0]?.stationId).toBe(stationA.id);
-    expect(rows[0]?.stationName).toBe("List Team Station A");
-    expect(rows[0]?.memberCount).toBe(1);
+    expect(page.items).toHaveLength(1);
+    expect(page.items[0]?.id).toBe(availableTeam.id);
+    expect(page.items[0]?.stationId).toBe(stationA.id);
+    expect(page.items[0]?.stationName).toBe("List Team Station A");
+    expect(page.items[0]?.memberCount).toBe(1);
+    expect(page).toMatchObject({
+      page: 1,
+      pageSize: 10,
+      total: 1,
+      totalPages: 1,
+    });
   });
 
   it("listAvailable omits full and unavailable teams and supports station filter", async () => {

--- a/apps/server/src/domain/technician-teams/services/technician-team-command.service.ts
+++ b/apps/server/src/domain/technician-teams/services/technician-team-command.service.ts
@@ -32,11 +32,14 @@ export function makeTechnicianTeamCommandService(args: {
           }));
         }
 
-        const existingTeams = yield* args.queryRepo.list({ stationId: input.stationId });
-        if (existingTeams.length > 0) {
+        const existingTeams = yield* args.queryRepo.list(
+          { stationId: input.stationId },
+          { page: 1, pageSize: 1 },
+        );
+        if (existingTeams.items.length > 0) {
           return yield* Effect.fail(new TechnicianTeamStationAlreadyAssigned({
             stationId: input.stationId,
-            teamId: existingTeams[0]!.id,
+            teamId: existingTeams.items[0]!.id,
           }));
         }
 

--- a/apps/server/src/domain/technician-teams/services/technician-team-query.service.ts
+++ b/apps/server/src/domain/technician-teams/services/technician-team-query.service.ts
@@ -16,7 +16,7 @@ export function makeTechnicianTeamQueryService(
           onSome: Effect.succeed,
         })),
       ),
-    listTechnicianTeams: filter => repo.list(filter),
+    listTechnicianTeams: (filter, pageReq) => repo.list(filter, pageReq),
     listAvailableTechnicianTeams: args => repo.listAvailable(args),
   };
 }

--- a/apps/server/src/domain/technician-teams/services/technician-team.service.types.ts
+++ b/apps/server/src/domain/technician-teams/services/technician-team.service.types.ts
@@ -1,5 +1,7 @@
 import type { Effect } from "effect";
 
+import type { PageRequest, PageResult } from "@/domain/shared/pagination";
+
 import type {
   TechnicianTeamInternalStationRequired,
   TechnicianTeamNotFound,
@@ -33,8 +35,9 @@ export type TechnicianTeamQueryService = {
     id: string,
   ) => Effect.Effect<TechnicianTeamDetailRow, TechnicianTeamNotFound>;
   listTechnicianTeams: (
-    filter?: TechnicianTeamFilter,
-  ) => Effect.Effect<readonly TechnicianTeamRow[]>;
+    filter: TechnicianTeamFilter,
+    pageReq: PageRequest,
+  ) => Effect.Effect<PageResult<TechnicianTeamRow>>;
   listAvailableTechnicianTeams: (args?: {
     readonly stationId?: string;
   }) => Effect.Effect<readonly TechnicianTeamAvailableOption[]>;

--- a/apps/server/src/http/controllers/technician-teams/admin.controller.ts
+++ b/apps/server/src/http/controllers/technician-teams/admin.controller.ts
@@ -30,15 +30,27 @@ const listTechnicianTeams: RouteHandler<TechnicianTeamsRoutes["adminList"]> = as
   const query = c.req.valid("query");
 
   const eff = Effect.flatMap(TechnicianTeamQueryServiceTag, service =>
-    service.listTechnicianTeams({
-      stationId: query.stationId,
-      availabilityStatus: query.availabilityStatus,
-    }));
+    service.listTechnicianTeams(
+      {
+        stationId: query.stationId,
+        availabilityStatus: query.availabilityStatus,
+      },
+      {
+        page: query.page ?? 1,
+        pageSize: query.pageSize ?? 50,
+      },
+    ));
 
   const result = await c.var.runPromise(eff);
 
   return c.json<TechnicianTeamListResponse, 200>({
-    data: result.map(toContractTechnicianTeamSummary),
+    data: result.items.map(toContractTechnicianTeamSummary),
+    pagination: {
+      page: result.page,
+      pageSize: result.pageSize,
+      total: result.total,
+      totalPages: result.totalPages,
+    },
   }, 200);
 };
 

--- a/apps/server/src/http/test/e2e/admin-technician-teams-routing.e2e.int.test.ts
+++ b/apps/server/src/http/test/e2e/admin-technician-teams-routing.e2e.int.test.ts
@@ -84,6 +84,61 @@ describe("admin technician teams routing e2e", () => {
     expect(body.data[0]?.id).toBe(matchingTeam.id);
     expect(body.data[0]?.station.id).toBe(stationA.id);
     expect(body.data[0]?.memberCount).toBe(1);
+    expect(body.pagination).toMatchObject({
+      page: 1,
+      pageSize: 50,
+      total: 1,
+      totalPages: 1,
+    });
+  });
+
+  it("paginates technician teams for admin list", async () => {
+    const stationA = await fixture.factories.station({ name: "Pagination Station A" });
+    const stationB = await fixture.factories.station({ name: "Pagination Station B" });
+    const stationC = await fixture.factories.station({ name: "Pagination Station C" });
+    await fixture.factories.technicianTeam({
+      name: "Admin Team Alpha",
+      stationId: stationA.id,
+    });
+    const betaTeam = await fixture.factories.technicianTeam({
+      name: "Admin Team Beta",
+      stationId: stationB.id,
+    });
+    await fixture.factories.technicianTeam({
+      name: "Admin Team Gamma",
+      stationId: stationC.id,
+      availabilityStatus: "UNAVAILABLE",
+    });
+    const technician = await fixture.factories.user({
+      fullname: "Paged Tech",
+      email: "paged-tech@example.com",
+      role: "TECHNICIAN",
+    });
+
+    await fixture.factories.userOrgAssignment({
+      userId: technician.id,
+      technicianTeamId: betaTeam.id,
+    });
+
+    const response = await fixture.app.request(
+      "http://test/v1/admin/technician-teams?availabilityStatus=AVAILABLE&page=2&pageSize=1",
+      {
+        method: "GET",
+        headers: authHeader(),
+      },
+    );
+    const body = await response.json() as TechnicianTeamsContracts.TechnicianTeamListResponse;
+
+    expect(response.status).toBe(200);
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0]?.id).toBe(betaTeam.id);
+    expect(body.data[0]?.memberCount).toBe(1);
+    expect(body.pagination).toMatchObject({
+      page: 2,
+      pageSize: 1,
+      total: 2,
+      totalPages: 2,
+    });
   });
 
   it("gets technician team detail with station address and members", async () => {

--- a/packages/shared/src/contracts/server/routes/technician-teams/shared.ts
+++ b/packages/shared/src/contracts/server/routes/technician-teams/shared.ts
@@ -1,5 +1,7 @@
 import { z } from "../../../../zod";
 import {
+  paginationQueryFields,
+  PaginationSchema,
   ServerErrorResponseSchema,
 } from "../../schemas";
 import {
@@ -19,6 +21,7 @@ export const TechnicianTeamIdParamSchema = z.object({
 export const TechnicianTeamListQuerySchema = z.object({
   stationId: z.uuidv7().optional(),
   availabilityStatus: TechnicianTeamAvailabilitySchema.optional(),
+  ...paginationQueryFields,
 }).openapi("TechnicianTeamListQuery");
 
 export const TechnicianTeamCreateBodySchema = z.object({
@@ -53,6 +56,7 @@ export const TechnicianTeamUpdateBodySchema = z
 
 export const TechnicianTeamListResponseSchema = z.object({
   data: z.array(TechnicianTeamSummarySchema),
+  pagination: PaginationSchema,
 }).openapi("TechnicianTeamListResponse");
 
 export const TechnicianTeamAvailableListResponseSchema = z.object({

--- a/packages/shared/src/contracts/server/technician-teams/index.ts
+++ b/packages/shared/src/contracts/server/technician-teams/index.ts
@@ -1,4 +1,5 @@
 import { z } from "../../../zod";
+import { PaginationSchema } from "../schemas";
 import {
   TechnicianTeamAvailableOptionSchema,
   TechnicianTeamDetailSchema,
@@ -10,6 +11,7 @@ export * from "./models";
 
 export const TechnicianTeamListResponseSchema = z.object({
   data: z.array(TechnicianTeamSummarySchema),
+  pagination: PaginationSchema,
 });
 
 export const TechnicianTeamAvailableListResponseSchema = z.object({
@@ -22,6 +24,7 @@ export const TechnicianTeamDetailResponseSchema = z.object({
 
 export type TechnicianTeamListResponse = {
   data: z.infer<typeof TechnicianTeamSummarySchema>[];
+  pagination: z.infer<typeof PaginationSchema>;
 };
 
 export type TechnicianTeamAvailableListResponse = {


### PR DESCRIPTION
## Summary
- add pagination support to `GET /v1/admin/technician-teams` through the existing technician-team list path
- return pagination metadata in the shared contract and admin controller response
- extend repository and e2e coverage to verify paginated admin technician-team listing

## Verification
- pnpm --dir ../../packages/shared build
- pnpm prisma generate
- pnpm tsc --noEmit
- pnpm vitest run --config vitest.e2e.config.ts src/http/test/e2e/admin-technician-teams-routing.e2e.int.test.ts