### PR TITLE
fix reservation confirm flow errors

### DIFF
--- a/apps/mobile/contracts/server.ts
+++ b/apps/mobile/contracts/server.ts
@@ -8,6 +8,7 @@ export type ActiveCouponRule = ServerContracts.CouponsContracts.ActiveCouponRule
 export type ActiveCouponRulesResponse = ServerContracts.CouponsContracts.ActiveCouponRulesResponse;
 
 export type ReservationDetail = ServerContracts.ReservationsContracts.ReservationDetail;
+export type ConfirmReservationResponse = ServerContracts.ReservationsContracts.ConfirmReservationResponse;
 export type ReservationExpandedDetail = ServerContracts.ReservationsContracts.ReservationExpandedDetail;
 export type CreateReservationPayload = ServerContracts.ReservationsContracts.CreateReservationRequest;
 export type PaginatedReservations = ServerContracts.ReservationsContracts.ListMyReservationsResponse;

--- a/apps/mobile/hooks/mutations/reservation/use-confirm-reservation-mutation.ts
+++ b/apps/mobile/hooks/mutations/reservation/use-confirm-reservation-mutation.ts
@@ -1,12 +1,10 @@
-import { useMutation } from "@tanstack/react-query";
-
-import type { Reservation } from "@/types/reservation-types";
-import type { ReservationError } from "@services/reservations";
+import type { ConfirmReservationResult, ReservationError } from "@services/reservations";
 
 import { reservationService } from "@services/reservations";
