### PR TITLE
chore(seed): tighten demo rental dates and station stock

### DIFF
--- a/apps/server/prisma/seed-demo.ts
+++ b/apps/server/prisma/seed-demo.ts
@@ -42,6 +42,9 @@ const DEMO_PASSWORD = "Demo@123456";
 const USERS_TARGET = 32;
 const RENTALS_TARGET = 120;
 const DEMO_NON_CUSTOMER_USERS = 7;
+const DEMO_BIKES_PER_STATION = 5;
+const DEMO_RENTAL_MIN_HOUR = 6;
+const DEMO_RENTAL_MAX_HOUR = 22;
 
 const DEMO_AGENCY_MAIN_ID = "019b17bd-d130-7e7d-be69-91ceef7b9003";
 const DEMO_AGENCY_EAST_ID = "019b17bd-d130-7e7d-be69-91ceef7b9004";
@@ -132,6 +135,25 @@ function toUtcDate(dayOffset: number, hour: number, minute: number) {
 
 function toUtcDateInMonth(year: number, month: number, day: number, hour: number, minute: number) {
   return new Date(Date.UTC(year, month, day, hour, minute, 0, 0));
+}
+
+function toDemoRentalHour(hour: number) {
+  return Math.max(DEMO_RENTAL_MIN_HOUR, Math.min(DEMO_RENTAL_MAX_HOUR, hour));
+}
+
+function toPastDemoRentalUtcDate(dayOffset: number, hour: number, minute: number) {
+  const safeHour = toDemoRentalHour(hour);
+  const candidate = toUtcDate(dayOffset, safeHour, minute);
+
+  if (candidate.getTime() < Date.now()) {
+    return candidate;
+  }
+
+  return toUtcDate(dayOffset - 1, safeHour, minute);
+}
+
+function toDemoRentalUtcDateInMonth(year: number, month: number, day: number, hour: number, minute: number) {
+  return toUtcDateInMonth(year, month, day, toDemoRentalHour(hour), minute);
 }
 
 function pick<T>(arr: readonly T[], idx: number): T {
@@ -333,8 +355,14 @@ function buildRentals(params: {
   const currentMonth = now.getUTCMonth();
   const prevMonth = currentMonth === 0 ? 11 : currentMonth - 1;
   const prevMonthYear = currentMonth === 0 ? currentYear - 1 : currentYear;
-  const daysInCurrentMonth = new Date(Date.UTC(currentYear, currentMonth + 1, 0)).getUTCDate();
   const daysInPrevMonth = new Date(Date.UTC(prevMonthYear, prevMonth + 1, 0)).getUTCDate();
+  const lastCompletedDayInCurrentMonth = now.getUTCDate() - 1;
+  const completedCurrentMonthYear = lastCompletedDayInCurrentMonth >= 1 ? currentYear : prevMonthYear;
+  const completedCurrentMonthMonth = lastCompletedDayInCurrentMonth >= 1 ? currentMonth : prevMonth;
+  const completedCurrentMonthDays = lastCompletedDayInCurrentMonth >= 1
+    ? lastCompletedDayInCurrentMonth
+    : daysInPrevMonth;
+  const activeRentalDayOffset = now.getUTCHours() >= 14 ? 0 : -1;
 
   const pushCompleted = (count: number, dateFactory: (idx: number) => Date, startIdx = 0) => {
     for (let i = 0; i < count; i++) {
@@ -366,13 +394,19 @@ function buildRentals(params: {
     }
   };
 
-  pushCompleted(12, idx => toUtcDate(0, 8 + (idx % 12), (idx * 7) % 60), 0);
-  pushCompleted(9, idx => toUtcDate(-1, 9 + (idx % 9), (idx * 9) % 60), 100);
+  pushCompleted(12, idx => toPastDemoRentalUtcDate(-1, 8 + (idx % 12), (idx * 7) % 60), 0);
+  pushCompleted(9, idx => toPastDemoRentalUtcDate(-2, 9 + (idx % 9), (idx * 9) % 60), 100);
   pushCompleted(
     36,
     (idx) => {
-      const day = ((idx % Math.max(1, daysInCurrentMonth - 2)) + 1);
-      return toUtcDateInMonth(currentYear, currentMonth, day, 6 + (idx % 14), (idx * 11) % 60);
+      const day = (idx % completedCurrentMonthDays) + 1;
+      return toDemoRentalUtcDateInMonth(
+        completedCurrentMonthYear,
+        completedCurrentMonthMonth,
+        day,
+        6 + (idx % 14),
+        (idx * 11) % 60,
+      );
     },
     200,
   );
@@ -380,7 +414,7 @@ function buildRentals(params: {
     27,
     (idx) => {
       const day = ((idx % daysInPrevMonth) + 1);
-      return toUtcDateInMonth(prevMonthYear, prevMonth, day, 7 + (idx % 12), (idx * 13) % 60);
+      return toDemoRentalUtcDateInMonth(prevMonthYear, prevMonth, day, 7 + (idx % 12), (idx * 13) % 60);
     },
     300,
   );
@@ -388,7 +422,7 @@ function buildRentals(params: {
   const rentedUsers = normalUsers.slice(0, 8);
   const rentedBikes = bikes.slice(0, 8);
   for (let i = 0; i < 8; i++) {
-    const start = toUtcDate(0, 6 + i, (i * 8) % 60);
+    const start = toPastDemoRentalUtcDate(activeRentalDayOffset, 6 + i, (i * 8) % 60);
     rentals.push({
       id: uuidv7(),
       userId: rentedUsers[i]!.id,
@@ -832,7 +866,7 @@ async function main() {
         })),
     });
 
-    const bikesToCreate = Array.from({ length: 40 }, (_, idx) => ({
+    const bikesToCreate = Array.from({ length: stationIds.length * DEMO_BIKES_PER_STATION }, (_, idx) => ({
       id: uuidv7(),
       bikeNumber: `DEMO-${String(idx + 1).padStart(3, "0")}`,
       stationId: pick(stationIds, idx),

--- a/apps/server/src/domain/stations/models.ts
+++ b/apps/server/src/domain/stations/models.ts
@@ -15,6 +15,7 @@ export type StationContextRow = {
   id: string;
   name: string;
   address: string;
+  stationType: StationType;
   operationalAvailableSlots: number;
 };
 

--- a/apps/server/src/domain/stations/repository/read/station.read.repository.ts
+++ b/apps/server/src/domain/stations/repository/read/station.read.repository.ts
@@ -308,6 +308,7 @@ export function makeStationReadRepository(
             id: row.id,
             name: row.name,
             address: row.address,
+            stationType: row.stationType,
             operationalAvailableSlots: applyCounts(row, counts).availableReturnSlots,
           })),
         ),

--- a/apps/server/src/http/controllers/operators.controller.ts
+++ b/apps/server/src/http/controllers/operators.controller.ts
@@ -55,12 +55,14 @@ const getStationContext: RouteHandler<OperatorsRoutes["stationContext"]> = async
           id: currentStation.id,
           name: currentStation.name,
           address: currentStation.address,
+          stationType: currentStation.stationType,
           operationalAvailableSlots: currentStation.availableReturnSlots,
         },
         otherStations: otherStations.map(station => ({
           id: station.id,
           name: station.name,
           address: station.address,
+          stationType: station.stationType,
           operationalAvailableSlots: station.operationalAvailableSlots,
         })),
       } satisfies OperatorsContracts.OperatorStationContextResponse;

--- a/apps/server/src/http/test/e2e/operator-station-context-routing.e2e.int.test.ts
+++ b/apps/server/src/http/test/e2e/operator-station-context-routing.e2e.int.test.ts
@@ -129,6 +129,7 @@ describe("operator station context routing e2e", () => {
       id: currentStation.id,
       name: "Current Station",
       address: "1 Current Street, Thu Duc, TP.HCM",
+      stationType: "INTERNAL",
       operationalAvailableSlots: expect.any(Number),
     });
     expect(body.otherStations).toEqual(expect.arrayContaining([
@@ -136,12 +137,14 @@ describe("operator station context routing e2e", () => {
         id: otherStationA.id,
         name: "Alpha Station",
         address: "2 Alpha Street, Thu Duc, TP.HCM",
+        stationType: "INTERNAL",
         operationalAvailableSlots: expect.any(Number),
       },
       {
         id: otherStationB.id,
         name: "Beta Station",
         address: "3 Beta Street, Thu Duc, TP.HCM",
+        stationType: "INTERNAL",
         operationalAvailableSlots: expect.any(Number),
       },
     ]));
@@ -182,6 +185,7 @@ describe("operator station context routing e2e", () => {
       id: targetStation.id,
       name: "Redistribution Target",
       address: "17 Target Street, Thu Duc, TP.HCM",
+      stationType: "INTERNAL",
       operationalAvailableSlots: 1,
     });
   });
@@ -219,6 +223,7 @@ describe("operator station context routing e2e", () => {
 
     expect(response.status).toBe(200);
     expect(body.currentStation.id).toBe(currentStation.id);
+    expect(body.currentStation.stationType).toBe("INTERNAL");
     expect(body.otherStations.some(station => station.id === otherStation.id)).toBe(true);
   });
 
@@ -253,6 +258,8 @@ describe("operator station context routing e2e", () => {
 
     expect(response.status).toBe(200);
     expect(body.currentStation.id).toBe(currentStation.id);
+    expect(body.currentStation.stationType).toBe("AGENCY");
+    expect(body.otherStations.find(station => station.id === otherStation.id)?.stationType).toBe("INTERNAL");
     expect(body.otherStations.some(station => station.id === otherStation.id)).toBe(true);
   });
 
@@ -277,6 +284,7 @@ describe("operator station context routing e2e", () => {
 
     expect(response.status).toBe(200);
     expect(body.currentStation.id).toBe(currentStation.id);
+    expect(body.currentStation.stationType).toBe("INTERNAL");
     expect(body.otherStations.some(station => station.id === otherStation.id)).toBe(true);
   });
 

--- a/packages/shared/src/contracts/server/operators/models.ts
+++ b/packages/shared/src/contracts/server/operators/models.ts
@@ -1,9 +1,12 @@
 import { z } from "../../../zod";
 
+import { StationTypeSchema } from "../stations";
+
 export const OperatorStationContextStationSchema = z.object({
   id: z.uuidv7(),
   name: z.string(),
   address: z.string(),
+  stationType: StationTypeSchema,
   operationalAvailableSlots: z.number(),
 }).openapi("OperatorStationContextStation");
 


### PR DESCRIPTION
## Summary
- keep seeded rental times in the past only and clamp generated rental hours to 06:00-22:00
- avoid same-day future demo rentals by shifting active rental start times back when needed
- increase base seed bike distribution to 5 bikes per station while preserving room for booster flow seeding