### PR TITLE
feat(server): paginate admin pricing policy list

### DIFF
--- a/apps/server/src/domain/pricing/repository/pricing-policy.repository.types.ts
+++ b/apps/server/src/domain/pricing/repository/pricing-policy.repository.types.ts
@@ -1,5 +1,6 @@
 import type { Effect, Option } from "effect";
 
+import type { PageRequest, PageResult } from "@/domain/shared/pagination";
 import type {
   AccountStatus,
 } from "generated/prisma/client";
@@ -62,7 +63,8 @@ export type PricingPolicyReadRepo = {
   >;
   listByStatus: (
     status?: AccountStatus,
-  ) => Effect.Effect<ReadonlyArray<PricingPolicyRow>>;
+    pageReq?: PageRequest,
+  ) => Effect.Effect<PageResult<PricingPolicyRow>>;
   getUsageSummary: (
     pricingPolicyId: string,
   ) => Effect.Effect<PricingPolicyUsageSummary>;

--- a/apps/server/src/domain/pricing/repository/read/pricing-policy.read.repository.ts
+++ b/apps/server/src/domain/pricing/repository/read/pricing-policy.read.repository.ts
@@ -6,6 +6,7 @@ import type {
 } from "generated/prisma/client";
 
 import { defectOn } from "@/domain/shared";
+import { makePageResult, normalizedPage } from "@/domain/shared/pagination";
 
 import type { PricingPolicyReadRepo } from "../pricing-policy.repository.types";
 
@@ -90,21 +91,30 @@ export function makePricingPolicyReadRepository(
         defectOn(PricingPolicyRepositoryError),
       ),
 
-    listByStatus: status =>
+    listByStatus: (status, pageReq = { page: 1, pageSize: 50 }) =>
       Effect.tryPromise({
-        try: () =>
-          client.pricingPolicy.findMany({
-            where: status ? { status } : undefined,
-            orderBy: [{ createdAt: "desc" }, { id: "desc" }],
-            select: pricingPolicySelect,
-          }),
+        try: async () => {
+          const { page, pageSize, skip, take } = normalizedPage(pageReq);
+          const where = status ? { status } : undefined;
+          const [rows, total] = await Promise.all([
+            client.pricingPolicy.findMany({
+              where,
+              orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+              skip,
+              take,
+              select: pricingPolicySelect,
+            }),
+            client.pricingPolicy.count({ where }),
+          ]);
+
+          return makePageResult(rows.map(toPricingPolicyRow), total, page, pageSize);
+        },
         catch: cause =>
           new PricingPolicyRepositoryError({
             operation: "pricingPolicy.listByStatus",
             cause,
           }),
       }).pipe(
-        Effect.map(rows => rows.map(toPricingPolicyRow)),
         defectOn(PricingPolicyRepositoryError),
       ),
 