+import { useMutation } from "@tanstack/react-query";
 
 export function useConfirmReservationMutation() {
-  return useMutation<Reservation, ReservationError, string>({
+  return useMutation<ConfirmReservationResult, ReservationError, string>({
     mutationFn: async (reservationId: string) => {
       const result = await reservationService.confirmReservation(reservationId);
       if (!result.ok) {

--- a/apps/mobile/hooks/reservation/use-reservation-mutations.ts
+++ b/apps/mobile/hooks/reservation/use-reservation-mutations.ts
@@ -1,3 +1,5 @@
+import type { ConfirmReservationResult } from "@services/reservations";
+
 import { useNavigation } from "@react-navigation/native";
 import { useCallback } from "react";
 import { Alert } from "react-native";
@@ -17,6 +19,11 @@ type ReservationOption = "MỘT LẦN" | "GÓI THÁNG";
 
 type MutationCallbacks = {
   onSuccess?: () => void;
+  onError?: (message: string) => void;
+};
+
+type ConfirmReservationCallbacks = {
+  onSuccess?: (result: ConfirmReservationResult) => void;
   onError?: (message: string) => void;
 };
 
@@ -150,7 +157,7 @@ export function useReservationMutations({ ensureAuthenticated }: UseReservationM
   );
 
   const confirmReservation = useCallback(
-    (reservationIdToConfirm: string, callbacks?: MutationCallbacks) => {
+    (reservationIdToConfirm: string, callbacks?: ConfirmReservationCallbacks) => {
       if (!ensureAuthenticated()) {
         return;
       }
@@ -163,10 +170,10 @@ export function useReservationMutations({ ensureAuthenticated }: UseReservationM
       }
 
       confirmReservationMutation.mutate(reservationIdToConfirm, {
-        onSuccess: () => {
+        onSuccess: (result) => {
           Alert.alert("Thành công", "Bắt đầu hành trình của bạn ngay thôi!");
           invalidateReservationQueries();
-          callbacks?.onSuccess?.();
+          callbacks?.onSuccess?.(result);
         },
         onError: (error) => {
           const message = getReservationErrorMessage(

--- a/apps/mobile/presenters/reservations/reservation-error-presenter.ts
+++ b/apps/mobile/presenters/reservations/reservation-error-presenter.ts
@@ -16,11 +16,12 @@ const reservationErrorMessages = {
   reservationConfirmBlockedByActiveRental:
     "Bạn đang có chuyến đi hoạt động nên chưa thể nhận thêm lượt giữ chỗ này.",
   reservationMissingBike: "Lượt giữ chỗ này chưa được gán xe phù hợp.",
+  reservationNotStarted: "Chưa đến thời gian bắt đầu của lượt giữ chỗ này.",
   reservationNotFound: "Không tìm thấy lượt giữ chỗ này.",
   reservationNotOwned: "Bạn không thể thao tác với lượt giữ chỗ của người khác.",
   reservationOptionNotSupported: "Hình thức đặt chỗ này hiện chưa được hỗ trợ.",
   stationReservationAvailabilityTooLow:
-    "Trạm này chỉ cho đặt trước khi số xe khả dụng còn trên 50% sức chứa.",
+    "Trạm này hiện không còn đủ xe khả dụng để nhận thêm lượt đặt trước.",
   subscriptionNotFound: "Không tìm thấy gói tháng đã chọn.",
   subscriptionNotUsable: "Gói tháng hiện chưa thể dùng để đặt xe.",
   subscriptionRequired: "Bạn cần có gói tháng để sử dụng lựa chọn này.",
@@ -74,6 +75,8 @@ function presentReservationApiError(error: Extract<ReservationError, { _tag: "Ap
       return reservationErrorMessages.reservationConfirmBlockedByActiveRental;
     case "RESERVATION_MISSING_BIKE":
       return reservationErrorMessages.reservationMissingBike;
+    case "RESERVATION_NOT_STARTED":
+      return reservationErrorMessages.reservationNotStarted;
     case "RESERVATION_NOT_FOUND":
       return reservationErrorMessages.reservationNotFound;
     case "RESERVATION_NOT_OWNED":

--- a/apps/mobile/screen/reservation-detail-screen.tsx
+++ b/apps/mobile/screen/reservation-detail-screen.tsx
@@ -92,9 +92,9 @@ function ReservationDetailScreen() {
           text: "Bắt đầu",
           onPress: () =>
             confirmReservation(reservationId, {
-              onSuccess: () => {
+              onSuccess: ({ rentalId }) => {
                 fetchReservationDetail();
-                navigation.replace("BookingHistoryDetail", { bookingId: reservationId });
+                navigation.replace("BookingHistoryDetail", { bookingId: rentalId });
               },
             }),
         },

--- a/apps/mobile/services/reservations/reservation.service.ts
+++ b/apps/mobile/services/reservations/reservation.service.ts
@@ -9,6 +9,7 @@ import { toSearchParams } from "@services/shared/search-params";
 import { StatusCodes } from "http-status-codes";
 
 import type {
+  ConfirmReservationResponse,
   CreateReservationPayload,
   PaginatedReservations,
   Reservation,
@@ -23,6 +24,11 @@ import type { ReservationError } from "./reservation-error";
 import { asNetworkError, parseReservationError } from "./reservation-error";
 
 export type { CreateReservationPayload };
+
+export type ConfirmReservationResult = {
+  reservation: Reservation;
+  rentalId: string;
+};
 
 type ReservationListParams = {
   page?: number;
@@ -187,7 +193,7 @@ export const reservationService = {
     }
   },
 
-  confirmReservation: async (reservationId: string): Promise<Result<Reservation, ReservationError>> => {
+  confirmReservation: async (reservationId: string): Promise<Result<ConfirmReservationResult, ReservationError>> => {
     try {
       const path = routePath(ServerRoutes.reservations.confirmReservation, { reservationId });
 
@@ -195,7 +201,10 @@ export const reservationService = {
 
       if (response.status === StatusCodes.OK) {
         const okSchema = ServerRoutes.reservations.confirmReservation.responses[200].content["application/json"].schema;
-        return decodeReservationResponse(response, okSchema as z.ZodType<ReservationDetail>, mapReservation);
+        return decodeReservationResponse(response, okSchema as z.ZodType<ConfirmReservationResponse>, value => ({
+          reservation: mapReservation(value.reservation),
+          rentalId: value.rentalId,
+        }));
       }
 
       return err(await parseReservationError(response));

--- a/apps/mobile/types/reservation-types.ts
+++ b/apps/mobile/types/reservation-types.ts
@@ -1,4 +1,5 @@
 import type {
+  ConfirmReservationResponse,
   CreateReservationPayload,
   PaginatedReservations,
   ReservationDetail,
@@ -8,6 +9,7 @@ import type {
 } from "@/contracts/server";
 
 export type {
+  ConfirmReservationResponse,
   CreateReservationPayload,
   PaginatedReservations,
   ReservationDetail,

--- a/apps/server/src/domain/iot/services/device-access-command.service.ts
+++ b/apps/server/src/domain/iot/services/device-access-command.service.ts
@@ -7,7 +7,7 @@ import type {
 import type { StartRentalInput } from "@/domain/rentals/types";
 import type {
   ConfirmReservationInput,
-  ReservationRow,
+  ConfirmReservationSuccess,
   ReservationServiceFailure,
 } from "@/domain/reservations";
 
@@ -28,7 +28,7 @@ import { Prisma } from "@/infrastructure/prisma";
 export type DeviceAccessCommandService = {
   readonly confirmReservation: (
     input: ConfirmReservationInput,
-  ) => Effect.Effect<ReservationRow, ReservationServiceFailure>;
+  ) => Effect.Effect<ConfirmReservationSuccess, ReservationServiceFailure>;
   readonly startRental: (
     input: StartRentalInput,
   ) => Effect.Effect<RentalRow, RentalServiceFailure>;
@@ -49,12 +49,12 @@ type DeviceAccessCommandDeps = {
  */
 function provideConfirmReservationDeps(
   effect: Effect.Effect<
-    ReservationRow,
+    ConfirmReservationSuccess,
     ReservationServiceFailure,
     Prisma
   >,
   deps: DeviceAccessCommandDeps,
-): Effect.Effect<ReservationRow, ReservationServiceFailure> {
+): Effect.Effect<ConfirmReservationSuccess, ReservationServiceFailure> {
   return effect.pipe(
     Effect.provideService(Prisma, deps.prisma),
   );

--- a/apps/server/src/domain/iot/services/device-tap-decision.service.ts
+++ b/apps/server/src/domain/iot/services/device-tap-decision.service.ts
@@ -171,10 +171,10 @@ const makeDeviceTapDecisionServiceEffect = Effect.gen(function* () {
     deviceAccessCommandService.confirmReservation({ reservationId, userId, now }).pipe(
       Effect.matchEffect({
         onFailure: failure => deny(mapReservationFailureToDenyReason(failure), { userId }),
-        onSuccess: reservation =>
+        onSuccess: confirmed =>
           unlock({
             userId,
-            reservationId: reservation.id,
+            reservationId: confirmed.reservation.id,
           }),
       }),
     );

--- a/apps/server/src/domain/reservations/domain-errors.ts
+++ b/apps/server/src/domain/reservations/domain-errors.ts
@@ -107,6 +107,16 @@ export class ReservationMissingBike extends Data.TaggedError("ReservationMissing
 }> {}
 
 /**
+ * EN: Reservation cannot be confirmed before its start time.
+ * VI: Chưa đến thời điểm bắt đầu nên không thể xác nhận reservation.
+ */
+export class ReservationNotStarted extends Data.TaggedError("ReservationNotStarted")<{
+  readonly reservationId: string;
+  readonly startTime: string;
+  readonly currentTime: string;
+}> {}
+
+/**
  * EN: Reservation status transition is invalid.
  * VI: Chuyển trạng thái reservation không hợp lệ.
  */
@@ -206,6 +216,7 @@ export type ReservationServiceFailure
     | ReservationNotFound
     | ReservationNotOwned
     | ReservationMissingBike
+    | ReservationNotStarted
     | InvalidReservationTransition
     | ReservationOperatingHourFailure
     | SubscriptionRequired

--- a/apps/server/src/domain/reservations/services/commands/confirm-reservation.service.ts
+++ b/apps/server/src/domain/reservations/services/commands/confirm-reservation.service.ts
@@ -4,10 +4,10 @@ import { defectOn } from "@/domain/shared";
 import { Prisma } from "@/infrastructure/prisma";
 import { PrismaTransactionError, runPrismaTransaction } from "@/lib/effect/prisma-tx";
 
-import type { ReservationRow } from "../../models";
 import type {
   ConfirmReservationFailure,
   ConfirmReservationInput,
+  ConfirmReservationSuccess,
 } from "./confirm-reservation/confirm-reservation.types";
 
 import { persistConfirmReservationInTx } from "./confirm-reservation/confirm-reservation.persistence";
@@ -16,6 +16,7 @@ import { prepareConfirmReservationInTx } from "./confirm-reservation/confirm-res
 export type {
   ConfirmReservationFailure,
   ConfirmReservationInput,
+  ConfirmReservationSuccess,
 } from "./confirm-reservation/confirm-reservation.types";
 
 /**
@@ -30,7 +31,7 @@ export type {
 export function confirmReservation(
   input: ConfirmReservationInput,
 ): Effect.Effect<
-  ReservationRow,
+  ConfirmReservationSuccess,
   ConfirmReservationFailure,
   Prisma
 > {

--- a/apps/server/src/domain/reservations/services/commands/confirm-reservation/confirm-reservation.persistence.ts
+++ b/apps/server/src/domain/reservations/services/commands/confirm-reservation/confirm-reservation.persistence.ts
@@ -15,10 +15,10 @@ import type {
   BikeIsRedistributing,
   BikeNotAvailable,
 } from "../../../domain-errors";
-import type { ReservationRow } from "../../../models";
 import type {
   ConfirmReservationCommandInput,
   ConfirmReservationFailure,
+  ConfirmReservationSuccess,
   PreparedConfirmReservation,
 } from "./confirm-reservation.types";
 
@@ -42,7 +42,7 @@ export function persistConfirmReservationInTx(args: {
   readonly tx: PrismaTypes.TransactionClient;
   readonly input: ConfirmReservationCommandInput;
   readonly prepared: PreparedConfirmReservation;
-}): Effect.Effect<ReservationRow, ConfirmReservationFailure> {
+}): Effect.Effect<ConfirmReservationSuccess, ConfirmReservationFailure> {
   return Effect.gen(function* () {
     const { tx, input, prepared } = args;
     const txRentalRepo = makeRentalRepository(tx);
@@ -94,13 +94,18 @@ export function persistConfirmReservationInTx(args: {
       defectOn(RentalRepositoryError),
     );
 
-    return yield* txReservationCommandRepo.updateStatus({
+    const reservation = yield* txReservationCommandRepo.updateStatus({
       reservationId: prepared.reservation.id,
       status: "FULFILLED",
       updatedAt: input.now,
     }).pipe(
       Effect.catchTag("ReservationNotFound", err => Effect.die(err)),
     );
+
+    return {
+      reservation,
+      rentalId: createdRental.id,
+    };
   });
 }
 

--- a/apps/server/src/domain/reservations/services/commands/confirm-reservation/confirm-reservation.types.ts
+++ b/apps/server/src/domain/reservations/services/commands/confirm-reservation/confirm-reservation.types.ts
@@ -33,4 +33,9 @@ export type PreparedConfirmReservation = ConfirmPendingReservationResult & {
   readonly requiredBalance: bigint;
 };
 
+export type ConfirmReservationSuccess = {
+  readonly reservation: ReservationRow;
+  readonly rentalId: string;
+};
+
 export type ConfirmReservationFailure = ReservationServiceFailure;

--- a/apps/server/src/domain/reservations/services/commands/confirm-reservation/confirm-reservation.validation.ts
+++ b/apps/server/src/domain/reservations/services/commands/confirm-reservation/confirm-reservation.validation.ts
@@ -21,6 +21,7 @@ import {
   ReservationMissingBike,
   ReservationNotFound,
   ReservationNotOwned,
+  ReservationNotStarted,
 } from "../../../domain-errors";
 import { makeReservationQueryRepository } from "../../../repository/reservation-query.repository";
 
@@ -46,6 +47,7 @@ export function validatePendingReservationForConfirmationInTx(
   | ReservationNotFound
   | ReservationNotOwned
   | ReservationMissingBike
+  | ReservationNotStarted
   | InvalidReservationTransition
 > {
   return Effect.gen(function* () {
@@ -72,10 +74,10 @@ export function validatePendingReservationForConfirmationInTx(
     }
 
     if (reservation.startTime > input.now) {
-      return yield* Effect.fail(new InvalidReservationTransition({
+      return yield* Effect.fail(new ReservationNotStarted({
         reservationId: reservation.id,
-        from: reservation.status,
-        to: "FULFILLED",
+        startTime: reservation.startTime.toISOString(),
+        currentTime: input.now.toISOString(),
       }));
     }
 

--- a/apps/server/src/domain/reservations/services/reservation-command.service.ts
+++ b/apps/server/src/domain/reservations/services/reservation-command.service.ts
@@ -12,6 +12,7 @@ import type {
 import type {
   ConfirmReservationFailure,
   ConfirmReservationInput,
+  ConfirmReservationSuccess,
 } from "./commands/confirm-reservation.service";
 import type {
   ReserveBikeFailure,
@@ -28,7 +29,7 @@ export type ReservationCommandService = {
   ) => Effect.Effect<ReservationRow, ReserveBikeFailure>;
   confirmReservation: (
     input: ConfirmReservationInput,
-  ) => Effect.Effect<ReservationRow, ConfirmReservationFailure>;
+  ) => Effect.Effect<ConfirmReservationSuccess, ConfirmReservationFailure>;
   cancelReservation: (
     input: CancelReservationInput,
   ) => Effect.Effect<ReservationRow, CancelReservationFailure>;

--- a/apps/server/src/domain/reservations/services/test/reservation.use-cases.int.test.ts
+++ b/apps/server/src/domain/reservations/services/test/reservation.use-cases.int.test.ts
@@ -130,7 +130,7 @@ describe("reservation use-cases integration", () => {
       now,
     });
 
-    expectRight(confirmResult);
+    const confirmed = expectRight(confirmResult);
 
     const activePricingPolicy = await fixture.prisma.pricingPolicy.findFirst({
       where: { status: "ACTIVE" },
@@ -143,6 +143,7 @@ describe("reservation use-cases integration", () => {
     const rental = await fixture.prisma.rental.findFirst({ where: { reservationId: reservation.id } });
     expect(rental?.status).toBe("RENTED");
     expect(rental?.reservationId).toBe(reservation.id);
+    expect(confirmed.rentalId).toBe(rental?.id);
     expect(rental?.bikeId).toBe(bike.id);
     expect(rental?.pricingPolicyId).toBe(reservation.pricingPolicyId);
     expect(rental?.depositHoldId).not.toBeNull();

--- a/apps/server/src/domain/reservations/services/test/reservation.use-cases.unhappy.int.test.ts
+++ b/apps/server/src/domain/reservations/services/test/reservation.use-cases.unhappy.int.test.ts
@@ -315,7 +315,7 @@ describe("reservation use-cases unhappy paths", () => {
     expectLeftTag(result, "InvalidReservationTransition");
   });
 
-  it("confirmReservationUseCase fails with InvalidReservationTransition when reservation has not started yet", async () => {
+  it("confirmReservationUseCase fails with ReservationNotStarted when reservation has not started yet", async () => {
     const user = await fixture.factories.user();
     const station = await fixture.factories.station();
     const bike = await fixture.factories.bike({ stationId: station.id });
@@ -331,7 +331,7 @@ describe("reservation use-cases unhappy paths", () => {
     });
 
     const result = await runConfirm({ reservationId: reservation.id, userId: user.id, now });
-    expectLeftTag(result, "InvalidReservationTransition");
+    expectLeftTag(result, "ReservationNotStarted");
   });
 
   it("confirmReservationUseCase fails with InvalidReservationTransition when reservation is already fulfilled", async () => {

--- a/apps/server/src/http/controllers/reservations/me.controller.ts
+++ b/apps/server/src/http/controllers/reservations/me.controller.ts
@@ -10,11 +10,13 @@ import {
 } from "@/domain/reservations";
 import { withLoggedCause } from "@/domain/shared";
 import {
+  toContractConfirmReservation,
   toContractReservation,
   toContractReservationExpanded,
 } from "@/http/presenters/reservations.presenter";
 
 import type {
+  ConfirmReservationResponse,
   ListMyReservationsResponse,
   ReservationDetailResponse,
   ReservationErrorResponse,
@@ -230,7 +232,7 @@ const confirmReservationHandler: RouteHandler<ReservationsRoutes["confirmReserva
 
   return Match.value(result).pipe(
     Match.tag("Right", ({ right }) =>
-      c.json<ReservationDetailResponse, 200>(toContractReservation(right), 200)),
+      c.json<ConfirmReservationResponse, 200>(toContractConfirmReservation(right), 200)),
     Match.tag("Left", ({ left }) =>
       Match.value(left).pipe(
         Match.tag("OvernightOperationsClosed", ({ currentTime, windowStart, windowEnd }) =>
@@ -274,6 +276,16 @@ const confirmReservationHandler: RouteHandler<ReservationsRoutes["confirmReserva
             details: {
               code: ReservationErrorCodeSchema.enum.RESERVATION_MISSING_BIKE,
               reservationId: missingId,
+            },
+          }, 400)),
+        Match.tag("ReservationNotStarted", ({ reservationId: missingId, startTime, currentTime }) =>
+          c.json<ReservationErrorResponse, 400>({
+            error: reservationErrorMessages.RESERVATION_NOT_STARTED,
+            details: {
+              code: ReservationErrorCodeSchema.enum.RESERVATION_NOT_STARTED,
+              reservationId: missingId,
+              startTime,
+              currentTime,
             },
           }, 400)),
         Match.tag("InvalidReservationTransition", ({ reservationId: missingId, from, to }) =>

--- a/apps/server/src/http/controllers/reservations/shared.ts
+++ b/apps/server/src/http/controllers/reservations/shared.ts
@@ -8,6 +8,7 @@ export const {
 } = ReservationsContracts;
 
 export type ReservationErrorResponse = ReservationsContracts.ReservationErrorResponse;
+export type ConfirmReservationResponse = ReservationsContracts.ConfirmReservationResponse;
 export type ReservationDetailResponse = ReservationsContracts.ReservationDetailResponse;
 export type ReservationExpandedDetailResponse = ReservationsContracts.ReservationExpandedDetailResponse;
 export type ListMyReservationsResponse = ReservationsContracts.ListMyReservationsResponse;

--- a/apps/server/src/http/presenters/reservations.presenter.ts
+++ b/apps/server/src/http/presenters/reservations.presenter.ts
@@ -3,6 +3,7 @@ import type { ReservationsContracts } from "@mebike/shared";
 import type { ReservationExpandedDetailRow, ReservationRow } from "@/domain/reservations";
 
 type ReservationListItem = ReservationsContracts.ReservationDetail;
+type ConfirmReservationResponse = ReservationsContracts.ConfirmReservationResponse;
 type ReservationExpandedDetail = ReservationsContracts.ReservationExpandedDetail;
 
 export function toContractReservation(row: ReservationRow): ReservationListItem {
@@ -52,5 +53,15 @@ export function toContractReservationExpanded(
       latitude: row.station.latitude,
       longitude: row.station.longitude,
     },
+  };
+}
+
+export function toContractConfirmReservation(args: {
+  reservation: ReservationRow;
+  rentalId: string;
+}): ConfirmReservationResponse {
+  return {
+    reservation: toContractReservation(args.reservation),
+    rentalId: args.rentalId,
   };
 }

--- a/packages/shared/src/contracts/server/reservations/schemas.ts
+++ b/packages/shared/src/contracts/server/reservations/schemas.ts
@@ -37,6 +37,7 @@ export const ReservationErrorCodeSchema = z
     "RESERVATION_NOT_FOUND",
     "RESERVATION_NOT_OWNED",
     "RESERVATION_MISSING_BIKE",
+    "RESERVATION_NOT_STARTED",
     "INVALID_RESERVATION_TRANSITION",
     "OVERNIGHT_OPERATIONS_CLOSED",
   ])
@@ -65,6 +66,7 @@ export const reservationErrorMessages = {
   RESERVATION_NOT_FOUND: "Reservation not found",
   RESERVATION_NOT_OWNED: "Reservation does not belong to user",
   RESERVATION_MISSING_BIKE: "Reservation missing bike assignment",
+  RESERVATION_NOT_STARTED: "Reservation cannot be confirmed before its start time",
   INVALID_RESERVATION_TRANSITION: "Invalid reservation status transition",
   OVERNIGHT_OPERATIONS_CLOSED: "Operations are closed overnight",
 } as const;
@@ -87,6 +89,7 @@ export const ReservationErrorDetailSchema = z.object({
   totalCapacity: z.number().optional(),
   availableBikes: z.number().optional(),
   requiredAvailableBikes: z.number().optional(),
+  startTime: z.string().optional(),
   currentTime: z.string().optional(),
   windowStart: z.string().optional(),
   windowEnd: z.string().optional(),
@@ -109,6 +112,10 @@ export const CreateReservationRequestSchema = z.object({
 }).openapi("CreateReservationRequest");
 
 export const ReservationDetailResponseSchema = ReservationDetailSchema.openapi("ReservationDetailResponse");
+export const ConfirmReservationResponseSchema = z.object({
+  reservation: ReservationDetailSchema,
+  rentalId: z.uuidv7(),
+}).openapi("ConfirmReservationResponse");
 export const ReservationExpandedDetailResponseSchema = ReservationExpandedDetailSchema.openapi("ReservationExpandedDetailResponse");
 export const ReservationSummaryStatsResponseSchema = ReservationSummaryStatsSchema.openapi("ReservationSummaryStatsResponse");
 
@@ -148,6 +155,7 @@ export const ListStaffReservationsResponseSchema = z.object({
 export type ReservationErrorResponse = z.infer<typeof ReservationErrorResponseSchema>;
 export type CreateReservationRequest = z.infer<typeof CreateReservationRequestSchema>;
 export type ReservationDetailResponse = z.infer<typeof ReservationDetailResponseSchema>;
+export type ConfirmReservationResponse = z.infer<typeof ConfirmReservationResponseSchema>;
 export type ReservationExpandedDetailResponse = z.infer<typeof ReservationExpandedDetailResponseSchema>;
 export type ReservationSummaryStatsResponse = z.infer<typeof ReservationSummaryStatsResponseSchema>;
 export type ListMyReservationsResponse = z.infer<typeof ListMyReservationsResponseSchema>;

--- a/packages/shared/src/contracts/server/routes/reservations/mutations.ts
+++ b/packages/shared/src/contracts/server/routes/reservations/mutations.ts
@@ -1,6 +1,7 @@
 import { createRoute } from "@hono/zod-openapi";
 
 import {
+  ConfirmReservationResponseSchema,
   CreateReservationRequestSchema,
   ReservationDetailResponseSchema,
   ReservationErrorCodeSchema,
@@ -88,7 +89,7 @@ export const confirmReservationRoute = createRoute({
       description: "Reservation confirmed successfully",
       content: {
         "application/json": {
-          schema: ReservationDetailResponseSchema,
+          schema: ConfirmReservationResponseSchema,
         },
       },
     },
@@ -108,6 +109,16 @@ export const confirmReservationRoute = createRoute({
               value: {
                 error: "Reservation does not belong to user",
                 details: { code: ReservationErrorCodeSchema.enum.RESERVATION_NOT_OWNED },
+              },
+            },
+            NotStarted: {
+              value: {
+                error: "Reservation cannot be confirmed before its start time",
+                details: {
+                  code: ReservationErrorCodeSchema.enum.RESERVATION_NOT_STARTED,
+                  startTime: "2026-04-20T10:00:00.000Z",
+                  currentTime: "2026-04-20T09:55:00.000Z",
+                },
               },
             },
             InvalidTransition: {


### PR DESCRIPTION
## Summary
- return a dedicated confirm-reservation response with `rentalId` so mobile can navigate to the created rental detail instead of the old reservation detail
- map confirm-before-start-time to a clean `RESERVATION_NOT_STARTED` API/mobile error and keep the reservation confirm contract aligned across server, shared, and mobile
- replace the misleading station reservation availability copy with clearer wording about insufficient available bikes