### PR TITLE
fix: lower station select overlay content

### DIFF
--- a/apps/mobile/components/station-map.tsx
+++ b/apps/mobile/components/station-map.tsx
@@ -123,7 +123,7 @@ export default function StationMap({
                   id="route-line"
                   style={{
                     lineColor: "#2563EB",
-                    lineWidth: 4,
+                    lineWidth: 3,
                     lineCap: "round",
                     lineJoin: "round",
                   }}

--- a/apps/mobile/styles/station-select/components/station-select-map-overlay.tsx
+++ b/apps/mobile/styles/station-select/components/station-select-map-overlay.tsx
@@ -11,8 +11,8 @@ import { useTheme, XStack, YStack } from "tamagui";
 
 import type { MapboxDirectionsProfile } from "@/lib/mapbox-directions";
 
-import { borderWidths } from "@theme/metrics";
 import { IconSymbol } from "@components/IconSymbol";
+import { borderWidths } from "@theme/metrics";
 import { AppCard } from "@ui/primitives/app-card";
 import { AppText } from "@ui/primitives/app-text";
 
@@ -168,7 +168,7 @@ export function StationSelectMapOverlay({
       pointerEvents="box-none"
       style={{
         position: "absolute",
-        bottom: 0,
+        bottom: -50,
         left: 0,
         right: 0,
       }}
@@ -218,7 +218,7 @@ export function StationSelectMapOverlay({
             : (
                 <Pressable onPress={showRouting ? toggleExpanded : undefined} {...(showRouting ? handlePanResponder.panHandlers : undefined)}>
                   <XStack alignItems="center" justifyContent="space-between" gap="$3" paddingHorizontal="$5" paddingBottom="$4">
-                    <YStack flex={1} gap="$1">
+                    <YStack flex={1} gap="$2">
                       <AppText variant="title">
                         {showRouting
                           ? "Lộ trình đến trạm"

--- a/apps/mobile/styles/station-select/hooks/use-station-select.ts
+++ b/apps/mobile/styles/station-select/hooks/use-station-select.ts
@@ -47,6 +47,22 @@ export function useStationSelect() {
     showingNearby && Boolean(currentLocation),
   );
 
+  const visibleStations = React.useMemo(() => {
+    if (!showingNearby) {
+      return allStations;
+    }
+
+    if (!currentLocation) {
+      return allStations;
+    }
+
+    if (isLoadingNearbyStations && nearbyStations.length === 0) {
+      return allStations;
+    }
+
+    return nearbyStations;
+  }, [allStations, currentLocation, isLoadingNearbyStations, nearbyStations, showingNearby]);
+
   const handleSelectStation = (stationId: string) => {
     navigation.navigate("StationDetail", {
       stationId,
@@ -92,13 +108,14 @@ export function useStationSelect() {
     }
   }, [refreshLocation]);
 
-  const stations = showingNearby ? nearbyStations : allStations;
-
   const selectedStation = React.useMemo(() => {
     if (!selectedStationId)
       return null;
-    return stations.find(s => s.id === selectedStationId) ?? null;
-  }, [selectedStationId, stations]);
+
+    return allStations.find(s => s.id === selectedStationId)
+      ?? nearbyStations.find(s => s.id === selectedStationId)
+      ?? null;
+  }, [allStations, nearbyStations, selectedStationId]);
 
   const destination = React.useMemo(() => {
     if (!selectedStation)
@@ -121,7 +138,7 @@ export function useStationSelect() {
   const isRouting = routeQuery.isFetching;
 
   const handleSelectStationForRoute = async (stationId: string) => {
-    const station = stations.find(s => s.id === stationId);
+    const station = visibleStations.find(s => s.id === stationId);
     if (!station)
       return;
 
@@ -173,7 +190,7 @@ export function useStationSelect() {
   };
 
   return {
-    stations,
+    stations: visibleStations,
     refreshing,
     showingNearby,
     selectedStationId,


### PR DESCRIPTION
## Summary
- move the station select overlay slightly lower on the map
- add a bit more spacing between the station select title and subtitle