--- a/apps/server/src/domain/pricing/services/pricing-policy-query.service.ts
+++ b/apps/server/src/domain/pricing/services/pricing-policy-query.service.ts
@@ -40,8 +40,8 @@ export function makePricingPolicyQueryService(
    * @param status Status cần lọc; bỏ qua nếu muốn lấy toàn bộ.
    * @returns Effect trả về danh sách policy phù hợp điều kiện lọc.
    */
-  const listPolicies: PricingPolicyQueryService["listPolicies"] = status =>
-    repo.listByStatus(status);
+  const listPolicies: PricingPolicyQueryService["listPolicies"] = (status, pageReq) =>
+    repo.listByStatus(status, pageReq);
 
   /**
    * Trả về usage summary để caller biết policy đã bị “khóa lịch sử” hay chưa.

--- a/apps/server/src/domain/pricing/services/pricing-policy.service.types.ts
+++ b/apps/server/src/domain/pricing/services/pricing-policy.service.types.ts
@@ -1,5 +1,6 @@
 import type { Effect } from "effect";
 
+import type { PageRequest, PageResult } from "@/domain/shared/pagination";
 import type { AccountStatus } from "generated/prisma/client";
 
 import type {
@@ -57,7 +58,8 @@ export type PricingPolicyQueryService = {
   >;
   listPolicies: (
     status?: AccountStatus,
-  ) => Effect.Effect<ReadonlyArray<PricingPolicyRow>>;
+    pageReq?: PageRequest,
+  ) => Effect.Effect<PageResult<PricingPolicyRow>>;
   getUsageSummary: (
     pricingPolicyId: string,
   ) => Effect.Effect<PricingPolicyUsageSummary>;

--- a/apps/server/src/domain/pricing/test/pricing-policy.repository.test.ts
+++ b/apps/server/src/domain/pricing/test/pricing-policy.repository.test.ts
@@ -28,6 +28,7 @@ function makeDb() {
     pricingPolicy: {
       findUnique: vi.fn(),
       findMany: vi.fn(),
+      count: vi.fn(),
     },
     reservation: {
       count: vi.fn(),
@@ -119,6 +120,22 @@ describe("pricing policy repository", () => {
     }
   });
 
+  it("lists pricing policies with pagination metadata", async () => {
+    const db = makeDb();
+    vi.mocked(db.pricingPolicy.findMany).mockResolvedValue([makePolicy("policy-a")]);
+    vi.mocked(db.pricingPolicy.count).mockResolvedValue(3);
+
+    const repo = makePricingPolicyRepository(db);
+    const result = await Effect.runPromise(repo.listByStatus("ACTIVE", { page: 2, pageSize: 1 }));
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]?.id).toBe("policy-a");
+    expect(result.page).toBe(2);
+    expect(result.pageSize).toBe(1);
+    expect(result.total).toBe(3);
+    expect(result.totalPages).toBe(3);
+  });
+
   it("returns usage summary when a policy has references", async () => {
     const db = makeDb();
     vi.mocked(db.reservation.count).mockResolvedValue(1);
@@ -176,6 +193,19 @@ describe("pricing policy repository", () => {
       repo.getActive(),
       PricingPolicyRepositoryError,
       { operation: "pricingPolicy.getActive" },
+    );
+  });
+
+  it("defects with PricingPolicyRepositoryError when listByStatus query rejects", async () => {
+    const db = makeDb();
+    vi.mocked(db.pricingPolicy.findMany).mockRejectedValue(new Error("db down"));
+
+    const repo = makePricingPolicyRepository(db);
+
+    await expectDefect(
+      repo.listByStatus("ACTIVE", { page: 1, pageSize: 10 }),
+      PricingPolicyRepositoryError,
+      { operation: "pricingPolicy.listByStatus" },
     );
   });
 

--- a/apps/server/src/http/controllers/pricing-policies/admin.controller.ts
+++ b/apps/server/src/http/controllers/pricing-policies/admin.controller.ts
@@ -95,14 +95,23 @@ const adminListPricingPolicies: RouteHandler<
 
   const eff = withLoggedCause(
     Effect.flatMap(PricingPolicyQueryServiceTag, service =>
-      service.listPolicies(query.status)),
+      service.listPolicies(query.status, {
+        page: query.page ?? 1,
+        pageSize: query.pageSize ?? 50,
+      })),
     "GET /v1/admin/pricing-policies",
   );
 
-  const policies = await c.var.runPromise(eff);
+  const result = await c.var.runPromise(eff);
 
   return c.json<PricingPoliciesContracts.PricingPolicyListResponse, 200>({
-    data: policies.map(toContractPricingPolicy),
+    data: result.items.map(toContractPricingPolicy),
+    pagination: {
+      page: result.page,
+      pageSize: result.pageSize,
+      total: result.total,
+      totalPages: result.totalPages,
+    },
   }, 200);
 };
 

--- a/apps/server/src/http/test/e2e/admin-pricing-policies-routing.e2e.int.test.ts
+++ b/apps/server/src/http/test/e2e/admin-pricing-policies-routing.e2e.int.test.ts
@@ -167,15 +167,26 @@ describe("admin pricing policies routing e2e", () => {
       name: "Inactive Pricing Policy",
       status: "INACTIVE",
     });
+    await fixture.factories.pricingPolicy({
+      name: "Another Inactive Pricing Policy",
+      status: "INACTIVE",
+    });
 
-    const response = await fixture.app.request("http://test/v1/admin/pricing-policies?status=INACTIVE", {
+    const response = await fixture.app.request("http://test/v1/admin/pricing-policies?status=INACTIVE&page=1&pageSize=1", {
       method: "GET",
       headers: authHeaders(),
     });
     const body = await response.json() as PricingPoliciesContracts.PricingPolicyListResponse;
 
     expect(response.status).toBe(200);
+    expect(body.data).toHaveLength(1);
     expect(body.data.every(policy => policy.status === "INACTIVE")).toBe(true);
+    expect(body.pagination).toEqual({
+      page: 1,
+      pageSize: 1,
+      total: 2,
+      totalPages: 2,
+    });
   });
 
   it("returns pricing policy detail with usage summary", async () => {

--- a/packages/shared/src/contracts/server/pricing-policies/models.ts
+++ b/packages/shared/src/contracts/server/pricing-policies/models.ts
@@ -1,5 +1,6 @@
 import { z } from "../../../zod";
 import { AccountStatusSchema } from "../users";
+import { PaginationSchema } from "../schemas";
 
 export const PricingPolicyTimeSchema = z.string().regex(/^([01]\d|2[0-3]):[0-5]\d:[0-5]\d$/).openapi(
   "PricingPolicyTime",
@@ -104,6 +105,7 @@ export const PricingPolicyDetailSchema = PricingPolicySchema.extend({
 
 export const PricingPolicyListResponseSchema = z.object({
   data: z.array(PricingPolicySchema),
+  pagination: PaginationSchema,
 }).openapi("PricingPolicyListResponse", {
   description: "Admin list of pricing policies.",
   example: {
@@ -121,6 +123,12 @@ export const PricingPolicyListResponseSchema = z.object({
         updated_at: "2026-04-20T16:00:00.000Z",
       },
     ],
+    pagination: {
+      page: 1,
+      pageSize: 50,
+      total: 1,
+      totalPages: 1,
+    },
   },
 });
 

--- a/packages/shared/src/contracts/server/routes/pricing-policies/shared.ts
+++ b/packages/shared/src/contracts/server/routes/pricing-policies/shared.ts
@@ -10,6 +10,7 @@ import {
 import {
   ServerErrorResponseSchema,
   UnauthorizedErrorResponseSchema,
+  paginationQueryFields,
 } from "../../schemas";
 import { AccountStatusSchema } from "../../users";
 
@@ -47,6 +48,7 @@ export const ListPricingPoliciesQuerySchema = z.object({
     description: "Optional filter by pricing policy status.",
     example: "ACTIVE",
   }),
+  ...paginationQueryFields,
 }).openapi("ListPricingPoliciesQuery");
 
 export const CreatePricingPolicyBodySchema = z.object({


### PR DESCRIPTION
## Summary
- add page and pageSize query params to the admin pricing policy list contract
- paginate pricing policy reads in the server query stack and return pagination metadata
- update focused pricing repository and admin e2e coverage for the new list shape

## Verification
- pnpm eslint --fix src/domain/pricing/repository/pricing-policy.repository.types.ts src/domain/pricing/repository/read/pricing-policy.read.repository.ts src/domain/pricing/services/pricing-policy-query.service.ts src/domain/pricing/services/pricing-policy.service.types.ts src/domain/pricing/test/pricing-policy.repository.test.ts src/http/controllers/pricing-policies/admin.controller.ts src/http/test/e2e/admin-pricing-policies-routing.e2e.int.test.ts
- pnpm --dir ../../packages/shared build
- pnpm vitest run src/domain/pricing/test/pricing-policy.repository.test.ts