### PR TITLE
fix(server): align seeded pricing policy id with uuidv7 contracts

### DIFF
--- a/apps/server/prisma/seed-pricing-policy.ts
+++ b/apps/server/prisma/seed-pricing-policy.ts
@@ -1,6 +1,6 @@
 import type { PrismaClient } from "../generated/prisma/client";
 
-export const DEFAULT_PRICING_POLICY_ID = "11111111-1111-4111-8111-111111111111";
+export const DEFAULT_PRICING_POLICY_ID = "0195c768-3456-7f01-8234-111111111111";
 
 export async function seedDefaultPricingPolicy(prisma: PrismaClient): Promise<void> {
   await prisma.pricingPolicy.upsert({

--- a/apps/server/src/domain/reservations/services/test/fixed-slot.service.int.test.ts
+++ b/apps/server/src/domain/reservations/services/test/fixed-slot.service.int.test.ts
@@ -70,7 +70,7 @@ describe("assignFixedSlotReservations integration", () => {
     expect(reservation?.bikeId).toBe(bike.id);
     expect(reservation?.stationId).toBe(station.id);
     expect(reservation?.endTime).toBeNull();
-    expect(reservation?.pricingPolicyId).toBe("11111111-1111-4111-8111-111111111111");
+    expect(reservation?.pricingPolicyId).toBe("0195c768-3456-7f01-8234-111111111111");
     expect(reservation?.subscriptionId).toBeNull();
     expect(reservation?.prepaid.toString()).toBe("2000");
 

--- a/apps/server/src/http/test/e2e/rentals-billing-preview-routing.e2e.int.test.ts
+++ b/apps/server/src/http/test/e2e/rentals-billing-preview-routing.e2e.int.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 
 import { setupHttpE2eFixture } from "@/test/http/e2e-fixture";
 
-const DEFAULT_PRICING_POLICY_ID = "11111111-1111-4111-8111-111111111111";
+const DEFAULT_PRICING_POLICY_ID = "0195c768-3456-7f01-8234-111111111111";
 
 describe("rentals billing preview routing e2e", () => {
   const fixture = setupHttpE2eFixture({

--- a/apps/server/src/test/db/seed-pricing-policy.ts
+++ b/apps/server/src/test/db/seed-pricing-policy.ts
@@ -1,6 +1,6 @@
 import type { PrismaClient } from "generated/prisma/client";
 
-const DEFAULT_PRICING_POLICY_ID = "11111111-1111-4111-8111-111111111111";
+const DEFAULT_PRICING_POLICY_ID = "0195c768-3456-7f01-8234-111111111111";
 
 export async function seedDefaultPricingPolicy(prisma: PrismaClient): Promise<void> {
   await prisma.pricingPolicy.upsert({


### PR DESCRIPTION
## Summary
- replace the hard-coded default pricing policy seed id with a UUIDv7-shaped value
- update test helpers and assertions that depend on the seeded default pricing policy id
- keep seeded pricing policy data aligned with shared route and model contracts that validate ids as uuidv7

## Testing
- searched for remaining uses of the old seeded pricing policy id
- targeted Vitest runs still hit unrelated existing `nfcCardUid` breakage on `main`