### PR TITLE
fix(server): open operator station access

### DIFF
--- a/apps/server/src/http/controllers/stations/agency.controller.ts
+++ b/apps/server/src/http/controllers/stations/agency.controller.ts
@@ -36,19 +36,6 @@ function getAgencyStationScope(currentUser: {
 
 const agencyListStations: RouteHandler<StationsRoutes["agencyListStations"]> = async (c) => {
   const query = c.req.valid("query");
-  const stationScopeId = getAgencyStationScope(c.var.currentUser!);
-
-  if (stationScopeId === null) {
-    return c.json<StationListResponse, 200>({
-      data: [],
-      pagination: {
-        page: query.page ?? 1,
-        pageSize: query.pageSize ?? 50,
-        total: 0,
-        totalPages: 0,
-      },
-    }, 200);
-  }
 
   const eff = withLoggedCause(
     Effect.gen(function* () {
@@ -56,7 +43,6 @@ const agencyListStations: RouteHandler<StationsRoutes["agencyListStations"]> = a
 
       const page = yield* service.listStations(
         {
-          id: stationScopeId!,
           name: query.name,
           address: query.address,
           stationType: query.stationType,
@@ -70,13 +56,6 @@ const agencyListStations: RouteHandler<StationsRoutes["agencyListStations"]> = a
           sortDir: query.sortDir ?? "asc",
         },
       );
-
-      if (page.total > 0) {
-        return page;
-      }
-
-      yield* service.getStationById(stationScopeId!);
-
       return page;
     }),
     "GET /v1/agency/stations",
@@ -96,30 +75,18 @@ const agencyListStations: RouteHandler<StationsRoutes["agencyListStations"]> = a
         },
       }, 200)),
     Match.tag("Left", () =>
-      c.json<StationErrorResponse, 404>({
-        error: stationErrorMessages.STATION_NOT_FOUND,
+      c.json<StationErrorResponse, 400>({
+        error: stationErrorMessages.INVALID_QUERY_PARAMS,
         details: {
-          code: StationErrorCodeSchema.enum.STATION_NOT_FOUND,
-          stationId: stationScopeId!,
+          code: StationErrorCodeSchema.enum.INVALID_QUERY_PARAMS,
         },
-      }, 404)),
+      }, 400)),
     Match.exhaustive,
   );
 };
 
 const agencyGetStation: RouteHandler<StationsRoutes["agencyGetStation"]> = async (c) => {
   const { stationId } = c.req.valid("param");
-  const stationScopeId = getAgencyStationScope(c.var.currentUser!);
-
-  if (stationScopeId === null || stationId !== stationScopeId) {
-    return c.json<StationErrorResponse, 404>({
-      error: stationErrorMessages.STATION_NOT_FOUND,
-      details: {
-        code: StationErrorCodeSchema.enum.STATION_NOT_FOUND,
-        stationId,
-      },
-    }, 404);
-  }
 
   const eff = withLoggedCause(
     Effect.gen(function* () {

--- a/apps/server/src/http/routes/operators.ts
+++ b/apps/server/src/http/routes/operators.ts
@@ -3,14 +3,14 @@ import type { RouteConfig } from "@hono/zod-openapi";
 import { serverRoutes } from "@mebike/shared";
 
 import { OperatorController } from "@/http/controllers/operators.controller";
-import { requireStaffOrManagerOrAgencyMiddleware } from "@/http/middlewares/auth";
+import { requireOperatorMiddleware } from "@/http/middlewares/auth";
 
 export function registerOperatorRoutes(app: import("@hono/zod-openapi").OpenAPIHono) {
   const operators = serverRoutes.operators;
 
   const stationContextRoute = {
     ...operators.stationContext,
-    middleware: [requireStaffOrManagerOrAgencyMiddleware] as const,
+    middleware: [requireOperatorMiddleware] as const,
   } satisfies RouteConfig;
 
   app.openapi(stationContextRoute, OperatorController.getStationContext);

--- a/apps/server/src/http/test/e2e/operator-station-context-routing.e2e.int.test.ts
+++ b/apps/server/src/http/test/e2e/operator-station-context-routing.e2e.int.test.ts
@@ -40,6 +40,17 @@ describe("operator station context routing e2e", () => {
     return fixture.auth.makeAccessToken({ userId: manager.id, role: "MANAGER" });
   }
 
+  async function createTechnicianToken(stationId?: string) {
+    const technician = await fixture.factories.user({ role: "TECHNICIAN" });
+
+    if (stationId) {
+      const team = await fixture.factories.technicianTeam({ stationId });
+      await fixture.factories.userOrgAssignment({ userId: technician.id, technicianTeamId: team.id });
+    }
+
+    return fixture.auth.makeAccessToken({ userId: technician.id, role: "TECHNICIAN" });
+  }
+
   it("returns current operator station plus all other stations", async () => {
     const currentStation = await fixture.factories.station({
       name: "Current Station",
@@ -140,6 +151,30 @@ describe("operator station context routing e2e", () => {
     const agencyUser = await fixture.factories.user({ role: "AGENCY" });
     await fixture.factories.userOrgAssignment({ userId: agencyUser.id, agencyId: agency.id });
     const token = fixture.auth.makeAccessToken({ userId: agencyUser.id, role: "AGENCY" });
+
+    const response = await fixture.app.request("http://test/v1/operators/station-context", {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    const body = await response.json() as OperatorsContracts.OperatorStationContextResponse;
+
+    expect(response.status).toBe(200);
+    expect(body.currentStation.id).toBe(currentStation.id);
+    expect(body.otherStations.some(station => station.id === otherStation.id)).toBe(true);
+  });
+
+  it("allows technicians to read station context for their assigned station", async () => {
+    const currentStation = await fixture.factories.station({
+      name: "Technician Station",
+      address: "13 Technician Street, Thu Duc, TP.HCM",
+    });
+    const otherStation = await fixture.factories.station({
+      name: "Technician Other Station",
+      address: "14 Technician Street, Thu Duc, TP.HCM",
+    });
+    const token = await createTechnicianToken(currentStation.id);
 
     const response = await fixture.app.request("http://test/v1/operators/station-context", {
       headers: {

--- a/apps/server/src/http/test/e2e/operator-stations-routing.e2e.int.test.ts
+++ b/apps/server/src/http/test/e2e/operator-stations-routing.e2e.int.test.ts
@@ -83,7 +83,7 @@ describe("operator stations routing e2e", () => {
     expect(body.id).toBe(hiddenStation.id);
   });
 
-  it("lists only the assigned station for agency", async () => {
+  it("lists all stations for agency", async () => {
     const { agency, token } = await createAgencyToken();
     const currentStation = await fixture.factories.station({
       capacity: 5,
@@ -91,7 +91,7 @@ describe("operator stations routing e2e", () => {
       stationType: "AGENCY",
       agencyId: agency.id,
     });
-    await fixture.factories.station({ capacity: 5, name: "Hidden Station" });
+    const hiddenStation = await fixture.factories.station({ capacity: 5, name: "Hidden Station" });
 
     const response = await fixture.app.request("http://test/v1/agency/stations?page=1&pageSize=20", {
       headers: {
@@ -102,11 +102,13 @@ describe("operator stations routing e2e", () => {
     const body = await response.json() as StationsContracts.StationListResponse;
 
     expect(response.status).toBe(200);
-    expect(body.data).toHaveLength(1);
-    expect(body.data[0]?.id).toBe(currentStation.id);
+    expect(body.data.length).toBeGreaterThanOrEqual(2);
+    expect(body.data.map(station => station.id)).toEqual(
+      expect.arrayContaining([currentStation.id, hiddenStation.id]),
+    );
   });
 
-  it("returns 404 when agency requests a different station detail", async () => {
+  it("allows agency to request a different station detail", async () => {
     const { agency, token } = await createAgencyToken();
     await fixture.factories.station({
       capacity: 5,
@@ -121,6 +123,9 @@ describe("operator stations routing e2e", () => {
       },
     });
 
-    expect(response.status).toBe(404);
+    const body = await response.json() as StationsContracts.StationReadSummary;
+
+    expect(response.status).toBe(200);
+    expect(body.id).toBe(hiddenStation.id);
   });
 });

--- a/packages/shared/src/contracts/server/routes/stations/queries.ts
+++ b/packages/shared/src/contracts/server/routes/stations/queries.ts
@@ -250,7 +250,7 @@ export const agencyListStations = createRoute({
   },
   responses: {
     200: {
-      description: "List current agency station only",
+      description: "List stations for agency",
       content: {
         "application/json": { schema: StationListResponseSchema },
       },
@@ -259,14 +259,6 @@ export const agencyListStations = createRoute({
       description: "Invalid query",
       content: {
         "application/json": { schema: StationErrorResponseSchema },
-      },
-    },
-    404: {
-      description: "Assigned station not found",
-      content: {
-        "application/json": {
-          schema: StationErrorResponseSchema,
-        },
       },
     },
     401: unauthorizedResponse(),
@@ -337,7 +329,7 @@ export const agencyGetStation = createRoute({
   },
   responses: {
     200: {
-      description: "Get station details for current agency station",
+      description: "Get station details for agency",
       content: {
         "application/json": { schema: StationReadSummarySchemaOpenApi },
       },


### PR DESCRIPTION
## Summary
- allow technicians to access the operator station-context endpoint through the shared operator auth guard
- align agency station list and detail endpoints with staff behavior so agency users can browse and read any station
- update station route contracts and e2e coverage for technician station context and agency station access

## Testing
- pnpm eslint src/http/routes/operators.ts src/http/controllers/stations/agency.controller.ts src/http/test/e2e/operator-station-context-routing.e2e.int.test.ts src/http/test/e2e/operator-stations-routing.e2e.int.test.ts
- pnpm vitest run --config vitest.int.config.ts src/http/test/e2e/operator-stations-routing.e2e.int.test.ts src/http/test/e2e/operator-station-context-routing.e2e.int.test.ts
- pnpm tsc --noEmit