### PR TITLE
feat(iot): surface NFC swipe failures over realtime

### DIFF
--- a/apps/mobile/app.tsx
+++ b/apps/mobile/app.tsx
@@ -1,19 +1,20 @@
-import { AuthProviderNext } from "@providers/auth-provider-next";
-import { BikeStatusStreamProvider } from "@providers/bike-status-stream-provider";
-import Providers from "@providers/providers";
 import { NavigationContainer } from "@react-navigation/native";
 import { initStripe } from "@stripe/stripe-react-native";
-import { appFontSources } from "@theme/typography";
 import * as Font from "expo-font";
 import * as SplashScreen from "expo-splash-screen";
 import { StatusBar } from "expo-status-bar";
 import React, { useEffect, useState } from "react";
 import { TamaguiProvider } from "tamagui";
 
+import { AuthProviderNext } from "@providers/auth-provider-next";
+import Providers from "@providers/providers";
+import { RealtimeEventProvider } from "@providers/realtime-event-provider";
+import { appFontSources } from "@theme/typography";
+
 import { runSharedContractsSmokeTest } from "./debug/shared-contract-smoke";
 import { log } from "./lib/log";
-import { navigationRef } from "./navigation/navigation-ref";
 import { STRIPE_PUBLISHABLE_KEY, STRIPE_URL_SCHEME } from "./lib/stripe";
+import { navigationRef } from "./navigation/navigation-ref";
 import RootNavigator from "./navigation/root-navigator";
 import tamaguiConfig from "./tamagui.config";
 
