### PR TITLE
fix(server): use bigint values in pricing policy seed

### DIFF
--- a/apps/server/prisma/seed-pricing-policy.ts
+++ b/apps/server/prisma/seed-pricing-policy.ts
@@ -1,7 +1,5 @@
 import type { PrismaClient } from "../generated/prisma/client";
 
-import { toPrismaDecimal } from "../src/domain/shared/decimal";
-
 export const DEFAULT_PRICING_POLICY_ID = "11111111-1111-4111-8111-111111111111";
 
 export async function seedDefaultPricingPolicy(prisma: PrismaClient): Promise<void> {
@@ -9,20 +7,20 @@ export async function seedDefaultPricingPolicy(prisma: PrismaClient): Promise<vo
     where: { id: DEFAULT_PRICING_POLICY_ID },
     update: {
       name: "Default Pricing Policy",
-      baseRate: toPrismaDecimal("2000"),
+      baseRate: 2000n,
       billingUnitMinutes: 30,
-      reservationFee: toPrismaDecimal("2000"),
-      depositRequired: toPrismaDecimal("500000"),
+      reservationFee: 2000n,
+      depositRequired: 500000n,
       lateReturnCutoff: new Date("1970-01-01T23:00:00.000Z"),
       status: "ACTIVE",
     },
     create: {
       id: DEFAULT_PRICING_POLICY_ID,
       name: "Default Pricing Policy",
-      baseRate: toPrismaDecimal("2000"),
+      baseRate: 2000n,
       billingUnitMinutes: 30,
-      reservationFee: toPrismaDecimal("2000"),
-      depositRequired: toPrismaDecimal("500000"),
+      reservationFee: 2000n,
+      depositRequired: 500000n,
       lateReturnCutoff: new Date("1970-01-01T23:00:00.000Z"),
       status: "ACTIVE",
     },


### PR DESCRIPTION
## Summary
- update the Prisma pricing policy seed to use `BigInt` literals for `baseRate`, `reservationFee`, and `depositRequired`
- remove the stale Decimal helper import from the seed file now that pricing policy money columns are `BigInt`
- unblock demo seeding on main after the pricing policy money column migration