### PR TITLE
Add pricing policy management domain layer

### DIFF
--- a/apps/server/src/domain/pricing/domain-errors.ts
+++ b/apps/server/src/domain/pricing/domain-errors.ts
@@ -26,3 +26,21 @@ export class ActivePricingPolicyAmbiguous extends Data.TaggedError(
 )<{
     readonly pricingPolicyIds: ReadonlyArray<string>;
   }> {}
+
+export class PricingPolicyAlreadyUsed extends Data.TaggedError(
+  "PricingPolicyAlreadyUsed",
+)<{
+    readonly pricingPolicyId: string;
+    readonly reservationCount: number;
+    readonly rentalCount: number;
+    readonly billingRecordCount: number;
+  }> {}
+
+export class PricingPolicyMutationWindowClosed extends Data.TaggedError(
+  "PricingPolicyMutationWindowClosed",
+)<{
+    readonly currentTime: string;
+    readonly timeZone: string;
+    readonly windowStart: string;
+    readonly windowEnd: string;
+  }> {}

--- a/apps/server/src/domain/pricing/index.ts
+++ b/apps/server/src/domain/pricing/index.ts
@@ -5,3 +5,5 @@ export * from "./models";
 export * from "./repository/pricing-policy-command.repository";
 export * from "./repository/pricing-policy-query.repository";
 export * from "./repository/pricing-policy.repository";
+export * from "./services/pricing-policy-command.service";
+export * from "./services/pricing-policy-query.service";

--- a/apps/server/src/domain/pricing/index.ts
+++ b/apps/server/src/domain/pricing/index.ts
@@ -2,4 +2,6 @@ export * from "./calculator";
 export * from "./domain-errors";
 export * from "./late-return";
 export * from "./models";
+export * from "./repository/pricing-policy-command.repository";
+export * from "./repository/pricing-policy-query.repository";
 export * from "./repository/pricing-policy.repository";

--- a/apps/server/src/domain/pricing/repository/pricing-policy-command.repository.ts
+++ b/apps/server/src/domain/pricing/repository/pricing-policy-command.repository.ts
@@ -1,0 +1,37 @@
+import { Effect, Layer } from "effect";
+
+import type {
+  PrismaClient,
+  Prisma as PrismaTypes,
+} from "generated/prisma/client";
+
+import { Prisma } from "@/infrastructure/prisma";
+
+import type { PricingPolicyWriteRepo } from "./pricing-policy.repository.types";
+
+import { makePricingPolicyWriteRepository } from "./write/pricing-policy.write.repository";
+
+export type { PricingPolicyWriteRepo } from "./pricing-policy.repository.types";
+
+const makePricingPolicyCommandRepositoryEffect = Effect.gen(function* () {
+  const { client } = yield* Prisma;
+  return makePricingPolicyCommandRepository(client);
+});
+
+export class PricingPolicyCommandRepository extends Effect.Service<PricingPolicyCommandRepository>()(
+  "PricingPolicyCommandRepository",
+  {
+    effect: makePricingPolicyCommandRepositoryEffect,
+  },
+) {}
+
+export function makePricingPolicyCommandRepository(
+  client: PrismaClient | PrismaTypes.TransactionClient,
+): PricingPolicyWriteRepo {
+  return makePricingPolicyWriteRepository(client);
+}
+
+export const PricingPolicyCommandRepositoryLive = Layer.effect(
+  PricingPolicyCommandRepository,
+  makePricingPolicyCommandRepositoryEffect.pipe(Effect.map(PricingPolicyCommandRepository.make)),
+);

--- a/apps/server/src/domain/pricing/repository/pricing-policy-command.repository.ts
+++ b/apps/server/src/domain/pricing/repository/pricing-policy-command.repository.ts
@@ -18,6 +18,12 @@ const makePricingPolicyCommandRepositoryEffect = Effect.gen(function* () {
   return makePricingPolicyCommandRepository(client);
 });
 
+/**
+ * Effect tag cho persistence phía ghi của pricing policy.
+ *
+ * Command service dùng tag này khi cần primitive ghi dữ liệu thô mà không phải
+ * gắn chặt với chi tiết bootstrap Prisma.
+ */
 export class PricingPolicyCommandRepository extends Effect.Service<PricingPolicyCommandRepository>()(
   "PricingPolicyCommandRepository",
   {
@@ -25,6 +31,12 @@ export class PricingPolicyCommandRepository extends Effect.Service<PricingPolicy
   },
 ) {}
 
