### PR TITLE
fix: mount firebase credentials and adjust guest station select offset

### DIFF
--- a/apps/mobile/styles/station-select/components/station-select-map-overlay.tsx
+++ b/apps/mobile/styles/station-select/components/station-select-map-overlay.tsx
@@ -23,6 +23,7 @@ import { StationSelectRoutingPanel } from "./station-select-routing-panel";
 
 type StationSelectMapOverlayProps = {
   safeBottom: number;
+  isAuthenticated: boolean;
   showingNearby: boolean;
   isLoadingNearbyStations: boolean;
   isResolvingNearbyLocation: boolean;
@@ -50,6 +51,7 @@ type StationSelectMapOverlayProps = {
 
 export function StationSelectMapOverlay({
   safeBottom,
+  isAuthenticated,
   showingNearby,
   isLoadingNearbyStations,
   isResolvingNearbyLocation,
@@ -168,7 +170,7 @@ export function StationSelectMapOverlay({
       pointerEvents="box-none"
       style={{
         position: "absolute",
-        bottom: -50,
+        bottom: isAuthenticated ? -50 : 0,
         left: 0,
         right: 0,
       }}

--- a/apps/mobile/styles/station-select/index.tsx
+++ b/apps/mobile/styles/station-select/index.tsx
@@ -123,6 +123,7 @@ export default function StationSelectScreen() {
 
       <StationSelectMapOverlay
         safeBottom={insets.bottom}
+        isAuthenticated={isAuthenticated}
         showingNearby={showingNearby}
         isLoadingNearbyStations={isLoadingNearbyStations}
         isResolvingNearbyLocation={isResolvingNearbyLocation}

--- a/compose.coolify.yaml
+++ b/compose.coolify.yaml
@@ -102,6 +102,7 @@ services:
       PORT: 4000
       DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
       PRISMA_TRANSACTION_TIMEOUT_MS: ${PRISMA_TRANSACTION_TIMEOUT_MS:-10000}
+      GOOGLE_APPLICATION_CREDENTIALS: ${GOOGLE_APPLICATION_CREDENTIALS:-/app/secrets/firebase-admin.json}
       REDIS_URL: redis://redis:6379
       IOT_MQTT_URL: mqtt://mosquitto:1883
       IOT_MQTT_USERNAME: ${IOT_MQTT_USERNAME}
@@ -124,6 +125,8 @@ services:
         condition: service_healthy
     networks:
       - mebike-internal
+    volumes:
+      - ${FIREBASE_ADMIN_CREDENTIALS_HOST_PATH}:/app/secrets/firebase-admin.json:ro
     expose:
       - "4000"
 

--- a/compose.vps.yaml
+++ b/compose.vps.yaml
@@ -82,6 +82,7 @@ services:
       NODE_ENV: production
       PORT: 4000
       DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
+      GOOGLE_APPLICATION_CREDENTIALS: ${GOOGLE_APPLICATION_CREDENTIALS:-/app/secrets/firebase-admin.json}
       REDIS_URL: redis://redis:6379
     depends_on:
       postgres:
@@ -91,6 +92,8 @@ services:
     networks:
       - mebike-internal
       - traefik-public
+    volumes:
+      - ${FIREBASE_ADMIN_CREDENTIALS_HOST_PATH}:/app/secrets/firebase-admin.json:ro
     labels:
       - "traefik.enable=true"
       - "traefik.docker.network=${TRAEFIK_NETWORK}"
@@ -112,6 +115,7 @@ services:
     environment:
       NODE_ENV: production
       DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
+      GOOGLE_APPLICATION_CREDENTIALS: ${GOOGLE_APPLICATION_CREDENTIALS:-/app/secrets/firebase-admin.json}
       REDIS_URL: redis://redis:6379
     depends_on:
       postgres:
@@ -120,6 +124,8 @@ services:
         condition: service_healthy
     networks:
       - mebike-internal
+    volumes:
+      - ${FIREBASE_ADMIN_CREDENTIALS_HOST_PATH}:/app/secrets/firebase-admin.json:ro
     command: ["pnpm", "--filter", "server", "exec", "prisma", "migrate", "deploy"]
 
 networks:


### PR DESCRIPTION
## Summary
- mount Firebase admin credentials into the production server containers and default the runtime credentials path
- avoid pushing the station select overlay too far down for logged-out users by using an auth-aware bottom offset