### PR TITLE
fix(mobile): handle missing profile state gracefully

### DIFF
--- a/apps/mobile/screen/account/profile/components/profile-header.tsx
+++ b/apps/mobile/screen/account/profile/components/profile-header.tsx
@@ -1,13 +1,14 @@
+import { MaterialIcons } from "@expo/vector-icons";
+import { LinearGradient } from "expo-linear-gradient";
+import React, { useEffect, useState } from "react";
+import { Image } from "react-native";
+import { useTheme, XStack, YStack } from "tamagui";
+
 import type { UserDetail } from "@services/users/user-service";
 
 import { IconSymbol } from "@components/IconSymbol";
 import { borderWidths, radii, spaceScale, spacingRules } from "@theme/metrics";
 import { AppText } from "@ui/primitives/app-text";
-import { LinearGradient } from "expo-linear-gradient";
-import { Image, Pressable } from "react-native";
-import { useTheme, XStack, YStack } from "tamagui";
-
-import avatarFallback from "@/assets/avatar2.png";
 
 type ProfileHeaderProps = {
   profile: UserDetail;
@@ -21,6 +22,23 @@ type ProfileHeaderProps = {
 const avatarSize = 92;
 const verificationBadgeSize = 28;
 
+function getAvatarFallbackLabel(fullName: string) {
+  const parts = fullName
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+
+  if (parts.length === 0) {
+    return "";
+  }
+
+  if (parts.length === 1) {
+    return parts[0].slice(0, 1).toUpperCase();
+  }
+
+  return `${parts[0].slice(0, 1)}${parts[1].slice(0, 1)}`.toUpperCase();
+}
+
 function ProfileHeader({
   profile,
   completedTrips,
@@ -30,9 +48,16 @@ function ProfileHeader({
   formatDate,
 }: ProfileHeaderProps) {
   const theme = useTheme();
+  const [hasAvatarLoadError, setHasAvatarLoadError] = useState(false);
   const memberSince = formatDate(profile.createdAt || profile.updatedAt);
   const isVerified = profile.verify === "VERIFIED";
   const showCompletedTrips = typeof completedTrips === "number";
+  const shouldShowAvatarImage = Boolean(profile.avatar) && !hasAvatarLoadError;
+  const avatarFallbackLabel = getAvatarFallbackLabel(profile.fullName);
+
+  useEffect(() => {
+    setHasAvatarLoadError(false);
+  }, [profile.avatar]);
 
   return (
     <LinearGradient
@@ -50,17 +75,46 @@ function ProfileHeader({
       <YStack gap="$5">
         <XStack alignItems="center" gap="$5">
           <XStack height={avatarSize} position="relative" width={avatarSize}>
-            <Image
-              source={profile.avatar ? { uri: profile.avatar } : avatarFallback}
-              style={{
-                width: avatarSize,
-                height: avatarSize,
-                borderRadius: avatarSize / 2,
-                borderWidth: 4,
-                borderColor: theme.surfaceDefault.val,
-                backgroundColor: theme.surfaceMuted.val,
-              }}
-            />
+            {shouldShowAvatarImage
+              ? (
+                  <Image
+                    onError={() => setHasAvatarLoadError(true)}
+                    source={{ uri: profile.avatar! }}
+                    style={{
+                      width: avatarSize,
+                      height: avatarSize,
+                      borderRadius: avatarSize / 2,
+                      borderWidth: 4,
+                      borderColor: theme.surfaceDefault.val,
+                      backgroundColor: theme.surfaceMuted.val,
+                    }}
+                  />
+                )
+              : (
+                  <XStack
+                    alignItems="center"
+                    backgroundColor={theme.surfaceDefault.val}
+                    borderColor={theme.surfaceDefault.val}
+                    borderRadius="$round"
+                    borderWidth={4}
+                    height={avatarSize}
+                    justifyContent="center"
+                    width={avatarSize}
+                  >
+                    {avatarFallbackLabel
+                      ? (
+                          <AppText
+                            color={theme.actionPrimary.val}
+                            fontSize={32}
+                            fontWeight="800"
+                            letterSpacing={0.5}
+                          >
+                            {avatarFallbackLabel}
+                          </AppText>
+                        )
+                      : <MaterialIcons color={theme.textSecondary.val} name="account-circle" size={64} />}
+                  </XStack>
+                )}
 
             {isVerified
               ? (

--- a/apps/mobile/screen/account/profile/hooks/use-profile-email-verification.ts
+++ b/apps/mobile/screen/account/profile/hooks/use-profile-email-verification.ts
@@ -1,8 +1,8 @@
-import type { UserDetail } from "@services/users/user-service";
-
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useState } from "react";
 import { Alert } from "react-native";
+
+import type { UserDetail } from "@services/users/user-service";
 
 import { useResendVerifyEmailMutation } from "@/hooks/mutations/AuthNext/use-resend-verify-email-mutation";
 import { useVerifyEmailOtpMutation } from "@/hooks/mutations/AuthNext/use-verify-email-otp-mutation";
@@ -10,7 +10,7 @@ import { authQueryKeys } from "@/hooks/query/auth-next/auth-query-keys";
 import { presentAuthError } from "@/presenters/auth/auth-error-presenter";
 
 type UseProfileEmailVerificationParams = {
-  profile: UserDetail;
+  profile: UserDetail | null;
   hydrate: () => Promise<void>;
 };
 
@@ -24,6 +24,11 @@ export function useProfileEmailVerification({
   const verifyOtpMutation = useVerifyEmailOtpMutation();
 
   const handleResendOtp = useCallback(async () => {
+    if (!profile) {
+      Alert.alert("Lỗi", "Không tìm thấy thông tin tài khoản. Vui lòng thử lại.");
+      return false;
+    }
+
     if (profile.verify === "VERIFIED") {
       Alert.alert("Thông báo", "Email của bạn đã được xác thực.");
       return false;
@@ -49,9 +54,14 @@ export function useProfileEmailVerification({
       Alert.alert("Lỗi", "Không thể gửi lại OTP. Vui lòng thử lại.");
       return false;
     }
-  }, [profile.email, profile.fullName, profile.id, profile.verify, resendOtpMutation]);
+  }, [profile, resendOtpMutation]);
 
   const handleVerifyEmail = useCallback(async (otp: string) => {
+    if (!profile) {
+      Alert.alert("Lỗi", "Không tìm thấy thông tin tài khoản. Vui lòng thử lại.");
+      return;
+    }
+
     try {
       const result = await verifyOtpMutation.mutateAsync({ userId: profile.id, otp });
 
@@ -70,7 +80,7 @@ export function useProfileEmailVerification({
     catch {
       Alert.alert("Lỗi", "Xác thực thất bại. Vui lòng thử lại.");
     }
-  }, [hydrate, profile.id, queryClient, verifyOtpMutation]);
+  }, [hydrate, profile, queryClient, verifyOtpMutation]);
 
   const openVerifyModal = useCallback(() => {
     setIsVerifyEmailModalOpen(true);

--- a/apps/mobile/screen/account/profile/hooks/use-profile.ts
+++ b/apps/mobile/screen/account/profile/hooks/use-profile.ts
@@ -1,9 +1,7 @@
 import { useNavigation } from "@react-navigation/native";
 import { useQueryClient } from "@tanstack/react-query";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useState } from "react";
 import { Alert } from "react-native";
-
-import type { UserDetail } from "@services/users/user-service";
 
 import { authQueryKeys } from "@/hooks/query/auth-next/auth-query-keys";
 import { useMyRentalCountsQuery } from "@hooks/query/rentals/use-my-rental-counts-query";
@@ -12,33 +10,14 @@ import { useAuthNext } from "@providers/auth-provider-next";
 
 import { useProfileEmailVerification } from "./use-profile-email-verification";
 
-function buildProfile(user: UserDetail | null | undefined): UserDetail {
-  return {
-    id: user?.id ?? "",
-    fullName: user?.fullName ?? "",
-    email: user?.email ?? "",
-    accountStatus: user?.accountStatus ?? "ACTIVE",
-    verify: user?.verify ?? "UNVERIFIED",
-    location: user?.location ?? null,
-    username: user?.username ?? null,
-    phoneNumber: user?.phoneNumber ?? null,
-    avatar: user?.avatar ?? null,
-    role: user?.role ?? "USER",
-    orgAssignment: user?.orgAssignment ?? null,
-    nfcCardUid: user?.nfcCardUid ?? null,
-    createdAt: user?.createdAt ?? "",
-    updatedAt: user?.updatedAt ?? "",
-  };
-}
-
 export function useProfile() {
   const navigation = useNavigation();
-  const { user, logout, isCustomer, hydrate } = useAuthNext();
+  const { user, logout, isCustomer, hydrate, isLoading } = useAuthNext();
   const queryClient = useQueryClient();
   const hasToken = Boolean(user?.id);
   const shouldLoadRentalCounts = hasToken && isCustomer;
   const [isRefreshing, setIsRefreshing] = useState(false);
-  const profile = useMemo(() => buildProfile(user), [user]);
+  const profile = user;
 
   const { data: rentalCounts, isLoading: isRentalCountsLoading } = useMyRentalCountsQuery({
     enabled: shouldLoadRentalCounts,
@@ -135,6 +114,7 @@ export function useProfile() {
     isResendingOtp,
     isVerifyingOtp,
     isRefreshing,
+    isProfileLoading: isLoading && !profile,
     onRefresh,
     isCustomer,
     isRentalCountsLoading,

--- a/apps/mobile/screen/account/profile/index.tsx
+++ b/apps/mobile/screen/account/profile/index.tsx
@@ -63,6 +63,7 @@ function ProfileScreen() {
     closeVerifyModal,
     isVerifyingOtp,
     isRefreshing,
+    isProfileLoading,
     onRefresh,
     isCustomer,
     isRentalCountsLoading,
@@ -155,7 +156,7 @@ function ProfileScreen() {
       iconBackground: theme.surfaceWarning.val,
       onPress: handleChangePassword,
     },
-    ...(profile.verify === "VERIFIED"
+    ...(profile?.verify === "VERIFIED"
       ? []
       : [{
           icon: "mail" as const,
@@ -178,7 +179,7 @@ function ProfileScreen() {
     handleMetroJourney,
     handleUpdateProfile,
     handleVerifyEmailPress,
-    profile.verify,
+    profile?.verify,
     theme.actionPrimary.val,
     theme.statusSuccess.val,
     theme.statusWarning.val,
@@ -197,6 +198,47 @@ function ProfileScreen() {
       destructive: true,
     },
   ], [handleLogout, theme.surfaceDanger.val, theme.textDanger.val]);
+
+  if (!profile) {
+    return (
+      <Screen tone="subtle">
+        <StatusBar barStyle="light-content" backgroundColor={theme.actionPrimary.val} translucent />
+
+        <ScrollView
+          refreshControl={<RefreshControl colors={[theme.actionPrimary.val]} onRefresh={onRefresh} refreshing={isRefreshing} tintColor={theme.actionPrimary.val} />}
+          showsVerticalScrollIndicator={false}
+        >
+          <YStack gap="$6" paddingHorizontal="$5" paddingTop={insets.top + 24} paddingBottom="$7">
+            <AppCard
+              backgroundColor="$surfaceDefault"
+              borderColor="$borderSubtle"
+              borderRadius={radii.xxl}
+              borderWidth={borderWidths.subtle}
+              chrome="flat"
+              gap="$3"
+              style={elevations.whisper}
+            >
+              <AppText variant="title">
+                {isProfileLoading ? "Đang tải thông tin tài khoản" : "Chưa thể tải thông tin tài khoản"}
+              </AppText>
+              <AppText tone="muted" variant="body">
+                {isProfileLoading
+                  ? "Vui lòng đợi trong giây lát."
+                  : "Kéo xuống để thử lại. Nếu lỗi tiếp tục xảy ra, bạn có thể đăng xuất rồi đăng nhập lại."}
+              </AppText>
+            </AppCard>
+
+            <YStack gap="$4">
+              <MenuGroup items={destructiveItems} />
+              <AppText align="center" opacity={0.58} tone="subtle" variant="eyebrow">
+                Phiên bản 1.0.0
+              </AppText>
+            </YStack>
+          </YStack>
+        </ScrollView>
+      </Screen>
+    );
+  }
 
   return (
     <Screen tone="subtle">

--- a/apps/mobile/screen/account/update-profile/components/update-profile-header.tsx
+++ b/apps/mobile/screen/account/update-profile/components/update-profile-header.tsx
@@ -1,14 +1,33 @@
 import { MaterialIcons } from "@expo/vector-icons";
+import React, { useEffect, useState } from "react";
 import { ActivityIndicator, Image } from "react-native";
 import { Button, useTheme, View, YStack } from "tamagui";
 
 import { borderWidths, spaceScale } from "@theme/metrics";
 import { AppHeroHeader } from "@ui/patterns/app-hero-header";
+import { AppText } from "@ui/primitives/app-text";
 import { StatusBadge } from "@ui/primitives/status-badge";
 
 const avatarFrameSize = spaceScale[10] + spaceScale[9] + spaceScale[6];
 const avatarImageSize = avatarFrameSize - spaceScale[3];
 const avatarActionButtonSize = spaceScale[8] - borderWidths.strong;
+
+function getAvatarFallbackLabel(fullName: string) {
+  const parts = fullName
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+
+  if (parts.length === 0) {
+    return "";
+  }
+
+  if (parts.length === 1) {
+    return parts[0].slice(0, 1).toUpperCase();
+  }
+
+  return `${parts[0].slice(0, 1)}${parts[1].slice(0, 1)}`.toUpperCase();
+}
 
 type UpdateProfileHeaderProps = {
   onBack: () => void;
@@ -16,6 +35,7 @@ type UpdateProfileHeaderProps = {
   isEditing: boolean;
   isBusy: boolean;
   avatarUrl: string;
+  fullName: string;
   onPickAvatar: () => void;
   isPickingAvatar: boolean;
   hasPendingAvatar: boolean;
@@ -27,11 +47,19 @@ export function UpdateProfileHeader({
   isEditing,
   isBusy,
   avatarUrl,
+  fullName,
   onPickAvatar,
   isPickingAvatar,
   hasPendingAvatar,
 }: UpdateProfileHeaderProps) {
   const theme = useTheme();
+  const [hasAvatarLoadError, setHasAvatarLoadError] = useState(false);
+  const shouldShowAvatarImage = Boolean(avatarUrl) && !hasAvatarLoadError;
+  const avatarFallbackLabel = getAvatarFallbackLabel(fullName);
+
+  useEffect(() => {
+    setHasAvatarLoadError(false);
+  }, [avatarUrl]);
 
   return (
     <AppHeroHeader
@@ -77,9 +105,26 @@ export function UpdateProfileHeader({
               justifyContent="center"
               overflow="hidden"
             >
-              {avatarUrl
-                ? <Image source={{ uri: avatarUrl }} style={{ width: avatarImageSize, height: avatarImageSize }} />
-                : <MaterialIcons color={theme.onSurfaceBrand.val} name="account-circle" size={56} />}
+              {shouldShowAvatarImage
+                ? (
+                    <Image
+                      onError={() => setHasAvatarLoadError(true)}
+                      source={{ uri: avatarUrl }}
+                      style={{ width: avatarImageSize, height: avatarImageSize }}
+                    />
+                  )
+                : avatarFallbackLabel
+                  ? (
+                      <AppText
+                        color={theme.onSurfaceBrand.val}
+                        fontSize={30}
+                        fontWeight="800"
+                        letterSpacing={0.5}
+                      >
+                        {avatarFallbackLabel}
+                      </AppText>
+                    )
+                  : <MaterialIcons color={theme.onSurfaceBrand.val} name="account-circle" size={56} />}
             </View>
 
             <Button

--- a/apps/mobile/screen/account/update-profile/components/update-profile-header.tsx
+++ b/apps/mobile/screen/account/update-profile/components/update-profile-header.tsx
@@ -102,15 +102,17 @@ export function UpdateProfileHeader({
               borderColor="$overlayGlass"
               borderRadius="$round"
               borderWidth={borderWidths.subtle}
+              height={avatarImageSize}
               justifyContent="center"
               overflow="hidden"
+              width={avatarImageSize}
             >
               {shouldShowAvatarImage
                 ? (
                     <Image
                       onError={() => setHasAvatarLoadError(true)}
                       source={{ uri: avatarUrl }}
-                      style={{ width: avatarImageSize, height: avatarImageSize }}
+                      style={{ width: avatarImageSize, height: avatarImageSize, borderRadius: avatarImageSize / 2 }}
                     />
                   )
                 : avatarFallbackLabel

--- a/apps/mobile/screen/account/update-profile/index.tsx
+++ b/apps/mobile/screen/account/update-profile/index.tsx
@@ -65,6 +65,7 @@ export default function UpdateProfileScreen() {
         <YStack backgroundColor="$actionPrimary" flex={1}>
           <UpdateProfileHeader
             avatarUrl={avatar}
+            fullName={user?.fullName ?? ""}
             hasPendingAvatar={hasPendingAvatar}
             isBusy={isSaving}
             isEditing={isEditing}


### PR DESCRIPTION
## Summary
- stop the Me screen from fabricating an empty profile and show an explicit loading/retry state when account data is missing
- replace the washed-out profile avatar fallback with a cleaner initials-based fallback, with image-load recovery for broken avatar URLs
- align the update-profile header with the same avatar fallback behavior for consistency

## Testing
- pnpm eslint --fix \"screen/account/profile/components/profile-header.tsx\" \"screen/account/profile/hooks/use-profile-email-verification.ts\" \"screen/account/profile/hooks/use-profile.ts\" \"screen/account/profile/index.tsx\" \"screen/account/update-profile/components/update-profile-header.tsx\" \"screen/account/update-profile/index.tsx\"
- pnpm tsc --noEmit *(still blocked by existing unrelated error in `screen/environment/hooks/use-environment-impact-screen.ts` about `pageParam`)*