@@ -79,10 +80,10 @@ export default function App() {
       <Providers>
         <NavigationContainer ref={navigationRef}>
           <AuthProviderNext>
-            <BikeStatusStreamProvider>
+            <RealtimeEventProvider>
               <StatusBar style="dark" />
               <RootNavigator />
-            </BikeStatusStreamProvider>
+            </RealtimeEventProvider>
           </AuthProviderNext>
         </NavigationContainer>
       </Providers>

--- a/apps/mobile/hooks/use-bike-status-events.ts
+++ b/apps/mobile/hooks/use-bike-status-events.ts
@@ -1,7 +1,8 @@
-import { useBikeStatusStreamContext } from "@providers/bike-status-stream-provider";
 import { useEffect } from "react";
 
-import type { BikeStatusUpdate } from "@/hooks/use-bike-status-stream";
+import type { BikeStatusUpdate } from "@/types/realtime-events";
+
+import { useRealtimeEventContext } from "@providers/realtime-event-provider";
 
 type Options = {
   enabled?: boolean;
@@ -9,14 +10,14 @@ type Options = {
 
 export function useBikeStatusEvents(onUpdate: (payload: BikeStatusUpdate) => void, options?: Options) {
   const { enabled = true } = options ?? {};
-  const { subscribe, lastUpdate } = useBikeStatusStreamContext();
+  const { subscribeBikeStatus, lastBikeStatusUpdate } = useRealtimeEventContext();
 
   useEffect(() => {
     if (!enabled)
       return;
-    const unsubscribe = subscribe(onUpdate);
+    const unsubscribe = subscribeBikeStatus(onUpdate);
     return () => unsubscribe();
-  }, [enabled, onUpdate, subscribe]);
+  }, [enabled, onUpdate, subscribeBikeStatus]);
 
-  return { lastUpdate };
+  return { lastUpdate: lastBikeStatusUpdate };
 }

--- a/apps/mobile/hooks/use-realtime-event-stream.ts
+++ b/apps/mobile/hooks/use-realtime-event-stream.ts
@@ -4,47 +4,40 @@ import { StatusCodes } from "http-status-codes";
 import { useCallback, useEffect, useRef, useState } from "react";
 import EventSource from "react-native-sse";
 
+import type {
+  BikeStatusUpdate,
+  NfcCardSwipeFailedUpdate,
+  ReturnSlotExpiredUpdate,
+} from "@/types/realtime-events";
+
 import { API_BASE_URL } from "@lib/api-base-url";
 import { clearTokens, getAccessToken } from "@lib/auth-tokens";
 import { refreshAccessToken } from "@lib/ky-client";
 import { log } from "@lib/log";
 
-export type BikeStatusUpdate = {
-  userId?: string;
-  bikeId: string;
-  status: string;
-};
+type CustomEventName = "bikeStatusUpdate" | "returnSlotExpired" | "nfcCardSwipeFailed";
 
-export type ReturnSlotExpiredUpdate = {
-  userId: string;
-  rentalId: string;
-  returnSlotId: string;
-  stationId: string;
-  reservedFrom: string;
-  expiredAt: string;
-  at: string;
-};
-
-type CustomEventName = "bikeStatusUpdate" | "returnSlotExpired";
-
-export type UseBikeStatusStreamOptions = {
+export type UseRealtimeEventStreamOptions = {
   autoConnect?: boolean;
   onUpdate?: (payload: BikeStatusUpdate) => void;
   onReturnSlotExpired?: (payload: ReturnSlotExpiredUpdate) => void;
+  onNfcCardSwipeFailed?: (payload: NfcCardSwipeFailedUpdate) => void;
   onError?: (error: Error) => void;
 };
 
 const SSE_UNAUTHORIZED_ERROR = "SSE_UNAUTHORIZED";
 
-export function useBikeStatusStream(options?: UseBikeStatusStreamOptions) {
-  const { autoConnect = true, onUpdate, onReturnSlotExpired, onError } = options ?? {};
-  const [lastUpdate, setLastUpdate] = useState<BikeStatusUpdate | null>(null);
+export function useRealtimeEventStream(options?: UseRealtimeEventStreamOptions) {
+  const { autoConnect = true, onUpdate, onReturnSlotExpired, onNfcCardSwipeFailed, onError } = options ?? {};
+  const [lastBikeStatusUpdate, setLastBikeStatusUpdate] = useState<BikeStatusUpdate | null>(null);
   const [lastReturnSlotExpired, setLastReturnSlotExpired] = useState<ReturnSlotExpiredUpdate | null>(null);
+  const [lastNfcCardSwipeFailed, setLastNfcCardSwipeFailed] = useState<NfcCardSwipeFailedUpdate | null>(null);
   const [isConnected, setIsConnected] = useState(false);
   const [isConnecting, setIsConnecting] = useState(false);
   const eventSourceRef = useRef<EventSource<CustomEventName> | null>(null);
   const onUpdateRef = useRef<typeof onUpdate>(onUpdate);
   const onReturnSlotExpiredRef = useRef<typeof onReturnSlotExpired>(onReturnSlotExpired);
+  const onNfcCardSwipeFailedRef = useRef<typeof onNfcCardSwipeFailed>(onNfcCardSwipeFailed);
   const onErrorRef = useRef<typeof onError>(onError);
   const suppressReconnectRef = useRef(false);
   const isRecoveringAuthRef = useRef(false);
@@ -57,6 +50,10 @@ export function useBikeStatusStream(options?: UseBikeStatusStreamOptions) {
   useEffect(() => {
     onReturnSlotExpiredRef.current = onReturnSlotExpired;
   }, [onReturnSlotExpired]);
+
+  useEffect(() => {
+    onNfcCardSwipeFailedRef.current = onNfcCardSwipeFailed;
+  }, [onNfcCardSwipeFailed]);
 
   useEffect(() => {
     onErrorRef.current = onError;
@@ -150,7 +147,7 @@ export function useBikeStatusStream(options?: UseBikeStatusStreamOptions) {
         try {
           const payload = event.data ? (JSON.parse(event.data) as BikeStatusUpdate) : null;
           if (payload) {
-            setLastUpdate(payload);
+            setLastBikeStatusUpdate(payload);
             onUpdateRef.current?.(payload);
           }
         }
@@ -169,6 +166,19 @@ export function useBikeStatusStream(options?: UseBikeStatusStreamOptions) {
         }
         catch (error) {
           log.warn("Failed to parse return slot expiry update", error);
+        }
+      });
+
+      eventSource.addEventListener("nfcCardSwipeFailed", (event) => {
+        try {
+          const payload = event.data ? (JSON.parse(event.data) as NfcCardSwipeFailedUpdate) : null;
+          if (payload) {
+            setLastNfcCardSwipeFailed(payload);
+            onNfcCardSwipeFailedRef.current?.(payload);
+          }
+        }
+        catch (error) {
+          log.warn("Failed to parse NFC card swipe failure update", error);
         }
       });
 
@@ -229,7 +239,8 @@ export function useBikeStatusStream(options?: UseBikeStatusStreamOptions) {
     disconnect,
     isConnected,
     isConnecting,
-    lastUpdate,
+    lastBikeStatusUpdate,
     lastReturnSlotExpired,
+    lastNfcCardSwipeFailed,
   };
 }

--- a/apps/mobile/hooks/use-return-slot-events.ts
+++ b/apps/mobile/hooks/use-return-slot-events.ts
@@ -1,8 +1,8 @@
 import { useEffect } from "react";
 
-import type { ReturnSlotExpiredUpdate } from "@/hooks/use-bike-status-stream";
+import type { ReturnSlotExpiredUpdate } from "@/types/realtime-events";
 
-import { useBikeStatusStreamContext } from "@providers/bike-status-stream-provider";
+import { useRealtimeEventContext } from "@providers/realtime-event-provider";
 
 type Options = {
   enabled?: boolean;
@@ -13,7 +13,7 @@ export function useReturnSlotExpiredEvents(
   options?: Options,
 ) {
   const { enabled = true } = options ?? {};
-  const { subscribeReturnSlotExpired, lastReturnSlotExpired } = useBikeStatusStreamContext();
+  const { subscribeReturnSlotExpired, lastReturnSlotExpired } = useRealtimeEventContext();
 
   useEffect(() => {
     if (!enabled)

--- a/apps/mobile/providers/realtime-event-provider.tsx
+++ b/apps/mobile/providers/realtime-event-provider.tsx
@@ -1,13 +1,14 @@
 import { useQueryClient } from "@tanstack/react-query";
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
-import { Platform, ToastAndroid } from "react-native";
+import { Alert, Platform, ToastAndroid } from "react-native";
 
 import type {
   BikeStatusUpdate,
+  NfcCardSwipeFailedUpdate,
   ReturnSlotExpiredUpdate,
-} from "@/hooks/use-bike-status-stream";
+} from "@/types/realtime-events";
 
-import { useBikeStatusStream } from "@/hooks/use-bike-status-stream";
+import { useRealtimeEventStream } from "@/hooks/use-realtime-event-stream";
 import {
   invalidateAllRentalQueries,
   invalidateRentalSupportQueries,
@@ -17,23 +18,51 @@ import { useAuthNext } from "@providers/auth-provider-next";
 type BikeStatusSubscriber = (payload: BikeStatusUpdate) => void;
 type ReturnSlotSubscriber = (payload: ReturnSlotExpiredUpdate) => void;
 
-type BikeStatusStreamContextValue = {
+const NFC_CARD_ALERT_DEDUPE_MS = 10_000;
+
+const nfcCardSwipeFailedMessages: Record<NfcCardSwipeFailedUpdate["reason"], { title: string; message: string }> = {
+  ACTIVE_RENTAL_EXISTS: {
+    title: "Bạn đang có chuyến thuê",
+    message: "Vui lòng kết thúc chuyến thuê hiện tại trước khi mở khóa xe khác.",
+  },
+  ACTIVE_RESERVATION_EXISTS: {
+    title: "Bạn đang có đặt xe",
+    message: "Vui lòng kiểm tra đơn đặt xe hiện tại trước khi mở khóa xe khác.",
+  },
+  BIKE_RESERVED: {
+    title: "Xe đã được đặt trước",
+    message: "Xe này đang được giữ cho người khác. Vui lòng chọn xe khác.",
+  },
+  INSUFFICIENT_FUNDS: {
+    title: "Số dư không đủ",
+    message: "Vui lòng nạp thêm tiền vào ví để tiếp tục thuê xe.",
+  },
+  OVERNIGHT_OPERATIONS_CLOSED: {
+    title: "Ngoài giờ phục vụ",
+    message: "Hiện ngoài giờ phục vụ. Vui lòng thử lại trong khung giờ hoạt động.",
+  },
+};
+
+type RealtimeEventContextValue = {
   isConnected: boolean;
-  lastUpdate: BikeStatusUpdate | null;
+  lastBikeStatusUpdate: BikeStatusUpdate | null;
   lastReturnSlotExpired: ReturnSlotExpiredUpdate | null;
-  subscribe: (listener: BikeStatusSubscriber) => () => void;
+  lastNfcCardSwipeFailed: NfcCardSwipeFailedUpdate | null;
+  subscribeBikeStatus: (listener: BikeStatusSubscriber) => () => void;
   subscribeReturnSlotExpired: (listener: ReturnSlotSubscriber) => () => void;
 };
 
-const BikeStatusStreamContext = createContext<BikeStatusStreamContextValue | undefined>(undefined);
+const RealtimeEventContext = createContext<RealtimeEventContextValue | undefined>(undefined);
 
-export function BikeStatusStreamProvider({ children }: { children: React.ReactNode }) {
+export function RealtimeEventProvider({ children }: { children: React.ReactNode }) {
   const { hydrate, status } = useAuthNext();
   const queryClient = useQueryClient();
   const subscribersRef = useRef<Set<BikeStatusSubscriber>>(new Set());
   const returnSlotSubscribersRef = useRef<Set<ReturnSlotSubscriber>>(new Set());
-  const [lastUpdate, setLastUpdate] = useState<BikeStatusUpdate | null>(null);
+  const nfcCardAlertDedupeRef = useRef<Map<string, number>>(new Map());
+  const [lastBikeStatusUpdate, setLastBikeStatusUpdate] = useState<BikeStatusUpdate | null>(null);
   const [lastReturnSlotExpired, setLastReturnSlotExpired] = useState<ReturnSlotExpiredUpdate | null>(null);
+  const [lastNfcCardSwipeFailed, setLastNfcCardSwipeFailed] = useState<NfcCardSwipeFailedUpdate | null>(null);
 
   const notifySubscribers = useCallback((payload: BikeStatusUpdate) => {
     subscribersRef.current.forEach((listener) => {
@@ -41,7 +70,7 @@ export function BikeStatusStreamProvider({ children }: { children: React.ReactNo
         listener(payload);
       }
       catch (error) {
-        console.warn("[BikeStatusStream] subscriber error", error);
+        console.warn("[RealtimeEvent] bike status subscriber error", error);
       }
     });
   }, []);
@@ -52,14 +81,14 @@ export function BikeStatusStreamProvider({ children }: { children: React.ReactNo
         listener(payload);
       }
       catch (error) {
-        console.warn("[BikeStatusStream] return slot subscriber error", error);
+        console.warn("[RealtimeEvent] return slot subscriber error", error);
       }
     });
   }, []);
 
   const handleUpdate = useCallback(
     (payload: BikeStatusUpdate) => {
-      setLastUpdate(payload);
+      setLastBikeStatusUpdate(payload);
       void invalidateAllRentalQueries(queryClient);
       void invalidateRentalSupportQueries(queryClient);
 
@@ -93,18 +122,40 @@ export function BikeStatusStreamProvider({ children }: { children: React.ReactNo
     [notifyReturnSlotSubscribers, queryClient],
   );
 
+  const handleNfcCardSwipeFailed = useCallback((payload: NfcCardSwipeFailedUpdate) => {
+    setLastNfcCardSwipeFailed(payload);
+    const now = Date.now();
+    const dedupeKey = `${payload.reason}:${payload.bikeId}`;
+    const lastShownAt = nfcCardAlertDedupeRef.current.get(dedupeKey) ?? 0;
+
+    for (const [key, shownAt] of nfcCardAlertDedupeRef.current) {
+      if (now - shownAt > NFC_CARD_ALERT_DEDUPE_MS) {
+        nfcCardAlertDedupeRef.current.delete(key);
+      }
+    }
+
+    if (now - lastShownAt < NFC_CARD_ALERT_DEDUPE_MS) {
+      return;
+    }
+
+    nfcCardAlertDedupeRef.current.set(dedupeKey, now);
+    const content = nfcCardSwipeFailedMessages[payload.reason];
+    Alert.alert(content.title, content.message);
+  }, []);
+
   const handleError = useCallback((error: Error) => {
     if (error.message === "SSE_UNAUTHORIZED") {
       void hydrate();
     }
 
-    console.warn("[BikeStatusStream] SSE error", error);
+    console.warn("[RealtimeEvent] SSE error", error);
   }, [hydrate]);
 
-  const { isConnected, connect, disconnect } = useBikeStatusStream({
+  const { isConnected, connect, disconnect } = useRealtimeEventStream({
     autoConnect: false,
     onUpdate: handleUpdate,
     onReturnSlotExpired: handleReturnSlotExpired,
+    onNfcCardSwipeFailed: handleNfcCardSwipeFailed,
     onError: handleError,
   });
 
@@ -118,7 +169,7 @@ export function BikeStatusStreamProvider({ children }: { children: React.ReactNo
     }
   }, [connect, disconnect, status]);
 
-  const subscribe = useCallback((listener: BikeStatusSubscriber) => {
+  const subscribeBikeStatus = useCallback((listener: BikeStatusSubscriber) => {
     subscribersRef.current.add(listener);
     return () => {
       subscribersRef.current.delete(listener);
@@ -135,21 +186,22 @@ export function BikeStatusStreamProvider({ children }: { children: React.ReactNo
   const value = useMemo(
     () => ({
       isConnected,
-      lastUpdate,
+      lastBikeStatusUpdate,
       lastReturnSlotExpired,
-      subscribe,
+      lastNfcCardSwipeFailed,
+      subscribeBikeStatus,
       subscribeReturnSlotExpired,
     }),
-    [isConnected, lastReturnSlotExpired, lastUpdate, subscribe, subscribeReturnSlotExpired],
+    [isConnected, lastBikeStatusUpdate, lastNfcCardSwipeFailed, lastReturnSlotExpired, subscribeBikeStatus, subscribeReturnSlotExpired],
   );
 
-  return <BikeStatusStreamContext.Provider value={value}>{children}</BikeStatusStreamContext.Provider>;
+  return <RealtimeEventContext.Provider value={value}>{children}</RealtimeEventContext.Provider>;
 }
 
-export function useBikeStatusStreamContext() {
-  const ctx = useContext(BikeStatusStreamContext);
+export function useRealtimeEventContext() {
+  const ctx = useContext(RealtimeEventContext);
   if (!ctx) {
-    throw new Error("useBikeStatusStreamContext must be used within BikeStatusStreamProvider");
+    throw new Error("useRealtimeEventContext must be used within RealtimeEventProvider");
   }
   return ctx;
 }

--- a/apps/mobile/screen/rental/booking-history-detail/hooks/use-rental-status-watcher.ts
+++ b/apps/mobile/screen/rental/booking-history-detail/hooks/use-rental-status-watcher.ts
@@ -1,10 +1,11 @@
-import { invalidateMyRentalQueries } from "@hooks/rentals/rental-cache";
-import { useBikeStatusEvents } from "@hooks/use-bike-status-events";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 
-import type { BikeStatusUpdate } from "@/hooks/use-bike-status-stream";
+import type { BikeStatusUpdate } from "@/types/realtime-events";
 import type { MyRentalResolvedDetail } from "@/types/rental-types";
+
+import { invalidateMyRentalQueries } from "@hooks/rentals/rental-cache";
+import { useBikeStatusEvents } from "@hooks/use-bike-status-events";
 
 type Options = {
   booking?: MyRentalResolvedDetail["rental"];

--- a/apps/mobile/types/realtime-events.ts
+++ b/apps/mobile/types/realtime-events.ts
@@ -1,0 +1,30 @@
+export type BikeStatusUpdate = {
+  userId?: string;
+  bikeId: string;
+  status: string;
+};
+
+export type ReturnSlotExpiredUpdate = {
+  userId: string;
+  rentalId: string;
+  returnSlotId: string;
+  stationId: string;
+  reservedFrom: string;
+  expiredAt: string;
+  at: string;
+};
+
+export type NfcCardSwipeFailedReason
+  = | "ACTIVE_RENTAL_EXISTS"
+    | "ACTIVE_RESERVATION_EXISTS"
+    | "BIKE_RESERVED"
+    | "INSUFFICIENT_FUNDS"
+    | "OVERNIGHT_OPERATIONS_CLOSED";
+
+export type NfcCardSwipeFailedUpdate = {
+  userId: string;
+  requestId: string;
+  bikeId: string;
+  reason: NfcCardSwipeFailedReason;
+  at: string;
+};

--- a/apps/server/prisma/seed-demo.ts
+++ b/apps/server/prisma/seed-demo.ts
@@ -14,6 +14,7 @@ import {
   IncidentSeverity,
   IncidentSource,
   IncidentStatus,
+  NfcCardStatus,
   PrismaClient,
   RentalStatus,
   ReservationOption,
@@ -45,6 +46,8 @@ const DEMO_NON_CUSTOMER_USERS = 7;
 const DEMO_BIKES_PER_STATION = 5;
 const DEMO_RENTAL_MIN_HOUR = 6;
 const DEMO_RENTAL_MAX_HOUR = 22;
+const DEMO_NFC_CARD_UID = "3946298114";
+const DEMO_NFC_CARD_USER_EMAIL = "user02@mebike.local";
 
 const DEMO_AGENCY_MAIN_ID = "019b17bd-d130-7e7d-be69-91ceef7b9003";
 const DEMO_AGENCY_EAST_ID = "019b17bd-d130-7e7d-be69-91ceef7b9004";
@@ -674,6 +677,20 @@ async function main() {
         },
       },
     });
+    await prisma.nfcCard.deleteMany({
+      where: {
+        OR: [
+          { uid: DEMO_NFC_CARD_UID },
+          {
+            assignedUser: {
+              email: {
+                in: userEmails,
+              },
+            },
+          },
+        ],
+      },
+    });
 
     await prisma.user.deleteMany({
       where: {
@@ -800,6 +817,19 @@ async function main() {
     );
 
     const userByEmail = new Map(users.map(user => [user.email, user]));
+    const demoNfcCardUser = userByEmail.get(DEMO_NFC_CARD_USER_EMAIL);
+    if (demoNfcCardUser) {
+      await prisma.nfcCard.create({
+        data: {
+          id: uuidv7(),
+          uid: DEMO_NFC_CARD_UID,
+          status: NfcCardStatus.ACTIVE,
+          assignedUserId: demoNfcCardUser.id,
+          issuedAt: new Date(),
+        },
+      });
+    }
+
     const technicianAssignments = technicianTeams
       .map((team, index) => ({
         user: userByEmail.get(`tech${index + 1}@mebike.local`),

--- a/apps/server/src/domain/iot/services/device-tap.service.ts
+++ b/apps/server/src/domain/iot/services/device-tap.service.ts
@@ -3,9 +3,24 @@ import type { DeviceTapEvent } from "@mebike/shared";
 import { Effect, Layer } from "effect";
 
 import type { MqttPublishError } from "@/infrastructure/mqtt";
+import type { NfcCardSwipeFailedReason } from "@/realtime/nfc-card-events";
+
+import { notifyNfcCardSwipeFailed } from "@/realtime/nfc-card-events";
 
 import { DeviceCommandServiceTag } from "./device-command.live";
 import { DeviceTapDecisionServiceTag } from "./device-tap-decision.service";
+
+const NFC_CARD_SWIPE_FAILED_REASONS = new Set<string>([
+  "ACTIVE_RENTAL_EXISTS",
+  "ACTIVE_RESERVATION_EXISTS",
+  "BIKE_RESERVED",
+  "INSUFFICIENT_FUNDS",
+  "OVERNIGHT_OPERATIONS_CLOSED",
+]);
+
+function toNfcCardSwipeFailedReason(reason: string): NfcCardSwipeFailedReason | null {
+  return NFC_CARD_SWIPE_FAILED_REASONS.has(reason) ? reason as NfcCardSwipeFailedReason : null;
+}
 
 /**
  * Kết quả cuối cùng của một tap event sau khi server ra quyết định.
@@ -83,6 +98,17 @@ const makeDeviceTapServiceEffect = Effect.gen(function* () {
         const decision = yield* decisionService.decideTapEvent(event, options);
 
         if (decision._tag === "Deny") {
+          const alertReason = toNfcCardSwipeFailedReason(decision.reason);
+          if (decision.userId && alertReason) {
+            yield* Effect.promise(() => notifyNfcCardSwipeFailed({
+              userId: decision.userId!,
+              requestId: event.requestId,
+              bikeId: event.deviceId,
+              reason: alertReason,
+              at: new Date(options?.now ?? Date.now()).toISOString(),
+            }));
+          }
+
           return yield* denyTap(event, decision.reason, {
             userId: decision.userId,
             reservationId: decision.reservationId,

--- a/apps/server/src/http/bootstrap.ts
+++ b/apps/server/src/http/bootstrap.ts
@@ -7,6 +7,7 @@ import { Prisma } from "@/infrastructure/prisma";
 import { Redis } from "@/infrastructure/redis";
 import logger from "@/lib/logger";
 import { startBikeStatusListener } from "@/realtime/pg-bike-status-listener";
+import { startNfcCardListener } from "@/realtime/pg-nfc-card-listener";
 import { startReturnSlotListener } from "@/realtime/pg-return-slot-listener";
 
 import { createHttpApp } from "./app";
@@ -22,6 +23,7 @@ export const startHonoServer = Effect.gen(function* () {
     })),
   );
   yield* Effect.promise(() => startBikeStatusListener());
+  yield* Effect.promise(() => startNfcCardListener());
   yield* Effect.promise(() => startReturnSlotListener());
   const port = env.PORT;
   serve({

--- a/apps/server/src/http/routes/events.ts
+++ b/apps/server/src/http/routes/events.ts
@@ -4,6 +4,7 @@ import { streamSSE } from "hono/streaming";
 
 import { requireAuthMiddleware } from "@/http/middlewares/auth";
 import { getBikeStatusEventBus } from "@/realtime/bike-status-events";
+import { getNfcCardEventBus } from "@/realtime/nfc-card-events";
 import { getReturnSlotEventBus } from "@/realtime/return-slot-events";
 
 type StreamWriter = {
@@ -12,6 +13,7 @@ type StreamWriter = {
 
 const connections = new Map<string, Set<StreamWriter>>();
 const bikeStatusEventBus = getBikeStatusEventBus();
+const nfcCardEventBus = getNfcCardEventBus();
 const returnSlotEventBus = getReturnSlotEventBus();
 
 bikeStatusEventBus.on("bikeStatusUpdate", (payload: { userId: string }) => {
@@ -33,6 +35,17 @@ returnSlotEventBus.on("returnSlotExpired", (payload: { userId: string }) => {
   const data = JSON.stringify(payload);
   for (const writer of targets) {
     void writer.writeSSE({ event: "returnSlotExpired", data });
+  }
+});
+
+nfcCardEventBus.on("nfcCardSwipeFailed", (payload: { userId: string }) => {
+  const targets = connections.get(payload.userId);
+  if (!targets || targets.size === 0) {
+    return;
+  }
+  const data = JSON.stringify(payload);
+  for (const writer of targets) {
+    void writer.writeSSE({ event: "nfcCardSwipeFailed", data });
   }
 });
 

--- a/apps/server/src/realtime/nfc-card-events.ts
+++ b/apps/server/src/realtime/nfc-card-events.ts
@@ -1,0 +1,47 @@
+import { sql } from "kysely";
+import EventEmitter from "node:events";
+
+import type { DeviceDenyReason } from "@/domain/iot";
+
+import { db } from "@/database";
+import logger from "@/lib/logger";
+
+export type NfcCardSwipeFailedReason = Extract<
+  DeviceDenyReason,
+  | "ACTIVE_RENTAL_EXISTS"
+  | "ACTIVE_RESERVATION_EXISTS"
+  | "BIKE_RESERVED"
+  | "INSUFFICIENT_FUNDS"
+  | "OVERNIGHT_OPERATIONS_CLOSED"
+>;
+
+export type NfcCardSwipeFailedPayload = {
+  userId: string;
+  requestId: string;
+  bikeId: string;
+  reason: NfcCardSwipeFailedReason;
+  at: string;
+};
+
+type NfcCardEventName = "nfcCardSwipeFailed";
+
+const CHANNEL_NAME = "nfc_card_events";
+const eventBus = new EventEmitter();
+
+export function getNfcCardEventBus() {
+  return eventBus;
+}
+
+export function emitNfcCardSwipeFailed(payload: NfcCardSwipeFailedPayload) {
+  eventBus.emit("nfcCardSwipeFailed" satisfies NfcCardEventName, payload);
+}
+
+export async function notifyNfcCardSwipeFailed(payload: NfcCardSwipeFailedPayload) {
+  const message = JSON.stringify(payload);
+  try {
+    await sql`select pg_notify(${CHANNEL_NAME}, ${message})`.execute(db);
+  }
+  catch (error) {
+    logger.error({ error }, "Failed to notify NFC card swipe failure");
+  }
+}

--- a/apps/server/src/realtime/pg-nfc-card-listener.ts
+++ b/apps/server/src/realtime/pg-nfc-card-listener.ts
@@ -1,0 +1,115 @@
+import { Client } from "pg";
+
+import { env } from "@/config/env";
+import logger from "@/lib/logger";
+
+import { emitNfcCardSwipeFailed } from "./nfc-card-events";
+
+const CHANNEL_NAME = "nfc_card_events";
+const RECONNECT_DELAYS_MS = [1000, 5000, 15000];
+
+let client: Client | null = null;
+let isStarting = false;
+let reconnectTimeout: NodeJS.Timeout | null = null;
+let reconnectAttempt = 0;
+
+async function cleanupClient(pgClient: Client | null) {
+  if (!pgClient) {
+    return;
+  }
+  try {
+    pgClient.removeAllListeners("notification");
+    pgClient.removeAllListeners("error");
+    pgClient.removeAllListeners("end");
+  }
+  catch {
+    // ignore
+  }
+  try {
+    await pgClient.end();
+  }
+  catch {
+    // ignore
+  }
+}
+
+function scheduleReconnect(reason: string, error?: unknown) {
+  if (reconnectTimeout || isStarting) {
+    return;
+  }
+
+  if (error) {
+    logger.error({ error }, `NFC card listener reconnecting: ${reason}`);
+  }
+  else {
+    logger.warn(`NFC card listener reconnecting: ${reason}`);
+  }
+
+  const delay = RECONNECT_DELAYS_MS[Math.min(reconnectAttempt, RECONNECT_DELAYS_MS.length - 1)];
+  reconnectAttempt = Math.min(reconnectAttempt + 1, 1000);
+
+  reconnectTimeout = setTimeout(() => {
+    reconnectTimeout = null;
+    void startNfcCardListener();
+  }, delay);
+}
+
+async function connectListener() {
+  const pgClient = new Client({ connectionString: env.DATABASE_URL });
+  await pgClient.connect();
+  await pgClient.query(`LISTEN ${CHANNEL_NAME}`);
+
+  pgClient.on("notification", (message) => {
+    if (message.channel !== CHANNEL_NAME || !message.payload) {
+      return;
+    }
+    try {
+      const payload = JSON.parse(message.payload) as Parameters<typeof emitNfcCardSwipeFailed>[0];
+      emitNfcCardSwipeFailed(payload);
+    }
+    catch (error) {
+      logger.error({ error }, "Failed to parse NFC card notification");
+    }
+  });
+
+  pgClient.on("error", (error) => {
+    logger.error({ error }, "NFC card listener error");
+    void cleanupClient(pgClient).then(() => {
+      if (client === pgClient) {
+        client = null;
+      }
+      scheduleReconnect("pg error", error);
+    });
+  });
+
+  pgClient.on("end", () => {
+    logger.warn("NFC card listener disconnected");
+    void cleanupClient(pgClient).then(() => {
+      if (client === pgClient) {
+        client = null;
+      }
+      scheduleReconnect("pg end");
+    });
+  });
+
+  return pgClient;
+}
+
+export async function startNfcCardListener() {
+  if (client || isStarting) {
+    return;
+  }
+  isStarting = true;
+  try {
+    client = await connectListener();
+    logger.info(`Listening for NFC card events on ${CHANNEL_NAME}`);
+    reconnectAttempt = 0;
+  }
+  catch (error) {
+    logger.error({ error }, "Failed to start NFC card listener");
+    await cleanupClient(client);
+    client = null;
+    scheduleReconnect("start failed", error);
+  }
+  isStarting = false;
+}


### PR DESCRIPTION
## Summary
- add a new server realtime channel for user-facing NFC swipe failures and forward supported deny reasons through `/events`
- extend mobile realtime handling with a renamed transport/provider layer, typed event payloads, and deduped alerts for actionable NFC failures
- seed demo NFC card `3946298114` for `user02@mebike.local` so the flow can be exercised locally

## Verification
- pnpm eslint --fix "src/realtime/nfc-card-events.ts" "src/realtime/pg-nfc-card-listener.ts" "src/http/bootstrap.ts" "src/http/routes/events.ts" "src/domain/iot/services/device-tap.service.ts"
- pnpm eslint --fix "app.tsx" "hooks/use-realtime-event-stream.ts" "hooks/use-bike-status-events.ts" "hooks/use-return-slot-events.ts" "providers/realtime-event-provider.tsx" "screen/rental/booking-history-detail/hooks/use-rental-status-watcher.ts" "types/realtime-events.ts"
- pnpm eslint --fix "prisma/seed-demo.ts"
- pnpm tsc --noEmit (apps/server)
- pnpm tsc --noEmit (apps/mobile) -> existing unrelated error in `screen/environment/hooks/use-environment-impact-screen.ts` about `pageParam` on `FetchNextPageOptions`