+/**
+ * Tạo write repository pricing policy từ Prisma client hiện tại.
+ *
+ * @param client Prisma client hoặc transaction client hiện tại.
+ * @returns Write repository cho pricing policy.
+ */
 export function makePricingPolicyCommandRepository(
   client: PrismaClient | PrismaTypes.TransactionClient,
 ): PricingPolicyWriteRepo {

--- a/apps/server/src/domain/pricing/repository/pricing-policy-query.repository.ts
+++ b/apps/server/src/domain/pricing/repository/pricing-policy-query.repository.ts
@@ -18,6 +18,12 @@ const makePricingPolicyQueryRepositoryEffect = Effect.gen(function* () {
   return makePricingPolicyQueryRepository(client);
 });
 
+/**
+ * Effect tag cho persistence phía đọc của pricing policy.
+ *
+ * Các feature layer có thể lấy tag này thay vì tự dựng repo trực tiếp từ
+ * Prisma client.
+ */
 export class PricingPolicyQueryRepository extends Effect.Service<PricingPolicyQueryRepository>()(
   "PricingPolicyQueryRepository",
   {
@@ -25,6 +31,12 @@ export class PricingPolicyQueryRepository extends Effect.Service<PricingPolicyQu
   },
 ) {}
 
+/**
+ * Tạo read repository pricing policy từ Prisma client hiện tại.
+ *
+ * @param client Prisma client hoặc transaction client hiện tại.
+ * @returns Read repository cho pricing policy.
+ */
 export function makePricingPolicyQueryRepository(
   client: PrismaClient | PrismaTypes.TransactionClient,
 ): PricingPolicyReadRepo {

--- a/apps/server/src/domain/pricing/repository/pricing-policy-query.repository.ts
+++ b/apps/server/src/domain/pricing/repository/pricing-policy-query.repository.ts
@@ -1,0 +1,37 @@
+import { Effect, Layer } from "effect";
+
+import type {
+  PrismaClient,
+  Prisma as PrismaTypes,
+} from "generated/prisma/client";
+
+import { Prisma } from "@/infrastructure/prisma";
+
+import type { PricingPolicyReadRepo } from "./pricing-policy.repository.types";
+
+import { makePricingPolicyReadRepository } from "./read/pricing-policy.read.repository";
+
+export type { PricingPolicyReadRepo } from "./pricing-policy.repository.types";
+
+const makePricingPolicyQueryRepositoryEffect = Effect.gen(function* () {
+  const { client } = yield* Prisma;
+  return makePricingPolicyQueryRepository(client);
+});
+
+export class PricingPolicyQueryRepository extends Effect.Service<PricingPolicyQueryRepository>()(
+  "PricingPolicyQueryRepository",
+  {
+    effect: makePricingPolicyQueryRepositoryEffect,
+  },
+) {}
+
+export function makePricingPolicyQueryRepository(
+  client: PrismaClient | PrismaTypes.TransactionClient,
+): PricingPolicyReadRepo {
+  return makePricingPolicyReadRepository(client);
+}
+
+export const PricingPolicyQueryRepositoryLive = Layer.effect(
+  PricingPolicyQueryRepository,
+  makePricingPolicyQueryRepositoryEffect.pipe(Effect.map(PricingPolicyQueryRepository.make)),
+);

--- a/apps/server/src/domain/pricing/repository/pricing-policy.mappers.ts
+++ b/apps/server/src/domain/pricing/repository/pricing-policy.mappers.ts
@@ -1,0 +1,26 @@
+import type { Prisma as PrismaTypes } from "generated/prisma/client";
+
+import type { PricingPolicyRow } from "../models";
+
+export const pricingPolicySelect = {
+  id: true,
+  name: true,
+  baseRate: true,
+  billingUnitMinutes: true,
+  reservationFee: true,
+  depositRequired: true,
+  lateReturnCutoff: true,
+  status: true,
+  createdAt: true,
+  updatedAt: true,
+} as const;
+
+type PricingPolicySelectRow = PrismaTypes.PricingPolicyGetPayload<{
+  select: typeof pricingPolicySelect;
+}>;
+
+export function toPricingPolicyRow(
+  row: PricingPolicySelectRow,
+): PricingPolicyRow {
+  return row;
+}

--- a/apps/server/src/domain/pricing/repository/pricing-policy.mappers.ts
+++ b/apps/server/src/domain/pricing/repository/pricing-policy.mappers.ts
@@ -2,6 +2,12 @@ import type { Prisma as PrismaTypes } from "generated/prisma/client";
 
 import type { PricingPolicyRow } from "../models";
 
+/**
+ * Shape `select` dùng chung cho pricing policy.
+ *
+ * Gom về một nơi giúp read path và write path luôn trả ra cùng một
+ * `PricingPolicyRow`, tránh lặp lại chi tiết Prisma select ở nhiều file.
+ */
 export const pricingPolicySelect = {
   id: true,
   name: true,
@@ -19,6 +25,14 @@ type PricingPolicySelectRow = PrismaTypes.PricingPolicyGetPayload<{
   select: typeof pricingPolicySelect;
 }>;
 
+/**
+ * Hiện tại row Prisma map 1:1 sang domain row.
+ * Hàm này giữ bước chuyển đổi rõ ràng để sau này nếu shape lệch nhau thì chỉ
+ * cần sửa đúng một chỗ.
+ *
+ * @param row Row Prisma đã được chọn theo `pricingPolicySelect`.
+ * @returns Domain row ổn định cho pricing policy.
+ */
 export function toPricingPolicyRow(
   row: PricingPolicySelectRow,
 ): PricingPolicyRow {

--- a/apps/server/src/domain/pricing/repository/pricing-policy.repository.ts
+++ b/apps/server/src/domain/pricing/repository/pricing-policy.repository.ts
@@ -1,113 +1,27 @@
-import { Effect, Match, Option } from "effect";
+import type {
+  PrismaClient,
+  Prisma as PrismaTypes,
+} from "generated/prisma/client";
 
-import type { PrismaClient, Prisma as PrismaTypes } from "generated/prisma/client";
+import type { PricingPolicyRepo } from "./pricing-policy.repository.types";
 
-import { defectOn } from "@/domain/shared";
+import { makePricingPolicyReadRepository } from "./read/pricing-policy.read.repository";
+import { makePricingPolicyWriteRepository } from "./write/pricing-policy.write.repository";
 
-import type { PricingPolicyRow } from "../models";
-
-import {
-  ActivePricingPolicyAmbiguous,
-  ActivePricingPolicyNotFound,
-  PricingPolicyNotFound,
-  PricingPolicyRepositoryError,
-} from "../domain-errors";
-
-export type PricingPolicyRepo = {
-  findById: (
-    pricingPolicyId: string,
-  ) => Effect.Effect<Option.Option<PricingPolicyRow>>;
-  getById: (
-    pricingPolicyId: string,
-  ) => Effect.Effect<PricingPolicyRow, PricingPolicyNotFound>;
-  getActive: () => Effect.Effect<
-    PricingPolicyRow,
-    ActivePricingPolicyNotFound | ActivePricingPolicyAmbiguous
-  >;
-};
-
-const pricingPolicySelect = {
-  id: true,
-  name: true,
-  baseRate: true,
-  billingUnitMinutes: true,
-  reservationFee: true,
-  depositRequired: true,
-  lateReturnCutoff: true,
-  status: true,
-  createdAt: true,
-  updatedAt: true,
-} as const;
-
-type PricingPolicySelectRow = PrismaTypes.PricingPolicyGetPayload<{
-  select: typeof pricingPolicySelect;
-}>;
-
-function toPricingPolicyRow(row: PricingPolicySelectRow): PricingPolicyRow {
-  return row;
-}
+export type {
+  CreatePricingPolicyInput,
+  PricingPolicyReadRepo,
+  PricingPolicyRepo,
+  PricingPolicyWriteRepo,
+  UpdatePricingPolicyInput,
+  UpdatePricingPolicyStatusInput,
+} from "./pricing-policy.repository.types";
 
 export function makePricingPolicyRepository(
   db: PrismaClient | PrismaTypes.TransactionClient,
 ): PricingPolicyRepo {
-  const client = db;
-
   return {
-    findById: pricingPolicyId =>
-      Effect.tryPromise({
-        try: () =>
-          client.pricingPolicy.findUnique({
-            where: { id: pricingPolicyId },
-            select: pricingPolicySelect,
-          }),
-        catch: cause =>
-          new PricingPolicyRepositoryError({
-            operation: "pricingPolicy.findById",
-            cause,
-          }),
-      }).pipe(
-        Effect.map(row => Option.fromNullable(row).pipe(Option.map(toPricingPolicyRow))),
-        defectOn(PricingPolicyRepositoryError),
-      ),
-
-    getById: pricingPolicyId =>
-      Effect.gen(function* () {
-        const policyOpt = yield* makePricingPolicyRepository(client).findById(pricingPolicyId);
-        if (Option.isNone(policyOpt)) {
-          return yield* Effect.fail(new PricingPolicyNotFound({ pricingPolicyId }));
-        }
-        return policyOpt.value;
-      }),
-
-    getActive: () =>
-      Effect.tryPromise({
-        try: () =>
-          client.pricingPolicy.findMany({
-            where: { status: "ACTIVE" },
-            orderBy: [{ createdAt: "asc" }, { id: "asc" }],
-            take: 2,
-            select: pricingPolicySelect,
-          }),
-        catch: cause =>
-          new PricingPolicyRepositoryError({
-            operation: "pricingPolicy.getActive",
-            cause,
-          }),
-      }).pipe(
-        Effect.flatMap(rows => Match.value(rows).pipe(
-          Match.when(
-            value => value.length === 0,
-            () => Effect.fail(new ActivePricingPolicyNotFound({ reason: "MISSING_ACTIVE_POLICY" })),
-          ),
-          Match.when(
-            value => value.length > 1,
-            value => Effect.fail(new ActivePricingPolicyAmbiguous({
-              pricingPolicyIds: value.map(row => row.id),
-            })),
-          ),
-          Match.orElse(value => Effect.succeed(toPricingPolicyRow(value[0]!))),
-        )),
-        defectOn(PricingPolicyRepositoryError),
-      ),
+    ...makePricingPolicyReadRepository(db),
+    ...makePricingPolicyWriteRepository(db),
   };
 }

--- a/apps/server/src/domain/pricing/repository/pricing-policy.repository.ts
+++ b/apps/server/src/domain/pricing/repository/pricing-policy.repository.ts
@@ -17,6 +17,15 @@ export type {
   UpdatePricingPolicyStatusInput,
 } from "./pricing-policy.repository.types";
 
+/**
+ * Facade repository tương thích ngược cho pricing policy.
+ *
+ * Rental và reservation hiện tại vẫn có thể dùng một factory duy nhất, trong
+ * khi bên trong domain pricing đã tách read và write rõ ràng hơn.
+ *
+ * @param db Prisma client hoặc transaction client hiện tại.
+ * @returns Repository gộp đủ cả read và write cho pricing policy.
+ */
 export function makePricingPolicyRepository(
   db: PrismaClient | PrismaTypes.TransactionClient,
 ): PricingPolicyRepo {

--- a/apps/server/src/domain/pricing/repository/pricing-policy.repository.types.ts
+++ b/apps/server/src/domain/pricing/repository/pricing-policy.repository.types.ts
@@ -1,0 +1,90 @@
+import type { Effect, Option } from "effect";
+
+import type {
+  AccountStatus,
+  Prisma as PrismaTypes,
+} from "generated/prisma/client";
+
+import type {
+  ActivePricingPolicyAmbiguous,
+  ActivePricingPolicyNotFound,
+  PricingPolicyNotFound,
+} from "../domain-errors";
+import type { PricingPolicyRow } from "../models";
+
+export type CreatePricingPolicyInput = {
+  readonly id?: string;
+  readonly name: string;
+  readonly baseRate: PrismaTypes.Decimal;
+  readonly billingUnitMinutes: number;
+  readonly reservationFee: PrismaTypes.Decimal;
+  readonly depositRequired: PrismaTypes.Decimal;
+  readonly lateReturnCutoff: Date;
+  readonly status?: AccountStatus;
+  readonly createdAt?: Date;
+  readonly updatedAt?: Date;
+};
+
+export type UpdatePricingPolicyInput = {
+  readonly pricingPolicyId: string;
+  readonly name?: string;
+  readonly baseRate?: PrismaTypes.Decimal;
+  readonly billingUnitMinutes?: number;
+  readonly reservationFee?: PrismaTypes.Decimal;
+  readonly depositRequired?: PrismaTypes.Decimal;
+  readonly lateReturnCutoff?: Date;
+  readonly status?: AccountStatus;
+  readonly updatedAt?: Date;
+};
+
+export type UpdatePricingPolicyStatusInput = {
+  readonly pricingPolicyId: string;
+  readonly status: AccountStatus;
+  readonly updatedAt?: Date;
+};
+
+export type PricingPolicyUsageSummary = {
+  readonly reservationCount: number;
+  readonly rentalCount: number;
+  readonly billingRecordCount: number;
+  readonly isUsed: boolean;
+};
+
+export type PricingPolicyReadRepo = {
+  findById: (
+    pricingPolicyId: string,
+  ) => Effect.Effect<Option.Option<PricingPolicyRow>>;
+  getById: (
+    pricingPolicyId: string,
+  ) => Effect.Effect<PricingPolicyRow, PricingPolicyNotFound>;
+  getActive: () => Effect.Effect<
+    PricingPolicyRow,
+    ActivePricingPolicyNotFound | ActivePricingPolicyAmbiguous
+  >;
+  listByStatus: (
+    status?: AccountStatus,
+  ) => Effect.Effect<ReadonlyArray<PricingPolicyRow>>;
+  getUsageSummary: (
+    pricingPolicyId: string,
+  ) => Effect.Effect<PricingPolicyUsageSummary>;
+};
+
+export type PricingPolicyWriteRepo = {
+  createPricingPolicy: (
+    input: CreatePricingPolicyInput,
+  ) => Effect.Effect<PricingPolicyRow>;
+  updatePricingPolicy: (
+    input: UpdatePricingPolicyInput,
+  ) => Effect.Effect<Option.Option<PricingPolicyRow>>;
+  updatePricingPolicyStatus: (
+    input: UpdatePricingPolicyStatusInput,
+  ) => Effect.Effect<Option.Option<PricingPolicyRow>>;
+  deactivateActivePolicies: (
+    args?: {
+      readonly excludePricingPolicyId?: string;
+      readonly updatedAt?: Date;
+    },
+  ) => Effect.Effect<number>;
+};
+
+export type PricingPolicyRepo = PricingPolicyReadRepo & PricingPolicyWriteRepo;

--- a/apps/server/src/domain/pricing/repository/read/pricing-policy.read.repository.ts
+++ b/apps/server/src/domain/pricing/repository/read/pricing-policy.read.repository.ts
@@ -20,6 +20,12 @@ import {
   toPricingPolicyRow,
 } from "../pricing-policy.mappers";
 
+/**
+ * Repository chỉ-đọc cho pricing policy.
+ *
+ * Module này gom toàn bộ query không có side effect, gồm lookup policy đang
+ * active và usage summary dùng cho rule bất biến ở service layer.
+ */
 export function makePricingPolicyReadRepository(
   client: PrismaClient | PrismaTypes.TransactionClient,
 ): PricingPolicyReadRepo {
@@ -43,6 +49,8 @@ export function makePricingPolicyReadRepository(
 
     getById: pricingPolicyId =>
       Effect.gen(function* () {
+        // Tái dùng nullable lookup để logic đổi "không tìm thấy row" sang lỗi
+        // domain chỉ nằm ở một chỗ.
         const policyOpt = yield* makePricingPolicyReadRepository(client).findById(pricingPolicyId);
         if (Option.isNone(policyOpt)) {
           return yield* Effect.fail(new PricingPolicyNotFound({ pricingPolicyId }));
@@ -66,6 +74,7 @@ export function makePricingPolicyReadRepository(
           }),
       }).pipe(
         Effect.flatMap(rows => Match.value(rows).pipe(
+          // Rule hiện tại yêu cầu đúng một pricing policy đang active.
           Match.when(
             value => value.length === 0,
             () => Effect.fail(new ActivePricingPolicyNotFound({ reason: "MISSING_ACTIVE_POLICY" })),
@@ -102,6 +111,8 @@ export function makePricingPolicyReadRepository(
     getUsageSummary: pricingPolicyId =>
       Effect.tryPromise({
         try: async () => {
+          // Cả ba loại tham chiếu này đều có thể "đóng băng" ý nghĩa lịch sử của
+          // policy, nên service layer phải kiểm tra đủ cả ba trước khi cho sửa.
           const [reservationCount, rentalCount, billingRecordCount] = await Promise.all([
             client.reservation.count({ where: { pricingPolicyId } }),
             client.rental.count({ where: { pricingPolicyId } }),

--- a/apps/server/src/domain/pricing/repository/read/pricing-policy.read.repository.ts
+++ b/apps/server/src/domain/pricing/repository/read/pricing-policy.read.repository.ts
@@ -1,0 +1,125 @@
+import { Effect, Match, Option } from "effect";
+
+import type {
+  PrismaClient,
+  Prisma as PrismaTypes,
+} from "generated/prisma/client";
+
+import { defectOn } from "@/domain/shared";
+
+import type { PricingPolicyReadRepo } from "../pricing-policy.repository.types";
+
+import {
+  ActivePricingPolicyAmbiguous,
+  ActivePricingPolicyNotFound,
+  PricingPolicyNotFound,
+  PricingPolicyRepositoryError,
+} from "../../domain-errors";
+import {
+  pricingPolicySelect,
+  toPricingPolicyRow,
+} from "../pricing-policy.mappers";
+
+export function makePricingPolicyReadRepository(
+  client: PrismaClient | PrismaTypes.TransactionClient,
+): PricingPolicyReadRepo {
+  return {
+    findById: pricingPolicyId =>
+      Effect.tryPromise({
+        try: () =>
+          client.pricingPolicy.findUnique({
+            where: { id: pricingPolicyId },
+            select: pricingPolicySelect,
+          }),
+        catch: cause =>
+          new PricingPolicyRepositoryError({
+            operation: "pricingPolicy.findById",
+            cause,
+          }),
+      }).pipe(
+        Effect.map(row => Option.fromNullable(row).pipe(Option.map(toPricingPolicyRow))),
+        defectOn(PricingPolicyRepositoryError),
+      ),
+
+    getById: pricingPolicyId =>
+      Effect.gen(function* () {
+        const policyOpt = yield* makePricingPolicyReadRepository(client).findById(pricingPolicyId);
+        if (Option.isNone(policyOpt)) {
+          return yield* Effect.fail(new PricingPolicyNotFound({ pricingPolicyId }));
+        }
+        return policyOpt.value;
+      }),
+
+    getActive: () =>
+      Effect.tryPromise({
+        try: () =>
+          client.pricingPolicy.findMany({
+            where: { status: "ACTIVE" },
+            orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+            take: 2,
+            select: pricingPolicySelect,
+          }),
+        catch: cause =>
+          new PricingPolicyRepositoryError({
+            operation: "pricingPolicy.getActive",
+            cause,
+          }),
+      }).pipe(
+        Effect.flatMap(rows => Match.value(rows).pipe(
+          Match.when(
+            value => value.length === 0,
+            () => Effect.fail(new ActivePricingPolicyNotFound({ reason: "MISSING_ACTIVE_POLICY" })),
+          ),
+          Match.when(
+            value => value.length > 1,
+            value => Effect.fail(new ActivePricingPolicyAmbiguous({
+              pricingPolicyIds: value.map(row => row.id),
+            })),
+          ),
+          Match.orElse(value => Effect.succeed(toPricingPolicyRow(value[0]!))),
+        )),
+        defectOn(PricingPolicyRepositoryError),
+      ),
+
+    listByStatus: status =>
+      Effect.tryPromise({
+        try: () =>
+          client.pricingPolicy.findMany({
+            where: status ? { status } : undefined,
+            orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+            select: pricingPolicySelect,
+          }),
+        catch: cause =>
+          new PricingPolicyRepositoryError({
+            operation: "pricingPolicy.listByStatus",
+            cause,
+          }),
+      }).pipe(
+        Effect.map(rows => rows.map(toPricingPolicyRow)),
+        defectOn(PricingPolicyRepositoryError),
+      ),
+
+    getUsageSummary: pricingPolicyId =>
+      Effect.tryPromise({
+        try: async () => {
+          const [reservationCount, rentalCount, billingRecordCount] = await Promise.all([
+            client.reservation.count({ where: { pricingPolicyId } }),
+            client.rental.count({ where: { pricingPolicyId } }),
+            client.rentalBillingRecord.count({ where: { pricingPolicyId } }),
+          ]);
+
+          return {
+            reservationCount,
+            rentalCount,
+            billingRecordCount,
+            isUsed: reservationCount > 0 || rentalCount > 0 || billingRecordCount > 0,
+          };
+        },
+        catch: cause =>
+          new PricingPolicyRepositoryError({
+            operation: "pricingPolicy.getUsageSummary",
+            cause,
+          }),
+      }).pipe(defectOn(PricingPolicyRepositoryError)),
+  };
+}

--- a/apps/server/src/domain/pricing/repository/write/pricing-policy.write.repository.ts
+++ b/apps/server/src/domain/pricing/repository/write/pricing-policy.write.repository.ts
@@ -1,0 +1,131 @@
+import { Effect, Option } from "effect";
+
+import type {
+  PrismaClient,
+  Prisma as PrismaTypes,
+} from "generated/prisma/client";
+
+import { defectOn } from "@/domain/shared";
+
+import type {
+  CreatePricingPolicyInput,
+  PricingPolicyWriteRepo,
+  UpdatePricingPolicyInput,
+  UpdatePricingPolicyStatusInput,
+} from "../pricing-policy.repository.types";
+
+import { PricingPolicyRepositoryError } from "../../domain-errors";
+import {
+  pricingPolicySelect,
+  toPricingPolicyRow,
+} from "../pricing-policy.mappers";
+
+export function makePricingPolicyWriteRepository(
+  client: PrismaClient | PrismaTypes.TransactionClient,
+): PricingPolicyWriteRepo {
+  const findByIdWithSelect = (pricingPolicyId: string) =>
+    client.pricingPolicy.findUnique({
+      where: { id: pricingPolicyId },
+      select: pricingPolicySelect,
+    });
+
+  const updateById = (
+    pricingPolicyId: string,
+    data: Omit<PrismaTypes.PricingPolicyUpdateManyMutationInput, "id">,
+  ) =>
+    Effect.tryPromise({
+      try: async () => {
+        const updated = await client.pricingPolicy.updateMany({
+          where: { id: pricingPolicyId },
+          data,
+        });
+
+        if (updated.count === 0) {
+          return null;
+        }
+
+        return await findByIdWithSelect(pricingPolicyId);
+      },
+      catch: cause =>
+        new PricingPolicyRepositoryError({
+          operation: "pricingPolicy.updateById",
+          cause,
+        }),
+    }).pipe(
+      Effect.map(row => Option.fromNullable(row).pipe(Option.map(toPricingPolicyRow))),
+      defectOn(PricingPolicyRepositoryError),
+    );
+
+  return {
+    createPricingPolicy: (input: CreatePricingPolicyInput) =>
+      Effect.tryPromise({
+        try: () =>
+          client.pricingPolicy.create({
+            data: {
+              ...(input.id ? { id: input.id } : {}),
+              name: input.name,
+              baseRate: input.baseRate,
+              billingUnitMinutes: input.billingUnitMinutes,
+              reservationFee: input.reservationFee,
+              depositRequired: input.depositRequired,
+              lateReturnCutoff: input.lateReturnCutoff,
+              status: input.status ?? "INACTIVE",
+              createdAt: input.createdAt,
+              updatedAt: input.updatedAt,
+            },
+            select: pricingPolicySelect,
+          }),
+        catch: cause =>
+          new PricingPolicyRepositoryError({
+            operation: "pricingPolicy.createPricingPolicy",
+            cause,
+          }),
+      }).pipe(
+        Effect.map(toPricingPolicyRow),
+        defectOn(PricingPolicyRepositoryError),
+      ),
+
+    updatePricingPolicy: (input: UpdatePricingPolicyInput) =>
+      updateById(input.pricingPolicyId, {
+        name: input.name,
+        baseRate: input.baseRate,
+        billingUnitMinutes: input.billingUnitMinutes,
+        reservationFee: input.reservationFee,
+        depositRequired: input.depositRequired,
+        lateReturnCutoff: input.lateReturnCutoff,
+        status: input.status,
+        updatedAt: input.updatedAt ?? new Date(),
+      }),
+
+    updatePricingPolicyStatus: (input: UpdatePricingPolicyStatusInput) =>
+      updateById(input.pricingPolicyId, {
+        status: input.status,
+        updatedAt: input.updatedAt ?? new Date(),
+      }),
+
+    deactivateActivePolicies: args =>
+      Effect.tryPromise({
+        try: () =>
+          client.pricingPolicy.updateMany({
+            where: {
+              status: "ACTIVE",
+              ...(args?.excludePricingPolicyId
+                ? { id: { not: args.excludePricingPolicyId } }
+                : {}),
+            },
+            data: {
+              status: "INACTIVE",
+              updatedAt: args?.updatedAt ?? new Date(),
+            },
+          }),
+        catch: cause =>
+          new PricingPolicyRepositoryError({
+            operation: "pricingPolicy.deactivateActivePolicies",
+            cause,
+          }),
+      }).pipe(
+        Effect.map(result => result.count),
+        defectOn(PricingPolicyRepositoryError),
+      ),
+  };
+}

--- a/apps/server/src/domain/pricing/repository/write/pricing-policy.write.repository.ts
+++ b/apps/server/src/domain/pricing/repository/write/pricing-policy.write.repository.ts
@@ -20,15 +20,29 @@ import {
   toPricingPolicyRow,
 } from "../pricing-policy.mappers";
 
+/**
+ * Repository ghi cho pricing policy.
+ *
+ * Layer này chỉ lo ghi dữ liệu và trả về state mới nhất. Rule nghiệp vụ như
+ * khung giờ được phép sửa, bất biến sau lần dùng đầu tiên, hay chuyển policy
+ * đang active thuộc về command service ở tầng trên.
+ */
 export function makePricingPolicyWriteRepository(
   client: PrismaClient | PrismaTypes.TransactionClient,
 ): PricingPolicyWriteRepo {
+  /**
+   * Đường reload dùng chung để mọi mutation đều trả về cùng một select shape.
+   */
   const findByIdWithSelect = (pricingPolicyId: string) =>
     client.pricingPolicy.findUnique({
       where: { id: pricingPolicyId },
       select: pricingPolicySelect,
     });
 
+  /**
+   * Helper update trả về `Option.none()` khi row không tồn tại, thay vì phụ
+   * thuộc vào lỗi record-not-found mà Prisma ném ra.
+   */
   const updateById = (
     pricingPolicyId: string,
     data: Omit<PrismaTypes.PricingPolicyUpdateManyMutationInput, "id">,
@@ -108,6 +122,8 @@ export function makePricingPolicyWriteRepository(
         try: () =>
           client.pricingPolicy.updateMany({
             where: {
+              // Activation flow sẽ hạ mọi row đang active trước đó, trừ target
+              // sắp được nâng lên active trong cùng transaction.
               status: "ACTIVE",
               ...(args?.excludePricingPolicyId
                 ? { id: { not: args.excludePricingPolicyId } }

--- a/apps/server/src/domain/pricing/services/pricing-policy-command.service.ts
+++ b/apps/server/src/domain/pricing/services/pricing-policy-command.service.ts
@@ -16,9 +16,7 @@ import type {
   PricingPolicyWriteRepo,
 } from "../repository/pricing-policy.repository.types";
 import type {
-  CreatePricingPolicyInput,
   PricingPolicyCommandService,
-  UpdatePricingPolicyInput,
 } from "./pricing-policy.service.types";
 
 import { defectOn } from "../../shared";
@@ -31,6 +29,15 @@ import { PricingPolicyCommandRepository } from "../repository/pricing-policy-com
 import { PricingPolicyQueryRepository } from "../repository/pricing-policy-query.repository";
 import { makePricingPolicyRepository } from "../repository/pricing-policy.repository";
 
+/**
+ * Format thời điểm theo giờ Việt Nam cho payload lỗi chặn theo khung giờ.
+ *
+ * Rule quản trị pricing policy bám theo giờ địa phương ở Việt Nam, nên thông tin trả
+ * ra cũng nên cùng hệ quy chiếu đó để dễ đọc và debug.
+ *
+ * @param date Mốc thời gian gốc cần format.
+ * @returns Chuỗi thời gian theo múi giờ Việt Nam để trả trong payload lỗi.
+ */
 function formatVietnamDateTime(date: Date): string {
   const formatter = new Intl.DateTimeFormat("en-CA", {
     timeZone: VIETNAM_TIME_ZONE,
@@ -55,6 +62,14 @@ function formatVietnamDateTime(date: Date): string {
   return `${year}-${month}-${day}T${hour}:${minute}:${second}+07:00`;
 }
 
+/**
+ * Mọi mutation của pricing policy chỉ được phép chạy trong khung giờ quản trị
+ * ban đêm.
+ *
+ * @param now Thời điểm hiện tại để kiểm tra cửa sổ mutation.
+ * @returns Effect thành công nếu đang trong cửa sổ cho phép; ngược lại fail với
+ * `PricingPolicyMutationWindowClosed`.
+ */
 function ensureMutationWindowOpen(now: Date) {
   if (isWithinOvernightOperationsWindow(now)) {
     return Effect.void;
@@ -68,6 +83,19 @@ function ensureMutationWindowOpen(now: Date) {
   }));
 }
 
+/**
+ * Command service cho pricing policy.
+ *
+ * Layer này sở hữu rule nghiệp vụ quanh việc tạo draft, bất biến sau lần dùng
+ * đầu tiên, và chuyển policy đang active một cách tường minh. Phần persist vẫn
+ * nằm ở repository để bên gọi có thể test hành vi mà chưa cần HTTP wiring.
+ *
+ * @param args Dependency cần thiết cho command flow pricing policy.
+ * @param args.client Prisma client gốc để chạy transaction activation.
+ * @param args.queryRepo Read capability cần cho usage check trước khi update.
+ * @param args.commandRepo Write capability cần cho create và update policy.
+ * @returns Command service áp dụng đầy đủ rule nghiệp vụ cho pricing policy.
+ */
 export function makePricingPolicyCommandService(args: {
   client: PrismaClient;
   queryRepo: Pick<PricingPolicyReadRepo, "getUsageSummary">;
@@ -76,86 +104,127 @@ export function makePricingPolicyCommandService(args: {
     "createPricingPolicy" | "updatePricingPolicy"
   >;
 }): PricingPolicyCommandService {
-  return {
-    createPolicy: (input: CreatePricingPolicyInput) =>
-      Effect.gen(function* () {
-        const now = input.now ?? new Date();
-        yield* ensureMutationWindowOpen(now);
+  /**
+   * Tạo mới một pricing policy ở trạng thái draft/inactive.
+   *
+   * Hàm này chỉ kiểm tra mutation window và persist draft mới. Việc chuyển
+   * policy này thành policy đang active là flow khác.
+   *
+   * @param input Dữ liệu đầu vào để tạo draft pricing policy.
+   * @returns Effect trả về policy vừa tạo hoặc lỗi nếu ngoài khung giờ mutate.
+   */
+  const createPolicy: PricingPolicyCommandService["createPolicy"] = input =>
+    Effect.gen(function* () {
+      const now = input.now ?? new Date();
+      yield* ensureMutationWindowOpen(now);
 
-        return yield* args.commandRepo.createPricingPolicy({
-          name: input.name.trim(),
-          baseRate: input.baseRate,
-          billingUnitMinutes: input.billingUnitMinutes,
-          reservationFee: input.reservationFee,
-          depositRequired: input.depositRequired,
-          lateReturnCutoff: input.lateReturnCutoff,
-          status: "INACTIVE",
-          updatedAt: now,
-        });
-      }),
+      // Policy mới luôn bắt đầu ở trạng thái draft/inactive. Việc đổi policy
+      // đang live là một command riêng, chạy tường minh.
+      return yield* args.commandRepo.createPricingPolicy({
+        name: input.name.trim(),
+        baseRate: input.baseRate,
+        billingUnitMinutes: input.billingUnitMinutes,
+        reservationFee: input.reservationFee,
+        depositRequired: input.depositRequired,
+        lateReturnCutoff: input.lateReturnCutoff,
+        status: "INACTIVE",
+        updatedAt: now,
+      });
+    });
 
-    updatePolicy: (input: UpdatePricingPolicyInput) =>
-      Effect.gen(function* () {
-        const now = input.now ?? new Date();
-        yield* ensureMutationWindowOpen(now);
+  /**
+   * Cập nhật nội dung của một pricing policy chưa từng được dùng.
+   *
+   * Ngay khi policy đã bị tham chiếu bởi reservation, rental hoặc billing
+   * record, hàm này sẽ fail để tránh làm sai nghĩa dữ liệu lịch sử.
+   *
+   * @param input Dữ liệu cập nhật cho pricing policy mục tiêu.
+   * @returns Effect trả về policy mới nhất hoặc lỗi nghiệp vụ tương ứng.
+   */
+  const updatePolicy: PricingPolicyCommandService["updatePolicy"] = input =>
+    Effect.gen(function* () {
+      const now = input.now ?? new Date();
+      yield* ensureMutationWindowOpen(now);
 
-        const usage = yield* args.queryRepo.getUsageSummary(input.pricingPolicyId);
-        if (usage.isUsed) {
-          return yield* Effect.fail(new PricingPolicyAlreadyUsed({
-            pricingPolicyId: input.pricingPolicyId,
-            reservationCount: usage.reservationCount,
-            rentalCount: usage.rentalCount,
-            billingRecordCount: usage.billingRecordCount,
-          }));
-        }
-
-        const updatedOpt = yield* args.commandRepo.updatePricingPolicy({
+      // Khi đã có bất kỳ bản ghi giao dịch nào tham chiếu policy này, việc sửa
+      // nội dung có thể làm sai nghĩa dữ liệu lịch sử nên phải chặn lại.
+      const usage = yield* args.queryRepo.getUsageSummary(input.pricingPolicyId);
+      if (usage.isUsed) {
+        return yield* Effect.fail(new PricingPolicyAlreadyUsed({
           pricingPolicyId: input.pricingPolicyId,
-          name: input.name?.trim(),
-          baseRate: input.baseRate,
-          billingUnitMinutes: input.billingUnitMinutes,
-          reservationFee: input.reservationFee,
-          depositRequired: input.depositRequired,
-          lateReturnCutoff: input.lateReturnCutoff,
-          updatedAt: now,
-        });
+          reservationCount: usage.reservationCount,
+          rentalCount: usage.rentalCount,
+          billingRecordCount: usage.billingRecordCount,
+        }));
+      }
 
-        if (Option.isNone(updatedOpt)) {
-          return yield* Effect.fail(new PricingPolicyNotFound({
-            pricingPolicyId: input.pricingPolicyId,
-          }));
-        }
+      const updatedOpt = yield* args.commandRepo.updatePricingPolicy({
+        pricingPolicyId: input.pricingPolicyId,
+        name: input.name?.trim(),
+        baseRate: input.baseRate,
+        billingUnitMinutes: input.billingUnitMinutes,
+        reservationFee: input.reservationFee,
+        depositRequired: input.depositRequired,
+        lateReturnCutoff: input.lateReturnCutoff,
+        updatedAt: now,
+      });
 
-        return updatedOpt.value;
-      }),
+      if (Option.isNone(updatedOpt)) {
+        return yield* Effect.fail(new PricingPolicyNotFound({
+          pricingPolicyId: input.pricingPolicyId,
+        }));
+      }
 
-    activatePolicy: (pricingPolicyId, now = new Date()) =>
-      Effect.gen(function* () {
-        yield* ensureMutationWindowOpen(now);
+      return updatedOpt.value;
+    });
 
-        return yield* runPrismaTransaction(args.client, tx =>
-          Effect.gen(function* () {
-            const txRepo = makePricingPolicyRepository(tx);
+  /**
+   * Chuyển policy được chỉ định thành policy đang active của hệ thống.
+   *
+   * Flow này chạy trong một transaction: xác nhận target tồn tại, hạ active row
+   * cũ xuống, rồi nâng target lên ACTIVE.
+   *
+   * @param pricingPolicyId Id policy cần kích hoạt.
+   * @param now Thời điểm hiện tại để kiểm tra mutation window và gắn timestamp.
+   * @returns Effect trả về policy vừa được kích hoạt hoặc lỗi nghiệp vụ tương ứng.
+   */
+  const activatePolicy: PricingPolicyCommandService["activatePolicy"] = (
+    pricingPolicyId,
+    now = new Date(),
+  ) =>
+    Effect.gen(function* () {
+      yield* ensureMutationWindowOpen(now);
 
-            yield* txRepo.getById(pricingPolicyId);
-            yield* txRepo.deactivateActivePolicies({
-              excludePricingPolicyId: pricingPolicyId,
-              updatedAt: now,
-            });
+      return yield* runPrismaTransaction(args.client, tx =>
+        Effect.gen(function* () {
+          const txRepo = makePricingPolicyRepository(tx);
 
-            const activatedOpt = yield* txRepo.updatePricingPolicyStatus({
-              pricingPolicyId,
-              status: "ACTIVE",
-              updatedAt: now,
-            });
+          // Activation chạy tường minh trong transaction: xác nhận target tồn
+          // tại, hạ policy active cũ xuống, rồi mới nâng target lên active.
+          yield* txRepo.getById(pricingPolicyId);
+          yield* txRepo.deactivateActivePolicies({
+            excludePricingPolicyId: pricingPolicyId,
+            updatedAt: now,
+          });
 
-            if (Option.isNone(activatedOpt)) {
-              return yield* Effect.fail(new PricingPolicyNotFound({ pricingPolicyId }));
-            }
+          const activatedOpt = yield* txRepo.updatePricingPolicyStatus({
+            pricingPolicyId,
+            status: "ACTIVE",
+            updatedAt: now,
+          });
 
-            return activatedOpt.value;
-          })).pipe(defectOn(PrismaTransactionError));
-      }),
+          if (Option.isNone(activatedOpt)) {
+            return yield* Effect.fail(new PricingPolicyNotFound({ pricingPolicyId }));
+          }
+
+          return activatedOpt.value;
+        })).pipe(defectOn(PrismaTransactionError));
+    });
+
+  return {
+    createPolicy,
+    updatePolicy,
+    activatePolicy,
   };
 }
 
@@ -173,6 +242,9 @@ const makePricingPolicyCommandServiceEffect = Effect.gen(function* () {
   });
 });
 
+/**
+ * Effect tag cho các use-case ghi pricing policy.
+ */
 export class PricingPolicyCommandServiceTag extends Effect.Service<PricingPolicyCommandServiceTag>()(
   "PricingPolicyCommandService",
   {

--- a/apps/server/src/domain/pricing/services/pricing-policy-command.service.ts
+++ b/apps/server/src/domain/pricing/services/pricing-policy-command.service.ts
@@ -1,0 +1,186 @@
+import { Effect, Layer, Option } from "effect";
+
+import type { PrismaClient } from "generated/prisma/client";
+
+import {
+  isWithinOvernightOperationsWindow,
+  OVERNIGHT_OPERATIONS_WINDOW_END_LABEL,
+  OVERNIGHT_OPERATIONS_WINDOW_START_LABEL,
+  VIETNAM_TIME_ZONE,
+} from "@/domain/shared/business-hours";
+import { Prisma } from "@/infrastructure/prisma";
+import { PrismaTransactionError, runPrismaTransaction } from "@/lib/effect/prisma-tx";
+
+import type {
+  PricingPolicyReadRepo,
+  PricingPolicyWriteRepo,
+} from "../repository/pricing-policy.repository.types";
+import type {
+  CreatePricingPolicyInput,
+  PricingPolicyCommandService,
+  UpdatePricingPolicyInput,
+} from "./pricing-policy.service.types";
+
+import { defectOn } from "../../shared";
+import {
+  PricingPolicyAlreadyUsed,
+  PricingPolicyMutationWindowClosed,
+  PricingPolicyNotFound,
+} from "../domain-errors";
+import { PricingPolicyCommandRepository } from "../repository/pricing-policy-command.repository";
+import { PricingPolicyQueryRepository } from "../repository/pricing-policy-query.repository";
+import { makePricingPolicyRepository } from "../repository/pricing-policy.repository";
+
+function formatVietnamDateTime(date: Date): string {
+  const formatter = new Intl.DateTimeFormat("en-CA", {
+    timeZone: VIETNAM_TIME_ZONE,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hourCycle: "h23",
+  });
+
+  const parts = formatter.formatToParts(date);
+
+  const year = parts.find(part => part.type === "year")?.value ?? "0000";
+  const month = parts.find(part => part.type === "month")?.value ?? "01";
+  const day = parts.find(part => part.type === "day")?.value ?? "01";
+  const hour = parts.find(part => part.type === "hour")?.value ?? "00";
+  const minute = parts.find(part => part.type === "minute")?.value ?? "00";
+  const second = parts.find(part => part.type === "second")?.value ?? "00";
+
+  return `${year}-${month}-${day}T${hour}:${minute}:${second}+07:00`;
+}
+
+function ensureMutationWindowOpen(now: Date) {
+  if (isWithinOvernightOperationsWindow(now)) {
+    return Effect.void;
+  }
+
+  return Effect.fail(new PricingPolicyMutationWindowClosed({
+    currentTime: formatVietnamDateTime(now),
+    timeZone: VIETNAM_TIME_ZONE,
+    windowStart: OVERNIGHT_OPERATIONS_WINDOW_START_LABEL,
+    windowEnd: OVERNIGHT_OPERATIONS_WINDOW_END_LABEL,
+  }));
+}
+
+export function makePricingPolicyCommandService(args: {
+  client: PrismaClient;
+  queryRepo: Pick<PricingPolicyReadRepo, "getUsageSummary">;
+  commandRepo: Pick<
+    PricingPolicyWriteRepo,
+    "createPricingPolicy" | "updatePricingPolicy"
+  >;
+}): PricingPolicyCommandService {
+  return {
+    createPolicy: (input: CreatePricingPolicyInput) =>
+      Effect.gen(function* () {
+        const now = input.now ?? new Date();
+        yield* ensureMutationWindowOpen(now);
+
+        return yield* args.commandRepo.createPricingPolicy({
+          name: input.name.trim(),
+          baseRate: input.baseRate,
+          billingUnitMinutes: input.billingUnitMinutes,
+          reservationFee: input.reservationFee,
+          depositRequired: input.depositRequired,
+          lateReturnCutoff: input.lateReturnCutoff,
+          status: "INACTIVE",
+          updatedAt: now,
+        });
+      }),
+
+    updatePolicy: (input: UpdatePricingPolicyInput) =>
+      Effect.gen(function* () {
+        const now = input.now ?? new Date();
+        yield* ensureMutationWindowOpen(now);
+
+        const usage = yield* args.queryRepo.getUsageSummary(input.pricingPolicyId);
+        if (usage.isUsed) {
+          return yield* Effect.fail(new PricingPolicyAlreadyUsed({
+            pricingPolicyId: input.pricingPolicyId,
+            reservationCount: usage.reservationCount,
+            rentalCount: usage.rentalCount,
+            billingRecordCount: usage.billingRecordCount,
+          }));
+        }
+
+        const updatedOpt = yield* args.commandRepo.updatePricingPolicy({
+          pricingPolicyId: input.pricingPolicyId,
+          name: input.name?.trim(),
+          baseRate: input.baseRate,
+          billingUnitMinutes: input.billingUnitMinutes,
+          reservationFee: input.reservationFee,
+          depositRequired: input.depositRequired,
+          lateReturnCutoff: input.lateReturnCutoff,
+          updatedAt: now,
+        });
+
+        if (Option.isNone(updatedOpt)) {
+          return yield* Effect.fail(new PricingPolicyNotFound({
+            pricingPolicyId: input.pricingPolicyId,
+          }));
+        }
+
+        return updatedOpt.value;
+      }),
+
+    activatePolicy: (pricingPolicyId, now = new Date()) =>
+      Effect.gen(function* () {
+        yield* ensureMutationWindowOpen(now);
+
+        return yield* runPrismaTransaction(args.client, tx =>
+          Effect.gen(function* () {
+            const txRepo = makePricingPolicyRepository(tx);
+
+            yield* txRepo.getById(pricingPolicyId);
+            yield* txRepo.deactivateActivePolicies({
+              excludePricingPolicyId: pricingPolicyId,
+              updatedAt: now,
+            });
+
+            const activatedOpt = yield* txRepo.updatePricingPolicyStatus({
+              pricingPolicyId,
+              status: "ACTIVE",
+              updatedAt: now,
+            });
+
+            if (Option.isNone(activatedOpt)) {
+              return yield* Effect.fail(new PricingPolicyNotFound({ pricingPolicyId }));
+            }
+
+            return activatedOpt.value;
+          })).pipe(defectOn(PrismaTransactionError));
+      }),
+  };
+}
+
+export type { PricingPolicyCommandService } from "./pricing-policy.service.types";
+
+const makePricingPolicyCommandServiceEffect = Effect.gen(function* () {
+  const { client } = yield* Prisma;
+  const queryRepo = yield* PricingPolicyQueryRepository;
+  const commandRepo = yield* PricingPolicyCommandRepository;
+
+  return makePricingPolicyCommandService({
+    client,
+    queryRepo,
+    commandRepo,
+  });
+});
+
+export class PricingPolicyCommandServiceTag extends Effect.Service<PricingPolicyCommandServiceTag>()(
+  "PricingPolicyCommandService",
+  {
+    effect: makePricingPolicyCommandServiceEffect,
+  },
+) {}
+
+export const PricingPolicyCommandServiceLive = Layer.effect(
+  PricingPolicyCommandServiceTag,
+  makePricingPolicyCommandServiceEffect.pipe(Effect.map(PricingPolicyCommandServiceTag.make)),
+);

--- a/apps/server/src/domain/pricing/services/pricing-policy-query.service.ts
+++ b/apps/server/src/domain/pricing/services/pricing-policy-query.service.ts
@@ -1,0 +1,36 @@
+import { Effect, Layer } from "effect";
+
+import type { PricingPolicyReadRepo } from "../repository/pricing-policy.repository.types";
+import type { PricingPolicyQueryService } from "./pricing-policy.service.types";
+
+import { PricingPolicyQueryRepository } from "../repository/pricing-policy-query.repository";
+
+export function makePricingPolicyQueryService(
+  repo: PricingPolicyReadRepo,
+): PricingPolicyQueryService {
+  return {
+    getById: pricingPolicyId => repo.getById(pricingPolicyId),
+    getActive: () => repo.getActive(),
+    listPolicies: status => repo.listByStatus(status),
+    getUsageSummary: pricingPolicyId => repo.getUsageSummary(pricingPolicyId),
+  };
+}
+
+export type { PricingPolicyQueryService } from "./pricing-policy.service.types";
+
+const makePricingPolicyQueryServiceEffect = Effect.gen(function* () {
+  const repo = yield* PricingPolicyQueryRepository;
+  return makePricingPolicyQueryService(repo);
+});
+
+export class PricingPolicyQueryServiceTag extends Effect.Service<PricingPolicyQueryServiceTag>()(
+  "PricingPolicyQueryService",
+  {
+    effect: makePricingPolicyQueryServiceEffect,
+  },
+) {}
+
+export const PricingPolicyQueryServiceLive = Layer.effect(
+  PricingPolicyQueryServiceTag,
+  makePricingPolicyQueryServiceEffect.pipe(Effect.map(PricingPolicyQueryServiceTag.make)),
+);

--- a/apps/server/src/domain/pricing/services/pricing-policy-query.service.ts
+++ b/apps/server/src/domain/pricing/services/pricing-policy-query.service.ts
@@ -5,14 +5,58 @@ import type { PricingPolicyQueryService } from "./pricing-policy.service.types";
 
 import { PricingPolicyQueryRepository } from "../repository/pricing-policy-query.repository";
 
+/**
+ * Query service mỏng bọc quanh repository đọc của pricing policy.
+ *
+ * Service này cố tình giữ nhẹ để bên gọi có một phụ thuộc ổn định cho các tác
+ * vụ đọc, còn rule nghiệp vụ nặng hơn nằm ở command flow.
+ *
+ * @param repo Read repository cung cấp dữ liệu pricing policy.
+ * @returns Query service cho pricing policy.
+ */
 export function makePricingPolicyQueryService(
   repo: PricingPolicyReadRepo,
 ): PricingPolicyQueryService {
+  /**
+   * Lấy pricing policy theo id và fail nếu không tồn tại.
+   *
+   * @param pricingPolicyId Id policy cần lấy.
+   * @returns Effect trả về policy tương ứng hoặc lỗi not found.
+   */
+  const getById: PricingPolicyQueryService["getById"] = pricingPolicyId =>
+    repo.getById(pricingPolicyId);
+
+  /**
+   * Lấy policy đang active theo rule hiện tại của hệ thống.
+   *
+   * @returns Effect trả về active policy hiện tại.
+   */
+  const getActive: PricingPolicyQueryService["getActive"] = () =>
+    repo.getActive();
+
+  /**
+   * Liệt kê pricing policy, có thể lọc theo status khi caller cần.
+   *
+   * @param status Status cần lọc; bỏ qua nếu muốn lấy toàn bộ.
+   * @returns Effect trả về danh sách policy phù hợp điều kiện lọc.
+   */
+  const listPolicies: PricingPolicyQueryService["listPolicies"] = status =>
+    repo.listByStatus(status);
+
+  /**
+   * Trả về usage summary để caller biết policy đã bị “khóa lịch sử” hay chưa.
+   *
+   * @param pricingPolicyId Id policy cần kiểm tra usage.
+   * @returns Effect trả về số lượng tham chiếu ở từng nơi và cờ `isUsed`.
+   */
+  const getUsageSummary: PricingPolicyQueryService["getUsageSummary"] = pricingPolicyId =>
+    repo.getUsageSummary(pricingPolicyId);
+
   return {
-    getById: pricingPolicyId => repo.getById(pricingPolicyId),
-    getActive: () => repo.getActive(),
-    listPolicies: status => repo.listByStatus(status),
-    getUsageSummary: pricingPolicyId => repo.getUsageSummary(pricingPolicyId),
+    getById,
+    getActive,
+    listPolicies,
+    getUsageSummary,
   };
 }
 
@@ -23,6 +67,9 @@ const makePricingPolicyQueryServiceEffect = Effect.gen(function* () {
   return makePricingPolicyQueryService(repo);
 });
 
+/**
+ * Effect tag cho các use-case đọc của pricing policy.
+ */
 export class PricingPolicyQueryServiceTag extends Effect.Service<PricingPolicyQueryServiceTag>()(
   "PricingPolicyQueryService",
   {

--- a/apps/server/src/domain/pricing/services/pricing-policy.service.types.ts
+++ b/apps/server/src/domain/pricing/services/pricing-policy.service.types.ts
@@ -1,0 +1,69 @@
+import type { Effect } from "effect";
+
+import type { AccountStatus, Prisma as PrismaTypes } from "generated/prisma/client";
+
+import type {
+  ActivePricingPolicyAmbiguous,
+  ActivePricingPolicyNotFound,
+  PricingPolicyAlreadyUsed,
+  PricingPolicyMutationWindowClosed,
+  PricingPolicyNotFound,
+} from "../domain-errors";
+import type { PricingPolicyRow } from "../models";
+import type { PricingPolicyUsageSummary } from "../repository/pricing-policy.repository.types";
+
+export type CreatePricingPolicyInput = {
+  readonly name: string;
+  readonly baseRate: PrismaTypes.Decimal;
+  readonly billingUnitMinutes: number;
+  readonly reservationFee: PrismaTypes.Decimal;
+  readonly depositRequired: PrismaTypes.Decimal;
+  readonly lateReturnCutoff: Date;
+  readonly now?: Date;
+};
+
+export type UpdatePricingPolicyInput = {
+  readonly pricingPolicyId: string;
+  readonly name?: string;
+  readonly baseRate?: PrismaTypes.Decimal;
+  readonly billingUnitMinutes?: number;
+  readonly reservationFee?: PrismaTypes.Decimal;
+  readonly depositRequired?: PrismaTypes.Decimal;
+  readonly lateReturnCutoff?: Date;
+  readonly now?: Date;
+};
+
+export type PricingPolicyQueryService = {
+  getById: (
+    pricingPolicyId: string,
+  ) => Effect.Effect<PricingPolicyRow, PricingPolicyNotFound>;
+  getActive: () => Effect.Effect<
+    PricingPolicyRow,
+    ActivePricingPolicyNotFound | ActivePricingPolicyAmbiguous
+  >;
+  listPolicies: (
+    status?: AccountStatus,
+  ) => Effect.Effect<ReadonlyArray<PricingPolicyRow>>;
+  getUsageSummary: (
+    pricingPolicyId: string,
+  ) => Effect.Effect<PricingPolicyUsageSummary>;
+};
+
+export type PricingPolicyCommandService = {
+  createPolicy: (
+    input: CreatePricingPolicyInput,
+  ) => Effect.Effect<PricingPolicyRow, PricingPolicyMutationWindowClosed>;
+  updatePolicy: (
+    input: UpdatePricingPolicyInput,
+  ) => Effect.Effect<
+    PricingPolicyRow,
+    PricingPolicyNotFound | PricingPolicyAlreadyUsed | PricingPolicyMutationWindowClosed
+  >;
+  activatePolicy: (
+    pricingPolicyId: string,
+    now?: Date,
+  ) => Effect.Effect<
+    PricingPolicyRow,
+    PricingPolicyNotFound | PricingPolicyMutationWindowClosed
+  >;
+};

--- a/apps/server/src/domain/pricing/services/pricing-policy.service.types.ts
+++ b/apps/server/src/domain/pricing/services/pricing-policy.service.types.ts
@@ -12,6 +12,12 @@ import type {
 import type { PricingPolicyRow } from "../models";
 import type { PricingPolicyUsageSummary } from "../repository/pricing-policy.repository.types";
 
+/**
+ * Input để tạo mới một draft pricing policy.
+ *
+ * `now` là optional cho production path, nhưng hữu ích cho test deterministic
+ * và cho rule chặn sửa theo khung giờ.
+ */
 export type CreatePricingPolicyInput = {
   readonly name: string;
   readonly baseRate: PrismaTypes.Decimal;
@@ -22,6 +28,9 @@ export type CreatePricingPolicyInput = {
   readonly now?: Date;
 };
 
+/**
+ * Các field nội dung còn được phép đổi trước lần sử dụng đầu tiên.
+ */
 export type UpdatePricingPolicyInput = {
   readonly pricingPolicyId: string;
   readonly name?: string;
@@ -33,6 +42,10 @@ export type UpdatePricingPolicyInput = {
   readonly now?: Date;
 };
 
+/**
+ * Nhóm use-case đọc cho pricing policy, dùng cho cả màn quản trị lẫn domain
+ * phía sau cần xem state hiện tại.
+ */
 export type PricingPolicyQueryService = {
   getById: (
     pricingPolicyId: string,
@@ -49,6 +62,12 @@ export type PricingPolicyQueryService = {
   ) => Effect.Effect<PricingPolicyUsageSummary>;
 };
 
+/**
+ * Nhóm use-case ghi cho pricing policy.
+ *
+ * Mutation được giữ hẹp có chủ đích: tạo draft, sửa draft chưa dùng, và chuyển
+ * policy đang active.
+ */
 export type PricingPolicyCommandService = {
   createPolicy: (
     input: CreatePricingPolicyInput,

--- a/apps/server/src/domain/pricing/services/test/pricing-policy.service.int.test.ts
+++ b/apps/server/src/domain/pricing/services/test/pricing-policy.service.int.test.ts
@@ -1,0 +1,310 @@
+import { Effect, Layer } from "effect";
+import { uuidv7 } from "uuidv7";
+import { describe, expect, it } from "vitest";
+
+import type {
+  PricingPolicyAlreadyUsed,
+  PricingPolicyMutationWindowClosed,
+  PricingPolicyNotFound,
+} from "@/domain/pricing/domain-errors";
+
+import { toPrismaDecimal } from "@/domain/shared/decimal";
+import { Prisma } from "@/infrastructure/prisma";
+import { expectLeftTag, expectRight } from "@/test/effect/assertions";
+import { runEffectEitherWithLayer } from "@/test/effect/run";
+import { setupPrismaIntFixture } from "@/test/prisma/prisma-int-fixture";
+
+import {
+  makePricingPolicyCommandRepository,
+  makePricingPolicyQueryRepository,
+  PricingPolicyCommandRepository,
+  PricingPolicyCommandServiceLive,
+  PricingPolicyCommandServiceTag,
+  PricingPolicyQueryRepository,
+  PricingPolicyQueryServiceLive,
+  PricingPolicyQueryServiceTag,
+} from "../..";
+
+describe("pricing policy service integration", () => {
+  const fixture = setupPrismaIntFixture();
+
+  function makeLayer() {
+    const queryRepo = makePricingPolicyQueryRepository(fixture.prisma);
+    const commandRepo = makePricingPolicyCommandRepository(fixture.prisma);
+    const infraLayer = Layer.mergeAll(
+      Layer.succeed(Prisma, Prisma.make({ client: fixture.prisma })),
+      Layer.succeed(
+        PricingPolicyQueryRepository,
+        PricingPolicyQueryRepository.make(queryRepo),
+      ),
+      Layer.succeed(
+        PricingPolicyCommandRepository,
+        PricingPolicyCommandRepository.make(commandRepo),
+      ),
+    );
+
+    return Layer.mergeAll(
+      Layer.provide(PricingPolicyQueryServiceLive, infraLayer),
+      Layer.provide(PricingPolicyCommandServiceLive, infraLayer),
+    );
+  }
+
+  function runCommand<A, E>(
+    factory: (service: InstanceType<typeof PricingPolicyCommandServiceTag>) => Effect.Effect<A, E>,
+  ) {
+    return runEffectEitherWithLayer(
+      Effect.gen(function* () {
+        const service = yield* PricingPolicyCommandServiceTag;
+        return yield* factory(service);
+      }),
+      makeLayer(),
+    );
+  }
+
+  function runQuery<A, E>(
+    factory: (service: InstanceType<typeof PricingPolicyQueryServiceTag>) => Effect.Effect<A, E>,
+  ) {
+    return runEffectEitherWithLayer(
+      Effect.gen(function* () {
+        const service = yield* PricingPolicyQueryServiceTag;
+        return yield* factory(service);
+      }),
+      makeLayer(),
+    );
+  }
+
+  it("returns the seeded active policy from query service", async () => {
+    const result = await runQuery(service => service.getActive());
+
+    const policy = expectRight(result);
+    expect(policy.name).toBe("Default Pricing Policy");
+    expect(policy.status).toBe("ACTIVE");
+  });
+
+  it("blocks policy creation outside overnight mutation window", async () => {
+    const result = await runCommand(service => service.createPolicy({
+      name: "Blocked Policy",
+      baseRate: toPrismaDecimal("2200"),
+      billingUnitMinutes: 30,
+      reservationFee: toPrismaDecimal("2000"),
+      depositRequired: toPrismaDecimal("500000"),
+      lateReturnCutoff: new Date("1970-01-01T23:00:00.000Z"),
+      now: new Date("2026-04-20T15:00:00.000Z"),
+    }));
+
+    const error = expectLeftTag(result, "PricingPolicyMutationWindowClosed");
+    expect(error.windowStart).toBe("23:00");
+    expect(error.windowEnd).toBe("05:00");
+  });
+
+  it("returns not found when updating a nonexistent policy", async () => {
+    const missingId = uuidv7();
+
+    const result = await runCommand(service => service.updatePolicy({
+      pricingPolicyId: missingId,
+      name: "Missing Policy",
+      now: new Date("2026-04-20T16:45:00.000Z"),
+    }));
+
+    const error = expectLeftTag(result, "PricingPolicyNotFound") as PricingPolicyNotFound;
+    expect(error.pricingPolicyId).toBe(missingId);
+  });
+
+  it("creates an inactive draft during overnight mutation window", async () => {
+    const result = await runCommand(service => service.createPolicy({
+      name: "  Night Draft Policy  ",
+      baseRate: toPrismaDecimal("2200"),
+      billingUnitMinutes: 45,
+      reservationFee: toPrismaDecimal("2500"),
+      depositRequired: toPrismaDecimal("550000"),
+      lateReturnCutoff: new Date("1970-01-01T23:00:00.000Z"),
+      now: new Date("2026-04-20T16:30:00.000Z"),
+    }));
+
+    const policy = expectRight(result);
+    expect(policy.name).toBe("Night Draft Policy");
+    expect(policy.status).toBe("INACTIVE");
+    expect(policy.billingUnitMinutes).toBe(45);
+  });
+
+  it("allows updating an unused policy during overnight mutation window", async () => {
+    const policy = await fixture.factories.pricingPolicy({
+      name: "Unused Policy",
+      status: "INACTIVE",
+    });
+
+    const result = await runCommand(service => service.updatePolicy({
+      pricingPolicyId: policy.id,
+      name: "  Renamed Policy  ",
+      baseRate: toPrismaDecimal("2800"),
+      billingUnitMinutes: 60,
+      reservationFee: toPrismaDecimal("3000"),
+      depositRequired: toPrismaDecimal("650000"),
+      lateReturnCutoff: new Date("1970-01-01T22:30:00.000Z"),
+      now: new Date("2026-04-20T16:45:00.000Z"),
+    }));
+
+    const updated = expectRight(result);
+    expect(updated.name).toBe("Renamed Policy");
+    expect(updated.baseRate.toString()).toBe("2800");
+    expect(updated.billingUnitMinutes).toBe(60);
+    expect(updated.lateReturnCutoff.toISOString()).toBe("1970-01-01T22:30:00.000Z");
+  });
+
+  it("blocks updating a policy once it is referenced", async () => {
+    const policy = await fixture.factories.pricingPolicy({
+      name: "Used Policy",
+      status: "INACTIVE",
+    });
+    const user = await fixture.factories.user();
+    const station = await fixture.factories.station();
+
+    await fixture.factories.reservation({
+      userId: user.id,
+      stationId: station.id,
+      pricingPolicyId: policy.id,
+    });
+
+    const result = await runCommand(service => service.updatePolicy({
+      pricingPolicyId: policy.id,
+      name: "Should Not Update",
+      now: new Date("2026-04-20T16:50:00.000Z"),
+    }));
+
+    const error = expectLeftTag(result, "PricingPolicyAlreadyUsed") as PricingPolicyAlreadyUsed;
+    expect(error.pricingPolicyId).toBe(policy.id);
+    expect(error.reservationCount).toBe(1);
+    expect(error.rentalCount).toBe(0);
+    expect(error.billingRecordCount).toBe(0);
+  });
+
+  it("blocks updating a policy once it is referenced by a rental", async () => {
+    const policy = await fixture.factories.pricingPolicy({
+      name: "Rental Used Policy",
+      status: "INACTIVE",
+    });
+    const user = await fixture.factories.user();
+    const station = await fixture.factories.station();
+    const bike = await fixture.factories.bike({ stationId: station.id, status: "BOOKED" });
+
+    await fixture.factories.rental({
+      userId: user.id,
+      bikeId: bike.id,
+      startStationId: station.id,
+      pricingPolicyId: policy.id,
+    });
+
+    const result = await runCommand(service => service.updatePolicy({
+      pricingPolicyId: policy.id,
+      name: "Should Not Update Rental",
+      now: new Date("2026-04-20T16:50:00.000Z"),
+    }));
+
+    const error = expectLeftTag(result, "PricingPolicyAlreadyUsed") as PricingPolicyAlreadyUsed;
+    expect(error.pricingPolicyId).toBe(policy.id);
+    expect(error.reservationCount).toBe(0);
+    expect(error.rentalCount).toBe(1);
+    expect(error.billingRecordCount).toBe(0);
+  });
+
+  it("blocks updating a policy once it is referenced by a billing record", async () => {
+    const policy = await fixture.factories.pricingPolicy({
+      name: "Billing Used Policy",
+      status: "INACTIVE",
+    });
+    const user = await fixture.factories.user();
+    const station = await fixture.factories.station();
+    const bike = await fixture.factories.bike({ stationId: station.id, status: "AVAILABLE" });
+    const rental = await fixture.factories.rental({
+      userId: user.id,
+      bikeId: bike.id,
+      startStationId: station.id,
+      pricingPolicyId: null,
+      status: "COMPLETED",
+      endStationId: station.id,
+      endTime: new Date("2026-04-21T04:00:00.000Z"),
+      duration: 60,
+      totalPrice: "5000",
+    });
+
+    await fixture.prisma.rentalBillingRecord.create({
+      data: {
+        rentalId: rental.id,
+        pricingPolicyId: policy.id,
+        totalDurationMinutes: 60,
+        estimatedDistanceKm: null,
+        baseAmount: toPrismaDecimal("7000"),
+        couponRuleId: null,
+        couponDiscountAmount: toPrismaDecimal("0"),
+        subscriptionDiscountAmount: toPrismaDecimal("0"),
+        depositForfeited: false,
+        totalAmount: toPrismaDecimal("5000"),
+      },
+    });
+
+    const result = await runCommand(service => service.updatePolicy({
+      pricingPolicyId: policy.id,
+      name: "Should Not Update Billing",
+      now: new Date("2026-04-20T16:50:00.000Z"),
+    }));
+
+    const error = expectLeftTag(result, "PricingPolicyAlreadyUsed") as PricingPolicyAlreadyUsed;
+    expect(error.pricingPolicyId).toBe(policy.id);
+    expect(error.reservationCount).toBe(0);
+    expect(error.rentalCount).toBe(0);
+    expect(error.billingRecordCount).toBe(1);
+  });
+
+  it("returns mutation window closed when activating outside overnight window", async () => {
+    const policy = await fixture.factories.pricingPolicy({
+      name: "Blocked Activation Policy",
+      status: "INACTIVE",
+    });
+
+    const result = await runCommand(service =>
+      service.activatePolicy(policy.id, new Date("2026-04-20T15:00:00.000Z")));
+
+    const error = expectLeftTag(result, "PricingPolicyMutationWindowClosed") as PricingPolicyMutationWindowClosed;
+    expect(error.windowStart).toBe("23:00");
+    expect(error.windowEnd).toBe("05:00");
+  });
+
+  it("returns not found when activating a nonexistent policy", async () => {
+    const missingId = uuidv7();
+
+    const result = await runCommand(service =>
+      service.activatePolicy(missingId, new Date("2026-04-20T17:00:00.000Z")));
+
+    const error = expectLeftTag(result, "PricingPolicyNotFound") as PricingPolicyNotFound;
+    expect(error.pricingPolicyId).toBe(missingId);
+  });
+
+  it("activates a target policy and deactivates the previous active one", async () => {
+    const nextPolicy = await fixture.factories.pricingPolicy({
+      name: "Next Active Policy",
+      status: "INACTIVE",
+    });
+
+    const initialActive = await fixture.prisma.pricingPolicy.findFirstOrThrow({
+      where: { status: "ACTIVE" },
+      orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+    });
+
+    const result = await runCommand(service =>
+      service.activatePolicy(nextPolicy.id, new Date("2026-04-20T17:00:00.000Z")));
+
+    const activated = expectRight(result);
+    expect(activated.id).toBe(nextPolicy.id);
+    expect(activated.status).toBe("ACTIVE");
+
+    const oldRow = await fixture.prisma.pricingPolicy.findUniqueOrThrow({
+      where: { id: initialActive.id },
+    });
+    const newRow = await fixture.prisma.pricingPolicy.findUniqueOrThrow({
+      where: { id: nextPolicy.id },
+    });
+
+    expect(oldRow.status).toBe("INACTIVE");
+    expect(newRow.status).toBe("ACTIVE");
+  });
+});

--- a/apps/server/src/domain/pricing/test/pricing-policy.repository.test.ts
+++ b/apps/server/src/domain/pricing/test/pricing-policy.repository.test.ts
@@ -30,6 +30,15 @@ function makeDb() {
       findUnique: vi.fn(),
       findMany: vi.fn(),
     },
+    reservation: {
+      count: vi.fn(),
+    },
+    rental: {
+      count: vi.fn(),
+    },
+    rentalBillingRecord: {
+      count: vi.fn(),
+    },
   } as unknown as PrismaClient;
 }
 
@@ -111,6 +120,40 @@ describe("pricing policy repository", () => {
     }
   });
 
+  it("returns usage summary when a policy has references", async () => {
+    const db = makeDb();
+    vi.mocked(db.reservation.count).mockResolvedValue(1);
+    vi.mocked(db.rental.count).mockResolvedValue(2);
+    vi.mocked(db.rentalBillingRecord.count).mockResolvedValue(3);
+
+    const repo = makePricingPolicyRepository(db);
+    const result = await Effect.runPromise(repo.getUsageSummary("policy-a"));
+
+    expect(result).toEqual({
+      reservationCount: 1,
+      rentalCount: 2,
+      billingRecordCount: 3,
+      isUsed: true,
+    });
+  });
+
+  it("returns unused usage summary when a policy has no references", async () => {
+    const db = makeDb();
+    vi.mocked(db.reservation.count).mockResolvedValue(0);
+    vi.mocked(db.rental.count).mockResolvedValue(0);
+    vi.mocked(db.rentalBillingRecord.count).mockResolvedValue(0);
+
+    const repo = makePricingPolicyRepository(db);
+    const result = await Effect.runPromise(repo.getUsageSummary("policy-a"));
+
+    expect(result).toEqual({
+      reservationCount: 0,
+      rentalCount: 0,
+      billingRecordCount: 0,
+      isUsed: false,
+    });
+  });
+
   it("defects with PricingPolicyRepositoryError when findById query rejects", async () => {
     const db = makeDb();
     vi.mocked(db.pricingPolicy.findUnique).mockRejectedValue(new Error("db down"));
@@ -134,6 +177,19 @@ describe("pricing policy repository", () => {
       repo.getActive(),
       PricingPolicyRepositoryError,
       { operation: "pricingPolicy.getActive" },
+    );
+  });
+
+  it("defects with PricingPolicyRepositoryError when getUsageSummary query rejects", async () => {
+    const db = makeDb();
+    vi.mocked(db.reservation.count).mockRejectedValue(new Error("db down"));
+
+    const repo = makePricingPolicyRepository(db);
+
+    await expectDefect(
+      repo.getUsageSummary("policy-a"),
+      PricingPolicyRepositoryError,
+      { operation: "pricingPolicy.getUsageSummary" },
     );
   });
 });

--- a/apps/server/src/domain/rentals/services/test/start-rental.int.test.ts
+++ b/apps/server/src/domain/rentals/services/test/start-rental.int.test.ts
@@ -2,6 +2,11 @@ import { Effect } from "effect";
 import { uuidv7 } from "uuidv7";
 import { beforeAll, describe, expect, it } from "vitest";
 
+import {
+  makePricingPolicyCommandRepository,
+  makePricingPolicyCommandService,
+  makePricingPolicyQueryRepository,
+} from "@/domain/pricing";
 import { makeRentalRepository } from "@/domain/rentals";
 import { expectLeftTag, expectRight } from "@/test/effect/assertions";
 import { runEffectEither } from "@/test/effect/run";
@@ -17,6 +22,14 @@ describe("startRentalUseCase Integration", () => {
   beforeAll(() => {
     runStartRental = makeRentalRunners(makeRentalTestLayer(fixture.prisma)).start;
   });
+
+  function makePricingPolicyService() {
+    return makePricingPolicyCommandService({
+      client: fixture.prisma,
+      queryRepo: makePricingPolicyQueryRepository(fixture.prisma),
+      commandRepo: makePricingPolicyCommandRepository(fixture.prisma),
+    });
+  }
 
   it("creates a rental and books the bike", async () => {
     const { user } = await givenUserWithWallet(fixture, {
@@ -57,6 +70,44 @@ describe("startRentalUseCase Integration", () => {
 
     const updatedBike = await fixture.prisma.bike.findUnique({ where: { id: bike.id } });
     expect(updatedBike?.status).toBe("BOOKED");
+  });
+
+  it("uses a policy activated through pricing policy service", async () => {
+    const nextPolicy = await fixture.factories.pricingPolicy({
+      name: "Start Rental Activated Policy",
+      depositRequired: "700000",
+      status: "INACTIVE",
+    });
+
+    const activation = await runEffectEither(
+      makePricingPolicyService().activatePolicy(
+        nextPolicy.id,
+        new Date("2026-04-20T16:30:00.000Z"),
+      ),
+    );
+    expectRight(activation);
+
+    const { user } = await givenUserWithWallet(fixture, {
+      wallet: { balance: 800000n },
+    });
+    const { station, bike } = await givenStationWithAvailableBike(fixture);
+
+    const startTime = new Date("2026-04-21T03:15:00.000Z");
+    const result = await runStartRental({
+      userId: user.id,
+      bikeId: bike.id,
+      startStationId: station.id,
+      startTime,
+      now: startTime,
+    });
+
+    const rental = expectRight(result);
+    expect(rental.pricingPolicyId).toBe(nextPolicy.id);
+
+    const wallet = await fixture.prisma.wallet.findUnique({
+      where: { userId: user.id },
+    });
+    expect(wallet?.reservedBalance.toString()).toBe("700000");
   });
 
   it("fails when user already has an active rental", async () => {

--- a/apps/server/src/domain/reservations/services/test/reservation.use-cases.int.test.ts
+++ b/apps/server/src/domain/reservations/services/test/reservation.use-cases.int.test.ts
@@ -1,8 +1,14 @@
 import { beforeAll, describe, expect, it } from "vitest";
 
 import { env } from "@/config/env";
+import {
+  makePricingPolicyCommandRepository,
+  makePricingPolicyCommandService,
+  makePricingPolicyQueryRepository,
+} from "@/domain/pricing";
 import { JobTypes } from "@/infrastructure/jobs/job-types";
 import { expectLeftTag, expectRight } from "@/test/effect/assertions";
+import { runEffectEither } from "@/test/effect/run";
 import { setupPrismaIntFixture } from "@/test/prisma/prisma-int-fixture";
 import { givenStationWithAvailableBike, givenUserWithWallet } from "@/test/scenarios";
 
@@ -22,6 +28,14 @@ describe("reservation use-cases integration", () => {
     runConfirm = runners.confirm;
     runCancel = runners.cancel;
   });
+
+  function makePricingPolicyService() {
+    return makePricingPolicyCommandService({
+      client: fixture.prisma,
+      queryRepo: makePricingPolicyQueryRepository(fixture.prisma),
+      commandRepo: makePricingPolicyCommandRepository(fixture.prisma),
+    });
+  }
 
   it("reserveBikeUseCase creates hold + outbox jobs and reserves bike", async () => {
     const { user } = await givenUserWithWallet(fixture, {
@@ -144,6 +158,44 @@ describe("reservation use-cases integration", () => {
 
     const updatedBike = await fixture.prisma.bike.findUnique({ where: { id: bike.id } });
     expect(updatedBike?.status).toBe("BOOKED");
+  });
+
+  it("reserveBikeUseCase uses a policy activated through pricing policy service", async () => {
+    const nextPolicy = await fixture.factories.pricingPolicy({
+      name: "Reservation Activated Policy",
+      reservationFee: "4500",
+      depositRequired: "650000",
+      status: "INACTIVE",
+    });
+
+    const activation = await runEffectEither(
+      makePricingPolicyService().activatePolicy(
+        nextPolicy.id,
+        new Date("2026-04-20T16:30:00.000Z"),
+      ),
+    );
+    expectRight(activation);
+
+    const { user } = await givenUserWithWallet(fixture, {
+      wallet: { balance: 50_000n },
+    });
+    const { station, bike } = await givenStationWithAvailableBike(fixture, {
+      station: { capacity: 2 },
+    });
+    await fixture.factories.bike({ stationId: station.id, status: "AVAILABLE" });
+
+    const now = new Date("2026-04-21T03:00:00.000Z");
+    const result = await runReserve({
+      userId: user.id,
+      bikeId: bike.id,
+      stationId: station.id,
+      startTime: now,
+      now,
+    });
+
+    const reservation = expectRight(result);
+    expect(reservation.pricingPolicyId).toBe(nextPolicy.id);
+    expect(reservation.prepaid.toString()).toBe("4500");
   });
 
   it("cancelReservationUseCase cancels hold, releases bike, and refunds prepaid amount", async () => {


### PR DESCRIPTION
## Summary
- refactor pricing policy persistence into dedicated read/write repositories with usage-summary support for history-safe edits
- add pricing policy query and command services with overnight mutation-window enforcement, inactive-draft creation, first-use immutability, and explicit activation flow
- cover service behavior plus reservation and rental activation integration so downstream pricing consumers pick up the active policy correctly