### PR TITLE
fix(server): expire fixed-slot reservation holds

### DIFF
--- a/apps/server/src/domain/reservations/repository/reservation.queries.ts
+++ b/apps/server/src/domain/reservations/repository/reservation.queries.ts
@@ -54,14 +54,14 @@ export function pendingStatusWhere(): PrismaTypes.ReservationWhereInput {
  * - bikeId is set (concrete bike)
  * - startTime <= now < endTime
  *
- * This intentionally excludes FIXED_SLOT reservations which often have `endTime = null`.
+ * This intentionally excludes future fixed-slot reservations until their hold window starts.
  *
  * VI: "Hold" = khoảng thời gian giữ xe hiện tại:
  * - status = PENDING
  * - có bikeId (đã gán xe cụ thể)
  * - startTime <= now < endTime
  *
- * Cố ý loại FIXED_SLOT vì thường `endTime = null`.
+ * Cố ý loại FIXED_SLOT trong tương lai cho tới khi cửa sổ giữ xe thực sự bắt đầu.
  */
 export function pendingHoldWhere(now: Date): PrismaTypes.ReservationWhereInput {
   return {

--- a/apps/server/src/domain/reservations/repository/reservation.repository.types.ts
+++ b/apps/server/src/domain/reservations/repository/reservation.repository.types.ts
@@ -59,7 +59,7 @@ export type ReservationQueryRepo = {
 
   /**
    * "Hold" = PENDING reservation with a concrete bike + endTime in the future.
-   * FIXED_SLOT reservations typically have endTime=null, so they won't match.
+   * Future fixed-slot reservations do not match until their hold window actually starts.
    *
    * EN: Use this to check "is there a current hold right now?" (time-window aware).
    * VI: Dùng để kiểm tra "hiện tại có đang giữ xe không?" (có xét theo khung thời gian).

--- a/apps/server/src/domain/reservations/repository/test/read/reservation.read.repository.int.test.ts
+++ b/apps/server/src/domain/reservations/repository/test/read/reservation.read.repository.int.test.ts
@@ -39,7 +39,7 @@ describe("reservationRepository read integration", () => {
     expect(Option.isSome(result)).toBe(true);
   });
 
-  it("findPendingHoldByBikeIdNow ignores fixed-slot with endTime null", async () => {
+  it("findPendingHoldByBikeIdNow ignores fixed-slot before hold window starts", async () => {
     const now = new Date();
     const user = await kit.createUser();
     const station = await kit.createStation({ name: "Station B" });
@@ -51,7 +51,7 @@ describe("reservationRepository read integration", () => {
       stationId: station.id,
       reservationOption: "FIXED_SLOT",
       startTime: new Date(now.getTime() + 30 * 60 * 1000),
-      endTime: null,
+      endTime: new Date(now.getTime() + 60 * 60 * 1000),
       prepaid: "0",
       status: "PENDING",
     });

--- a/apps/server/src/domain/reservations/services/commands/confirm-reservation/confirm-reservation.validation.ts
+++ b/apps/server/src/domain/reservations/services/commands/confirm-reservation/confirm-reservation.validation.ts
@@ -71,6 +71,14 @@ export function validatePendingReservationForConfirmationInTx(
       }));
     }
 
+    if (reservation.startTime > input.now) {
+      return yield* Effect.fail(new InvalidReservationTransition({
+        reservationId: reservation.id,
+        from: reservation.status,
+        to: "FULFILLED",
+      }));
+    }
+
     if (reservation.endTime && reservation.endTime <= input.now) {
       return yield* Effect.fail(new InvalidReservationTransition({
         reservationId: reservation.id,

--- a/apps/server/src/domain/reservations/services/commands/reserve-bike/reserve-bike.persistence.ts
+++ b/apps/server/src/domain/reservations/services/commands/reserve-bike/reserve-bike.persistence.ts
@@ -5,7 +5,6 @@ import type { SubscriptionCommandService } from "@/domain/subscriptions/services
 import type { DecreaseBalanceInput } from "@/domain/wallets/models";
 import type { Prisma as PrismaTypes } from "generated/prisma/client";
 
-import { env } from "@/config/env";
 import { makeBikeRepository } from "@/domain/bikes";
 import { makeStationQueryRepository } from "@/domain/stations";
 import { makeUserQueryRepository } from "@/domain/users";
@@ -20,6 +19,7 @@ import type { PreparedReserveBike, ReserveBikeCommandInput, ReserveBikeFailure }
 import { BikeAlreadyReserved } from "../../../domain-errors";
 import { makeReservationCommandRepository } from "../../../repository/reservation-command.repository";
 import { mapReservationUniqueViolation } from "../../../repository/unique-violation";
+import { scheduleReservationLifecycleJobsInTx } from "../../reservation-lifecycle-jobs";
 
 const RESERVATION_TIME_ZONE = "Asia/Ho_Chi_Minh";
 
@@ -110,50 +110,6 @@ export function persistReserveBikeInTx(args: {
     });
 
     return reservation;
-  });
-}
-
-/**
- * Enqueue các job nhắc hết hạn và auto-expire cho reservation hold.
- *
- * @param tx Transaction client đang dùng.
- * @param reservation Reservation vừa được tạo.
- * @param now Mốc hiện tại để clamp lịch chạy job.
- */
-function scheduleReservationLifecycleJobsInTx(
-  tx: PrismaTypes.TransactionClient,
-  reservation: ReservationRow,
-  now: Date,
-): Effect.Effect<void> {
-  return Effect.gen(function* () {
-    if (!reservation.endTime) {
-      return;
-    }
-
-    const notifyAtMs = reservation.endTime.getTime()
-      - env.EXPIRY_NOTIFY_MINUTES * 60 * 1000;
-    const notifyAt = new Date(Math.max(now.getTime(), notifyAtMs));
-    const expireAt = new Date(Math.max(now.getTime(), reservation.endTime.getTime()));
-
-    yield* enqueueOutboxJobInTx(tx, {
-      type: JobTypes.ReservationNotifyNearExpiry,
-      payload: {
-        version: 1,
-        reservationId: reservation.id,
-      },
-      runAt: notifyAt,
-      dedupeKey: `reservation:notify:${reservation.id}`,
-    });
-
-    yield* enqueueOutboxJobInTx(tx, {
-      type: JobTypes.ReservationExpireHold,
-      payload: {
-        version: 1,
-        reservationId: reservation.id,
-      },
-      runAt: expireAt,
-      dedupeKey: `reservation:expire:${reservation.id}`,
-    });
   });
 }
 

--- a/apps/server/src/domain/reservations/services/fixed-slot/fixed-slot.assignment.ts
+++ b/apps/server/src/domain/reservations/services/fixed-slot/fixed-slot.assignment.ts
@@ -6,6 +6,7 @@ import type {
 } from "@/domain/wallets/domain-errors";
 import type { PrismaClient, Prisma as PrismaTypes } from "generated/prisma/client";
 
+import { env } from "@/config/env";
 import { makeBikeRepository } from "@/domain/bikes";
 import { makePricingPolicyRepository } from "@/domain/pricing";
 import { isWallClockWithinOvernightOperationsWindow } from "@/domain/shared";
@@ -38,7 +39,10 @@ import {
   lockStationForReservationCheck,
   stationCanAcceptReservation,
 } from "../reservation-availability-rule";
+import { scheduleReservationLifecycleJobsInTx } from "../reservation-lifecycle-jobs";
 import { buildFixedSlotLabels } from "./fixed-slot.helpers";
+
+const FIXED_SLOT_HOLD_MINUTES = env.RESERVATION_HOLD_MINUTES;
 
 class FixedSlotAssignmentConflict extends Error {
   constructor() {
@@ -279,6 +283,9 @@ async function runFixedSlotAssignmentTransaction(
       }
 
       const billing = billingResult.right;
+      const reservationEndTime = new Date(
+        labels.slotStartAt.getTime() + FIXED_SLOT_HOLD_MINUTES * 60 * 1000,
+      );
 
       const bikeReserved = yield* bikeRepo.reserveBikeIfAvailable(bike.id, context.now);
       if (!bikeReserved) {
@@ -294,7 +301,7 @@ async function runFixedSlotAssignmentTransaction(
         fixedSlotTemplateId: template.id,
         subscriptionId: billing.subscriptionId,
         startTime: labels.slotStartAt,
-        endTime: null,
+        endTime: reservationEndTime,
         prepaid: billing.prepaid,
         status: "PENDING",
       }).pipe(
@@ -302,6 +309,7 @@ async function runFixedSlotAssignmentTransaction(
           Effect.fail(new FixedSlotAssignmentConflict())),
       );
 
+      yield* scheduleReservationLifecycleJobsInTx(tx, reservation, context.now);
       yield* enqueueAssignedEmail(tx, reservation.id, template, labels, context);
 
       return "ASSIGNED" as const;

--- a/apps/server/src/domain/reservations/services/reservation-lifecycle-jobs.ts
+++ b/apps/server/src/domain/reservations/services/reservation-lifecycle-jobs.ts
@@ -1,0 +1,53 @@
+import { JobTypes } from "@mebike/shared/contracts/server/jobs";
+import { Effect } from "effect";
+
+import type { Prisma as PrismaTypes } from "generated/prisma/client";
+
+import { env } from "@/config/env";
+import { enqueueOutboxJobInTx } from "@/infrastructure/jobs/outbox-enqueue";
+
+import type { ReservationRow } from "../models";
+
+/**
+ * Enqueue jobs nhac sap het han va auto-expire cho reservation hold.
+ *
+ * @param tx Transaction client dang dung.
+ * @param reservation Reservation vua duoc tao hoac da co hold window cu the.
+ * @param now Moc hien tai de clamp lich chay job.
+ */
+export function scheduleReservationLifecycleJobsInTx(
+  tx: PrismaTypes.TransactionClient,
+  reservation: ReservationRow,
+  now: Date,
+): Effect.Effect<void> {
+  return Effect.gen(function* () {
+    if (!reservation.endTime) {
+      return;
+    }
+
+    const notifyAtMs = reservation.endTime.getTime()
+      - env.EXPIRY_NOTIFY_MINUTES * 60 * 1000;
+    const notifyAt = new Date(Math.max(now.getTime(), notifyAtMs));
+    const expireAt = new Date(Math.max(now.getTime(), reservation.endTime.getTime()));
+
+    yield* enqueueOutboxJobInTx(tx, {
+      type: JobTypes.ReservationNotifyNearExpiry,
+      payload: {
+        version: 1,
+        reservationId: reservation.id,
+      },
+      runAt: notifyAt,
+      dedupeKey: `reservation:notify:${reservation.id}`,
+    });
+
+    yield* enqueueOutboxJobInTx(tx, {
+      type: JobTypes.ReservationExpireHold,
+      payload: {
+        version: 1,
+        reservationId: reservation.id,
+      },
+      runAt: expireAt,
+      dedupeKey: `reservation:expire:${reservation.id}`,
+    });
+  });
+}

--- a/apps/server/src/domain/reservations/services/test/fixed-slot.service.int.test.ts
+++ b/apps/server/src/domain/reservations/services/test/fixed-slot.service.int.test.ts
@@ -2,6 +2,7 @@ import { Layer } from "effect";
 import { uuidv7 } from "uuidv7";
 import { beforeAll, describe, expect, it } from "vitest";
 
+import { env } from "@/config/env";
 import { BikeRepository } from "@/domain/bikes";
 import { Prisma } from "@/infrastructure/prisma";
 import { runEffectWithLayer } from "@/test/effect/run";
@@ -23,6 +24,10 @@ describe("assignFixedSlotReservations integration", () => {
   it("creates and assigns a daily fixed-slot reservation", async () => {
     const slotDate = new Date(Date.UTC(2026, 3, 14));
     const slotStart = new Date(Date.UTC(2000, 0, 1, 9, 0, 0));
+    const expectedStartTime = new Date(Date.UTC(2026, 3, 14, 2, 0, 0));
+    const expectedEndTime = new Date(
+      expectedStartTime.getTime() + env.RESERVATION_HOLD_MINUTES * 60 * 1000,
+    );
     const user = await fixture.factories.user({ fullname: "Fixed Slot User" });
     await fixture.factories.wallet({ userId: user.id, balance: 10000n });
     const station = await fixture.factories.station({ name: "Fixed Slot Station", capacity: 2 });
@@ -61,7 +66,7 @@ describe("assignFixedSlotReservations integration", () => {
       where: {
         fixedSlotTemplateId: template.id,
         reservationOption: "FIXED_SLOT",
-        startTime: new Date(Date.UTC(2026, 3, 14, 2, 0, 0)),
+        startTime: expectedStartTime,
       },
     });
 
@@ -69,7 +74,7 @@ describe("assignFixedSlotReservations integration", () => {
     expect(reservation?.userId).toBe(user.id);
     expect(reservation?.bikeId).toBe(bike.id);
     expect(reservation?.stationId).toBe(station.id);
-    expect(reservation?.endTime).toBeNull();
+    expect(reservation?.endTime?.toISOString()).toBe(expectedEndTime.toISOString());
     expect(reservation?.pricingPolicyId).toBe("0195c768-3456-7f01-8234-111111111111");
     expect(reservation?.subscriptionId).toBeNull();
     expect(reservation?.prepaid.toString()).toBe("2000");
@@ -81,9 +86,17 @@ describe("assignFixedSlotReservations integration", () => {
     expect(updatedBike?.status).toBe("RESERVED");
 
     const outbox = await fixture.prisma.jobOutbox.findMany({
-      where: { dedupeKey: `fixed-slot:assigned:${reservation!.id}` },
+      where: {
+        dedupeKey: {
+          in: [
+            `fixed-slot:assigned:${reservation!.id}`,
+            `reservation:notify:${reservation!.id}`,
+            `reservation:expire:${reservation!.id}`,
+          ],
+        },
+      },
     });
-    expect(outbox).toHaveLength(1);
+    expect(outbox).toHaveLength(3);
   });
 
   it("stores fixed-slot start time as the UTC instant for Vietnam local time", async () => {

--- a/apps/server/src/domain/reservations/services/test/fixed-slot.service.test.ts
+++ b/apps/server/src/domain/reservations/services/test/fixed-slot.service.test.ts
@@ -1,6 +1,7 @@
 import { Effect, Layer, Option } from "effect";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { env } from "@/config/env";
 import { BikeRepository } from "@/domain/bikes";
 import { toPrismaDecimal } from "@/domain/shared/decimal";
 import { Prisma } from "@/infrastructure/prisma";
@@ -75,7 +76,7 @@ describe("assignFixedSlotReservations", () => {
   it("creates and assigns daily fixed-slot reservation when bike is available", async () => {
     const slotDate = new Date(Date.UTC(2026, 3, 14));
     const slotStart = new Date(Date.UTC(2000, 0, 1, 9, 0, 0));
-    const createdReservation = { id: "reservation-1", bikeId: null };
+    const createdReservation = { id: "reservation-1" };
     const bike = { id: "bike-1" };
     const template = {
       id: "template-1",
@@ -108,9 +109,22 @@ describe("assignFixedSlotReservations", () => {
     });
 
     mocks.makeReservationCommandRepository.mockImplementation((tx: { state: DraftState }) => ({
-      createReservation: ({ bikeId }: { bikeId?: string | null }) => Effect.sync(() => {
+      createReservation: ({
+        bikeId,
+        startTime,
+        endTime,
+      }: {
+        bikeId?: string | null;
+        startTime: Date;
+        endTime: Date | null;
+      }) => Effect.sync(() => {
         tx.state.reservationId = createdReservation.id;
-        return { ...createdReservation, bikeId: bikeId ?? null };
+        return {
+          id: createdReservation.id,
+          bikeId: bikeId ?? null,
+          startTime,
+          endTime,
+        };
       }),
       assignBikeToPendingReservation: vi.fn(),
     }));
@@ -159,7 +173,19 @@ describe("assignFixedSlotReservations", () => {
     });
     expect(state.reservationId).toBe(createdReservation.id);
     expect(state.bikeStatus).toBe("RESERVED");
-    expect(mocks.enqueueOutboxJobInTx).toHaveBeenCalledTimes(1);
+    expect(mocks.enqueueOutboxJobInTx).toHaveBeenCalledTimes(3);
+    expect(mocks.enqueueOutboxJobInTx).toHaveBeenNthCalledWith(1, expect.anything(), expect.objectContaining({
+      dedupeKey: "reservation:notify:reservation-1",
+    }));
+    expect(mocks.enqueueOutboxJobInTx).toHaveBeenNthCalledWith(2, expect.anything(), expect.objectContaining({
+      dedupeKey: "reservation:expire:reservation-1",
+    }));
+    expect(mocks.enqueueOutboxJobInTx).toHaveBeenNthCalledWith(3, expect.anything(), expect.objectContaining({
+      dedupeKey: "fixed-slot:assigned:reservation-1",
+    }));
+    expect(mocks.enqueueOutboxJobInTx).toHaveBeenNthCalledWith(2, expect.anything(), expect.objectContaining({
+      runAt: new Date(Date.UTC(2026, 3, 14, 2, env.RESERVATION_HOLD_MINUTES, 0)),
+    }));
   });
 
   it("skips templates whose slot start is overnight", async () => {

--- a/apps/server/src/domain/reservations/services/test/reservation.use-cases.unhappy.int.test.ts
+++ b/apps/server/src/domain/reservations/services/test/reservation.use-cases.unhappy.int.test.ts
@@ -275,6 +275,7 @@ describe("reservation use-cases unhappy paths", () => {
       bikeId: null,
       stationId: station.id,
       status: "PENDING",
+      startTime: new Date(Date.now() - 60_000),
       endTime: new Date(Date.now() + env.RESERVATION_HOLD_MINUTES * 60 * 1000),
     });
 
@@ -314,6 +315,25 @@ describe("reservation use-cases unhappy paths", () => {
     expectLeftTag(result, "InvalidReservationTransition");
   });
 
+  it("confirmReservationUseCase fails with InvalidReservationTransition when reservation has not started yet", async () => {
+    const user = await fixture.factories.user();
+    const station = await fixture.factories.station();
+    const bike = await fixture.factories.bike({ stationId: station.id });
+    const now = new Date();
+    const reservation = await fixture.factories.reservation({
+      userId: user.id,
+      bikeId: bike.id,
+      stationId: station.id,
+      reservationOption: "FIXED_SLOT",
+      status: "PENDING",
+      startTime: new Date(now.getTime() + 30 * 60 * 1000),
+      endTime: new Date(now.getTime() + 60 * 60 * 1000),
+    });
+
+    const result = await runConfirm({ reservationId: reservation.id, userId: user.id, now });
+    expectLeftTag(result, "InvalidReservationTransition");
+  });
+
   it("confirmReservationUseCase fails with InvalidReservationTransition when reservation is already fulfilled", async () => {
     const user = await fixture.factories.user();
     const station = await fixture.factories.station();
@@ -339,6 +359,7 @@ describe("reservation use-cases unhappy paths", () => {
       bikeId: bike.id,
       stationId: station.id,
       status: "PENDING",
+      startTime: new Date(Date.now() - 60_000),
       endTime: new Date(Date.now() + env.RESERVATION_HOLD_MINUTES * 60 * 1000),
     });
 

--- a/apps/server/src/worker/test/reservation-hold-worker.int.test.ts
+++ b/apps/server/src/worker/test/reservation-hold-worker.int.test.ts
@@ -187,4 +187,66 @@ describe("reservation hold worker integration", () => {
     expect(rentalAfter).toBeNull();
     expect(bikeAfter?.status).toBe("AVAILABLE");
   });
+
+  it("expires fixed-slot hold and releases bike after claim window", async () => {
+    const user = await fixture.factories.user({
+      fullname: "Expired Fixed Slot User",
+      email: "expired-fixed-slot-user@example.com",
+    });
+    const station = await createStation(fixture, {
+      name: "Expired Fixed Slot Station",
+      address: "District 3",
+      capacity: 15,
+      latitude: 10.775658,
+      longitude: 106.700424,
+    });
+    const bike = await fixture.factories.bike({
+      stationId: station.id,
+      status: "RESERVED",
+    });
+    const reservation = await fixture.prisma.reservation.create({
+      data: {
+        id: uuidv7(),
+        userId: user.id,
+        bikeId: bike.id,
+        stationId: station.id,
+        reservationOption: "FIXED_SLOT",
+        startTime: new Date(Date.now() - 60 * 60 * 1000),
+        endTime: new Date(Date.now() - 10 * 60 * 1000),
+        status: "PENDING",
+      },
+    });
+
+    const { producer, send } = makeBossMock();
+    const handler = makeReservationExpireHoldHandler(makeRunEffect(), producer);
+    await handler(makeReservationJob(reservation.id));
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenNthCalledWith(
+      1,
+      JobTypes.EmailSend,
+      expect.objectContaining({
+        version: 1,
+        kind: "raw",
+        to: user.email,
+      }),
+      expect.objectContaining({
+        dedupeKey: `reservation:expired:${reservation.id}`,
+      }),
+    );
+
+    const [reservationAfter, bikeAfter] = await Promise.all([
+      fixture.prisma.reservation.findUnique({
+        where: { id: reservation.id },
+        select: { status: true },
+      }),
+      fixture.prisma.bike.findUnique({
+        where: { id: bike.id },
+        select: { status: true },
+      }),
+    ]);
+
+    expect(reservationAfter?.status).toBe("EXPIRED");
+    expect(bikeAfter?.status).toBe("AVAILABLE");
+  });
 });


### PR DESCRIPTION
## Summary
- give fixed-slot reservations a real hold window and reuse the standard reservation expiry/near-expiry job scheduling
- block reservation confirmation before the fixed-slot start time so future slots cannot be claimed early
- update reservation, worker, and repository tests to cover fixed-slot expiry and current-hold semantics

## Testing
- pnpm eslint src/domain/reservations/services/reservation-lifecycle-jobs.ts src/domain/reservations/services/commands/reserve-bike/reserve-bike.persistence.ts src/domain/reservations/services/fixed-slot/fixed-slot.assignment.ts src/domain/reservations/services/commands/confirm-reservation/confirm-reservation.validation.ts src/domain/reservations/repository/reservation.repository.types.ts src/domain/reservations/repository/reservation.queries.ts src/domain/reservations/services/test/fixed-slot.service.int.test.ts src/domain/reservations/services/test/fixed-slot.service.test.ts src/domain/reservations/repository/test/read/reservation.read.repository.int.test.ts src/domain/reservations/services/test/reservation.use-cases.unhappy.int.test.ts src/worker/test/reservation-hold-worker.int.test.ts
- pnpm vitest run src/domain/reservations/services/test/fixed-slot.service.test.ts
- pnpm vitest run --config vitest.int.config.ts src/domain/reservations/services/test/fixed-slot.service.int.test.ts src/domain/reservations/services/test/reservation.use-cases.unhappy.int.test.ts src/domain/reservations/repository/test/read/reservation.read.repository.int.test.ts src/worker/test/reservation-hold-worker.int.test.ts
- pnpm tsc --noEmit