### PR TITLE
Add user riding offers view

### DIFF
--- a/apps/mobile/components/IconSymbol.tsx
+++ b/apps/mobile/components/IconSymbol.tsx
@@ -2,7 +2,6 @@
 
 import type { ColorValue, StyleProp, ViewStyle } from "react-native";
 
-import { iconSizes } from "@theme/metrics";
 import {
   ArrowDown,
   ArrowLeft,
@@ -55,8 +54,11 @@ import {
   Wind,
   Wrench,
   X,
+  Zap,
 } from "lucide-react-native";
 import React from "react";
+
+import { iconSizes } from "@theme/metrics";
 
 type LucideIconComponent = typeof ArrowLeft;
 
@@ -123,6 +125,7 @@ const ICONS = {
   "wallet": { outline: { icon: Wallet } },
   "warning": { outline: { icon: TriangleAlert }, filled: { icon: TriangleAlert, fill: true } },
   "wind": { outline: { icon: Wind } },
+  "zap": { outline: { icon: Zap }, filled: { icon: Zap, fill: true, strokeWidth: 1.8 } },
 } as const satisfies Record<string, IconVariantConfig>;
 
 type IconRegistry = typeof ICONS;

--- a/apps/mobile/contracts/server.ts
+++ b/apps/mobile/contracts/server.ts
@@ -4,6 +4,8 @@ import type { z } from "zod";
 export type BikeSummary = ServerContracts.BikesContracts.BikeSummary;
 export type StationReadSummary = ServerContracts.StationsContracts.StationReadSummary;
 export type StationListResponse = ServerContracts.StationsContracts.StationListResponse;
+export type ActiveCouponRule = ServerContracts.CouponsContracts.ActiveCouponRule;
+export type ActiveCouponRulesResponse = ServerContracts.CouponsContracts.ActiveCouponRulesResponse;
 
 export type ReservationDetail = ServerContracts.ReservationsContracts.ReservationDetail;
 export type ReservationExpandedDetail = ServerContracts.ReservationsContracts.ReservationExpandedDetail;

--- a/apps/mobile/hooks/query/coupons/coupon-query-keys.ts
+++ b/apps/mobile/hooks/query/coupons/coupon-query-keys.ts
@@ -1,0 +1,4 @@
+export const couponRuleQueryKeys = {
+  all: () => ["coupon-rules"] as const,
+  active: () => ["coupon-rules", "active"] as const,
+};

--- a/apps/mobile/hooks/query/coupons/use-active-coupon-rules-query.ts
+++ b/apps/mobile/hooks/query/coupons/use-active-coupon-rules-query.ts
@@ -1,0 +1,23 @@
+import { useQuery } from "@tanstack/react-query";
+
+import type { ActiveCouponRulesResponse } from "@/contracts/server";
+import type { CouponRuleError } from "@services/coupons";
+
+import { couponRuleService } from "@services/coupons";
+
+import { couponRuleQueryKeys } from "./coupon-query-keys";
+
+export function useActiveCouponRulesQuery(enabled: boolean = true) {
+  return useQuery<ActiveCouponRulesResponse, CouponRuleError>({
+    queryKey: couponRuleQueryKeys.active(),
+    enabled,
+    queryFn: async () => {
+      const result = await couponRuleService.listActive();
+      if (!result.ok) {
+        throw result.error;
+      }
+      return result.value;
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/apps/mobile/navigation/root-navigator.tsx
+++ b/apps/mobile/navigation/root-navigator.tsx
@@ -1,7 +1,8 @@
-import { LoadingScreen } from "@components/LoadingScreen";
-import { useAuthNext } from "@providers/auth-provider-next";
 import { createStackNavigator } from "@react-navigation/stack";
 import React, { useEffect } from "react";
+
+import { LoadingScreen } from "@components/LoadingScreen";
+import { useAuthNext } from "@providers/auth-provider-next";
 
 import type { RootStackParamList } from "../types/navigation";
 
@@ -29,6 +30,7 @@ import {
   ReservationScreen,
   ResetPasswordFormScreen,
   ResetPasswordOTPScreen,
+  RidingOffersScreen,
   StaffBikeSwapDetailScreen,
   StaffBikeSwapListScreen,
   StaffPhoneLookupScreen,
@@ -40,8 +42,8 @@ import {
   UpdateProfileScreen,
 } from "../screen";
 import StationSelectScreen from "../styles/StationSelect";
-import { navigationRef } from "./navigation-ref";
 import MainTabNavigator from "./main-tab-navigator";
+import { navigationRef } from "./navigation-ref";
 
 const Stack = createStackNavigator<RootStackParamList>();
 
@@ -178,6 +180,11 @@ function RootNavigator() {
               <Stack.Screen
                 name="Reservations"
                 component={ReservationScreen}
+                options={standardScreenOptions}
+              />
+              <Stack.Screen
+                name="RidingOffers"
+                component={RidingOffersScreen}
                 options={standardScreenOptions}
               />
               <Stack.Screen

--- a/apps/mobile/screen/account/profile/hooks/use-profile.ts
+++ b/apps/mobile/screen/account/profile/hooks/use-profile.ts
@@ -107,6 +107,10 @@ export function useProfile() {
     navigation.navigate("Reservations" as never);
   };
 
+  const handleRidingOffers = () => {
+    navigation.navigate("RidingOffers" as never);
+  };
+
   const handleSubscriptions = () => {
     navigation.navigate("Subscriptions" as never);
   };
@@ -140,6 +144,7 @@ export function useProfile() {
     handleChangePassword,
     handleUpdateProfile,
     handleReservations,
+    handleRidingOffers,
     handleSubscriptions,
     handleEnvironmentImpact,
     handleMetroJourney,

--- a/apps/mobile/screen/account/profile/index.tsx
+++ b/apps/mobile/screen/account/profile/index.tsx
@@ -1,12 +1,13 @@
+import { useMemo } from "react";
+import { RefreshControl, ScrollView, StatusBar } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Separator, useTheme, YStack } from "tamagui";
+
 import { VerifyEmailModal } from "@components/verify-email-modal";
 import { borderWidths, elevations, radii } from "@theme/metrics";
 import { AppCard } from "@ui/primitives/app-card";
 import { AppText } from "@ui/primitives/app-text";
 import { Screen } from "@ui/primitives/screen";
-import { useMemo } from "react";
-import { RefreshControl, ScrollView, StatusBar } from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { Separator, useTheme, YStack } from "tamagui";
 
 import ProfileHeader from "./components/profile-header";
 import ProfileMenuOption from "./components/profile-menu-option";
@@ -72,6 +73,7 @@ function ProfileScreen() {
     handleVerifyEmailPress,
     handleUpdateProfile,
     handleReservations,
+    handleRidingOffers,
     handleSubscriptions,
     handleEnvironmentImpact,
     handleMetroJourney,
@@ -97,6 +99,15 @@ function ProfileScreen() {
     ];
 
     items.push({
+      icon: "tag",
+      title: "Ưu đãi đạp xe",
+      subtitle: "Xem các mốc giảm giá tự động",
+      iconColor: theme.statusSuccess.val,
+      iconBackground: theme.surfaceSuccess.val,
+      onPress: handleRidingOffers,
+    });
+
+    items.push({
       icon: "bike",
       title: "Gói tháng",
       subtitle: "Ưu đãi và lịch sử sử dụng",
@@ -118,6 +129,7 @@ function ProfileScreen() {
   }, [
     handleEnvironmentImpact,
     handleReservations,
+    handleRidingOffers,
     handleSubscriptions,
     isCustomer,
     theme.actionPrimary.val,

--- a/apps/mobile/screen/index.ts
+++ b/apps/mobile/screen/index.ts
@@ -24,6 +24,7 @@ export { default as RentalQrScreen } from "./rental/rental-qr";
 export { default as ReservationDetailScreen } from "./reservation-detail-screen";
 export { default as ReservationFlowScreen } from "./reservation-flow";
 export { default as ReservationScreen } from "./reservations";
+export { default as RidingOffersScreen } from "./riding-offers";
 export { default as StaffBikeSwapDetailScreen } from "./staff/bike-swap/detail/staff-bike-swap-detail-screen";
 export { default as StaffBikeSwapListScreen } from "./staff/bike-swap/list/staff-bike-swap-list-screen";
 export { default as StaffDashboardScreen } from "./staff/dashboard/staff-dashboard-screen";

--- a/apps/mobile/screen/riding-offers/index.tsx
+++ b/apps/mobile/screen/riding-offers/index.tsx
@@ -23,20 +23,20 @@ function formatDiscount(rule: ActiveCouponRule) {
   return `Giảm ${formatCurrency(rule.discountValue)}`;
 }
 
-function formatCondition(rule: ActiveCouponRule) {
-  if (rule.minRidingMinutes > 0) {
-    return `Từ ${rule.minRidingMinutes} phút tính cước`;
+function formatDuration(minutes: number) {
+  if (minutes % 60 === 0) {
+    return `${minutes / 60} giờ`;
   }
 
-  if (rule.minBillableHours > 0) {
-    return `Từ ${rule.minBillableHours} giờ tính cước`;
-  }
-
-  return "Áp dụng cho chuyến đi đủ điều kiện";
+  return `${minutes} phút`;
 }
 
-function RuleCard({ rule }: { rule: ActiveCouponRule }) {
+function RuleCard({ nextMinRidingMinutes, rule }: { nextMinRidingMinutes?: number; rule: ActiveCouponRule }) {
   const theme = useTheme();
+  const thresholdLabel = `Từ ${formatDuration(rule.minRidingMinutes)} đạp xe`;
+  const upperBoundLabel = nextMinRidingMinutes
+    ? `Đến dưới ${formatDuration(nextMinRidingMinutes)}`
+    : null;
 
   return (
     <AppCard
@@ -77,9 +77,18 @@ function RuleCard({ rule }: { rule: ActiveCouponRule }) {
 
       <XStack alignItems="center" gap="$3">
         <IconSymbol color={theme.textTertiary.val} name="clock" size="input" />
-        <AppText flex={1} variant="subhead">
-          {formatCondition(rule)}
-        </AppText>
+        <YStack flex={1} gap="$1" minWidth={0}>
+          <AppText variant="subhead">
+            {thresholdLabel}
+          </AppText>
+          {upperBoundLabel
+            ? (
+                <AppText tone="muted" variant="bodySmall">
+                  {upperBoundLabel}
+                </AppText>
+              )
+            : null}
+        </YStack>
       </XStack>
     </AppCard>
   );
@@ -132,7 +141,7 @@ export default function RidingOffersScreen() {
   const navigation = useNavigation<RidingOffersNavigationProp>();
   const theme = useTheme();
   const query = useActiveCouponRulesQuery();
-  const rules = query.data?.data ?? [];
+  const rules = [...(query.data?.data ?? [])].sort((left, right) => left.minRidingMinutes - right.minRidingMinutes);
 
   return (
     <Screen tone="subtle">
@@ -171,7 +180,13 @@ export default function RidingOffersScreen() {
                 ? <ErrorState onRetry={() => { void query.refetch(); }} />
                 : rules.length === 0
                   ? <EmptyState />
-                  : rules.map(rule => <RuleCard key={rule.id} rule={rule} />)}
+                  : rules.map((rule, index) => (
+                      <RuleCard
+                        key={rule.id}
+                        nextMinRidingMinutes={rules[index + 1]?.minRidingMinutes}
+                        rule={rule}
+                      />
+                    ))}
           </YStack>
 
         </YStack>

--- a/apps/mobile/screen/riding-offers/index.tsx
+++ b/apps/mobile/screen/riding-offers/index.tsx
@@ -1,0 +1,181 @@
+import { useNavigation } from "@react-navigation/native";
+import { RefreshControl, ScrollView, StatusBar } from "react-native";
+import { Separator, Spinner, useTheme, XStack, YStack } from "tamagui";
+
+import type { ActiveCouponRule } from "@/contracts/server";
+import type { RidingOffersNavigationProp } from "@/types/navigation";
+
+import { useActiveCouponRulesQuery } from "@/hooks/query/coupons/use-active-coupon-rules-query";
+import { formatCurrency } from "@/utils/wallet/formatters";
+import { IconSymbol } from "@components/IconSymbol";
+import { borderWidths, elevations, radii, spaceScale } from "@theme/metrics";
+import { AppHeroHeader } from "@ui/patterns/app-hero-header";
+import { AppButton } from "@ui/primitives/app-button";
+import { AppCard } from "@ui/primitives/app-card";
+import { AppText } from "@ui/primitives/app-text";
+import { Screen } from "@ui/primitives/screen";
+
+function formatDiscount(rule: ActiveCouponRule) {
+  if (rule.discountType === "PERCENTAGE") {
+    return `Giảm ${rule.discountValue}%`;
+  }
+
+  return `Giảm ${formatCurrency(rule.discountValue)}`;
+}
+
+function formatCondition(rule: ActiveCouponRule) {
+  if (rule.minRidingMinutes > 0) {
+    return `Từ ${rule.minRidingMinutes} phút tính cước`;
+  }
+
+  if (rule.minBillableHours > 0) {
+    return `Từ ${rule.minBillableHours} giờ tính cước`;
+  }
+
+  return "Áp dụng cho chuyến đi đủ điều kiện";
+}
+
+function RuleCard({ rule }: { rule: ActiveCouponRule }) {
+  const theme = useTheme();
+
+  return (
+    <AppCard
+      borderColor="$borderSubtle"
+      borderRadius={radii.xl}
+      borderWidth={borderWidths.subtle}
+      chrome="flat"
+      gap="$4"
+      padding="$4"
+      style={elevations.whisper}
+    >
+      <XStack alignItems="center" gap="$4">
+        <YStack
+          alignItems="center"
+          backgroundColor="$surfaceSuccess"
+          borderRadius="$round"
+          height={56}
+          justifyContent="center"
+          width={56}
+        >
+          <IconSymbol color={theme.statusSuccess.val} name="tag" size="lg" />
+        </YStack>
+
+        <YStack flex={1} gap="$1" minWidth={0}>
+          <AppText numberOfLines={1} tone="success" variant="headline">
+            {formatDiscount(rule)}
+          </AppText>
+          <XStack alignItems="center" gap="$2">
+            <IconSymbol color={theme.statusWarning.val} name="zap" size="caption" variant="filled" />
+            <AppText tone="muted" variant="bodySmall">
+              Áp dụng tự động
+            </AppText>
+          </XStack>
+        </YStack>
+      </XStack>
+
+      <Separator borderColor="$backgroundSubtle" />
+
+      <XStack alignItems="center" gap="$3">
+        <IconSymbol color={theme.textTertiary.val} name="clock" size="input" />
+        <AppText flex={1} variant="subhead">
+          {formatCondition(rule)}
+        </AppText>
+      </XStack>
+    </AppCard>
+  );
+}
+
+function LoadingState() {
+  return (
+    <YStack alignItems="center" gap="$3" paddingVertical="$9">
+      <Spinner size="small" color="$textBrand" />
+      <AppText tone="muted" variant="bodySmall">
+        Đang tải ưu đãi đạp xe...
+      </AppText>
+    </YStack>
+  );
+}
+
+function EmptyState() {
+  const theme = useTheme();
+
+  return (
+    <AppCard alignItems="center" borderRadius={radii.xl} gap="$3" padding="$6">
+      <IconSymbol color={theme.textTertiary.val} name="tag" size="xl" />
+      <AppText align="center" variant="cardTitle">
+        Chưa có ưu đãi đang áp dụng
+      </AppText>
+      <AppText align="center" tone="muted" variant="bodySmall">
+        Các mốc giảm giá mới sẽ hiển thị tại đây khi được hệ thống kích hoạt.
+      </AppText>
+    </AppCard>
+  );
+}
+
+function ErrorState({ onRetry }: { onRetry: () => void }) {
+  return (
+    <AppCard alignItems="center" borderRadius={radii.xl} gap="$3" padding="$6" tone="warning">
+      <AppText align="center" variant="cardTitle">
+        Không thể tải ưu đãi
+      </AppText>
+      <AppText align="center" tone="muted" variant="bodySmall">
+        Vui lòng kiểm tra kết nối và thử lại.
+      </AppText>
+      <AppButton buttonSize="compact" onPress={onRetry}>
+        Thử lại
+      </AppButton>
+    </AppCard>
+  );
+}
+
+export default function RidingOffersScreen() {
+  const navigation = useNavigation<RidingOffersNavigationProp>();
+  const theme = useTheme();
+  const query = useActiveCouponRulesQuery();
+  const rules = query.data?.data ?? [];
+
+  return (
+    <Screen tone="subtle">
+      <StatusBar backgroundColor={theme.actionPrimary.val} barStyle="light-content" />
+      <AppHeroHeader
+        onBack={() => navigation.goBack()}
+        size="compact"
+        subtitle="Tự động áp dụng khi chuyến đi đủ điều kiện"
+        title="Ưu đãi đạp xe"
+        variant="brand"
+      />
+
+      <ScrollView
+        contentContainerStyle={{ paddingBottom: spaceScale[7] }}
+        refreshControl={(
+          <RefreshControl
+            colors={[theme.actionPrimary.val]}
+            onRefresh={() => {
+              void query.refetch();
+            }}
+            refreshing={query.isRefetching}
+            tintColor={theme.actionPrimary.val}
+          />
+        )}
+        showsVerticalScrollIndicator={false}
+      >
+        <YStack gap="$5" padding="$5" paddingTop="$6">
+          <YStack gap="$3">
+            <AppText variant="sectionTitle">
+              Các mốc đang áp dụng
+            </AppText>
+
+            {query.isLoading
+              ? <LoadingState />
+              : query.isError
+                ? <ErrorState onRetry={() => { void query.refetch(); }} />
+                : rules.length === 0
+                  ? <EmptyState />
+                  : rules.map(rule => <RuleCard key={rule.id} rule={rule} />)}
+          </YStack>
+
+        </YStack>
+      </ScrollView>
+    </Screen>
+  );
+}

--- a/apps/mobile/services/coupons/coupon-error.ts
+++ b/apps/mobile/services/coupons/coupon-error.ts
@@ -1,32 +1,29 @@
+import type { z } from "zod";
+
+import { ServerContracts } from "@mebike/shared";
+
 import type { Result } from "@lib/result";
 import type { ServiceError } from "@services/shared/service-error";
 
-import { readJson } from "@lib/api-decode";
-import { asNetworkError as asSharedNetworkError } from "@services/shared/service-error";
+import { asNetworkError as asSharedNetworkError, normalizeServiceErrorCode, parseServiceError } from "@services/shared/service-error";
 
-export type CouponRuleErrorCode = "UNKNOWN";
+type ContractCouponRuleErrorCode = z.infer<
+  typeof ServerContracts.CouponsContracts.CouponRuleErrorCodeSchema
+>;
+
+export type CouponRuleErrorCode = ContractCouponRuleErrorCode | "UNAUTHORIZED" | "FORBIDDEN" | "UNKNOWN";
 
 export type CouponRuleError = ServiceError<CouponRuleErrorCode>;
 
-export async function parseCouponRuleError(response: Response): Promise<CouponRuleError> {
-  try {
-    const data = await readJson(response) as {
-      error?: unknown;
-      details?: unknown;
-    };
+function isCouponRuleContractErrorCode(code: string): code is ContractCouponRuleErrorCode {
+  return ServerContracts.CouponsContracts.CouponRuleErrorCodeSchema.safeParse(code).success;
+}
 
-    return {
-      _tag: "ApiError",
-      code: "UNKNOWN",
-      message: typeof data.error === "string" ? data.error : undefined,
-      details: data.details && typeof data.details === "object"
-        ? data.details as Record<string, unknown>
-        : undefined,
-    };
-  }
-  catch {
-    return { _tag: "DecodeError" };
-  }
+export async function parseCouponRuleError(response: Response): Promise<CouponRuleError> {
+  return parseServiceError(response, {
+    schema: ServerContracts.CouponsContracts.CouponRuleErrorResponseSchema,
+    mapCode: code => normalizeServiceErrorCode(code, isCouponRuleContractErrorCode),
+  });
 }
 
 export function asNetworkError(error: unknown): Result<never, CouponRuleError> {

--- a/apps/mobile/services/coupons/coupon-error.ts
+++ b/apps/mobile/services/coupons/coupon-error.ts
@@ -1,0 +1,34 @@
+import type { Result } from "@lib/result";
+import type { ServiceError } from "@services/shared/service-error";
+
+import { readJson } from "@lib/api-decode";
+import { asNetworkError as asSharedNetworkError } from "@services/shared/service-error";
+
+export type CouponRuleErrorCode = "UNKNOWN";
+
+export type CouponRuleError = ServiceError<CouponRuleErrorCode>;
+
+export async function parseCouponRuleError(response: Response): Promise<CouponRuleError> {
+  try {
+    const data = await readJson(response) as {
+      error?: unknown;
+      details?: unknown;
+    };
+
+    return {
+      _tag: "ApiError",
+      code: "UNKNOWN",
+      message: typeof data.error === "string" ? data.error : undefined,
+      details: data.details && typeof data.details === "object"
+        ? data.details as Record<string, unknown>
+        : undefined,
+    };
+  }
+  catch {
+    return { _tag: "DecodeError" };
+  }
+}
+
+export function asNetworkError(error: unknown): Result<never, CouponRuleError> {
+  return asSharedNetworkError<Extract<CouponRuleError, { _tag: "NetworkError" }>>(error);
+}

--- a/apps/mobile/services/coupons/coupon.service.ts
+++ b/apps/mobile/services/coupons/coupon.service.ts
@@ -1,0 +1,52 @@
+import type { z } from "zod";
+
+import { StatusCodes } from "http-status-codes";
+
+import type { ActiveCouponRulesResponse } from "@/contracts/server";
+import type { Result } from "@lib/result";
+
+import { decodeWithSchema, readJson } from "@lib/api-decode";
+import { kyClient } from "@lib/ky-client";
+import { err, ok } from "@lib/result";
+import { routePath, ServerRoutes } from "@lib/server-routes";
+
+import type { CouponRuleError } from "./coupon-error";
+
+import { asNetworkError, parseCouponRuleError } from "./coupon-error";
+
+export type { CouponRuleError } from "./coupon-error";
+
+async function decodeCouponRuleResponse<TValue>(
+  response: Response,
+  schema: z.ZodType<TValue>,
+): Promise<Result<TValue, CouponRuleError>> {
+  try {
+    const data = await readJson(response);
+    const parsed = decodeWithSchema(schema, data);
+    return parsed.ok ? ok(parsed.value) : err({ _tag: "DecodeError" });
+  }
+  catch {
+    return err({ _tag: "DecodeError" });
+  }
+}
+
+export const couponRuleService = {
+  listActive: async (): Promise<Result<ActiveCouponRulesResponse, CouponRuleError>> => {
+    try {
+      const response = await kyClient.get(
+        routePath(ServerRoutes.couponRules.listActiveCouponRules),
+        { throwHttpErrors: false },
+      );
+
+      if (response.status === StatusCodes.OK) {
+        const okSchema = ServerRoutes.couponRules.listActiveCouponRules.responses[200].content["application/json"].schema;
+        return decodeCouponRuleResponse(response, okSchema as z.ZodType<ActiveCouponRulesResponse>);
+      }
+
+      return err(await parseCouponRuleError(response));
+    }
+    catch (error) {
+      return asNetworkError(error);
+    }
+  },
+};

--- a/apps/mobile/services/coupons/index.ts
+++ b/apps/mobile/services/coupons/index.ts
@@ -1,0 +1,2 @@
+export * from "./coupon-error";
+export * from "./coupon.service";

--- a/apps/mobile/types/navigation.ts
+++ b/apps/mobile/types/navigation.ts
@@ -59,6 +59,7 @@ export type RootStackParamList = {
   "UpdateProfile": undefined;
   "MyWallet": undefined;
   "MetroJourney": undefined;
+  "RidingOffers": undefined;
   "Ví": undefined;
   "Subscriptions": undefined;
   "Xe": undefined;
@@ -187,6 +188,10 @@ export type MyWalletNavigationProp = StackNavigationProp<
 export type MetroJourneyNavigationProp = StackNavigationProp<
   RootStackParamList,
   "MetroJourney"
+>;
+export type RidingOffersNavigationProp = StackNavigationProp<
+  RootStackParamList,
+  "RidingOffers"
 >;
 export type SubscriptionsNavigationProp = StackNavigationProp<
   RootStackParamList,

--- a/apps/mobile/ui/patterns/app-hero-header.tsx
+++ b/apps/mobile/ui/patterns/app-hero-header.tsx
@@ -1,15 +1,16 @@
 import type { ReactNode } from "react";
 
-import { IconSymbol } from "@components/IconSymbol";
-import { radii, spacingRules } from "@theme/metrics";
-import { AppText } from "@ui/primitives/app-text";
 import { LinearGradient } from "expo-linear-gradient";
 import { Pressable } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTheme, XStack, YStack } from "tamagui";
 
+import { IconSymbol } from "@components/IconSymbol";
+import { radii, spacingRules } from "@theme/metrics";
+import { AppText } from "@ui/primitives/app-text";
+
 type AppHeroHeaderSize = "default" | "compact";
-type AppHeroHeaderVariant = "gradient" | "surface";
+type AppHeroHeaderVariant = "brand" | "gradient" | "surface";
 
 type AppHeroHeaderProps = {
   title: string;
@@ -128,6 +129,21 @@ export function AppHeroHeader({
         borderBottomLeftRadius={footer ? radii.xxl : 0}
         borderBottomRightRadius={footer ? radii.xxl : 0}
         borderBottomWidth={1}
+        paddingTop={insets.top + spacingRules.hero.paddingTop}
+        paddingHorizontal={spacingRules.hero.paddingX}
+        paddingBottom={bottomPadding}
+      >
+        {headerContent}
+      </YStack>
+    );
+  }
+
+  if (variant === "brand") {
+    return (
+      <YStack
+        backgroundColor="$actionPrimary"
+        borderBottomLeftRadius={radii.xxl}
+        borderBottomRightRadius={radii.xxl}
         paddingTop={insets.top + spacingRules.hero.paddingTop}
         paddingHorizontal={spacingRules.hero.paddingX}
         paddingBottom={bottomPadding}


### PR DESCRIPTION
## Summary
- Add mobile service/query support for active coupon rules.
- Add a user-facing `Ưu đãi đạp xe` screen and Profile menu entry.
- Extend shared mobile UI primitives with a solid brand header variant and lightning icon support.

## Validation
- `pnpm --dir apps/mobile exec eslint screen/riding-offers/index.tsx ui/patterns/app-hero-header.tsx components/IconSymbol.tsx`
- `pnpm exec eslint ...` on all changed mobile files passed before commit
- `pnpm exec tsc --noEmit` in `apps/mobile` still fails on existing unrelated `screen/environment/hooks/use-environment-impact-screen.ts(252,26)` `pageParam` error.