### PR TITLE
refactor: tighten role-facing mobile copy

### DIFF
--- a/apps/mobile/presenters/rentals/rental-error-presenter.ts
+++ b/apps/mobile/presenters/rentals/rental-error-presenter.ts
@@ -40,7 +40,7 @@ const rentalErrorMessages = {
   notEnoughBalanceToRent: "Số dư ví không đủ để bắt đầu chuyến đi.",
   notFoundRentedRental: "Bạn hiện không có chuyến đi đang diễn ra.",
   noAvailableBike: "Hiện không còn xe phù hợp để đổi.",
-  overnightOperationsClosed: "Hệ thống tạm ngưng thao tác này từ 23:00 đến 05:00 giờ Việt Nam. Vui lòng thử lại sau 05:00.",
+  overnightOperationsClosed: "Không thể thực hiện thao tác này từ 23:00 đến 05:00. Vui lòng thử lại sau 05:00.",
   provideAtLeastOneUpdatedFieldBesidesReason: "Bạn cần chọn ít nhất một thông tin để cập nhật.",
   rentalNotFound: "Không tìm thấy chuyến đi này.",
   rentalUpdateFailed: "Không thể cập nhật chuyến đi lúc này.",

--- a/apps/mobile/presenters/reservations/reservation-error-presenter.ts
+++ b/apps/mobile/presenters/reservations/reservation-error-presenter.ts
@@ -12,7 +12,7 @@ const reservationErrorMessages = {
   insufficientWalletBalance: "Số dư ví không đủ để đặt xe.",
   invalidReservationTransition: "Không thể chuyển lượt giữ chỗ sang trạng thái này.",
   networkError: "Không thể kết nối tới máy chủ.",
-  overnightOperationsClosed: "Hệ thống tạm ngưng thao tác này từ 23:00 đến 05:00 giờ Việt Nam. Vui lòng thử lại sau 05:00.",
+  overnightOperationsClosed: "Không thể thực hiện thao tác này từ 23:00 đến 05:00. Vui lòng thử lại sau 05:00.",
   reservationConfirmBlockedByActiveRental:
     "Bạn đang có chuyến đi hoạt động nên chưa thể nhận thêm lượt giữ chỗ này.",
   reservationMissingBike: "Lượt giữ chỗ này chưa được gán xe phù hợp.",

--- a/apps/mobile/screen/rental/booking-history-detail/components/rental-action-bar.tsx
+++ b/apps/mobile/screen/rental/booking-history-detail/components/rental-action-bar.tsx
@@ -37,7 +37,7 @@ export function RentalActionBar({
       <AppText align="center" tone={hasReturnSlot ? "muted" : "muted"} variant="body">
         {hasReturnSlot
           ? `Vui lòng đưa mã QR cho nhân viên tại ${returnStationName ?? "bãi trả đã chọn"} để trả xe.`
-          : "Đưa mã QR cho nhân viên tại trạm còn chỗ. Giữ chỗ trước nếu muốn chắc suất."}
+          : "Đưa mã QR cho nhân viên tại trạm còn chỗ. Giữ chỗ trước để đảm bảo còn chỗ trả xe."}
       </AppText>
 
       <XStack gap="$3">

--- a/apps/mobile/screen/rental/rental-qr/index.tsx
+++ b/apps/mobile/screen/rental/rental-qr/index.tsx
@@ -330,7 +330,7 @@ function RentalQrScreen() {
             {[
               "Nếu đã giữ chỗ trước, hãy đến đúng bãi trả xe đã chọn. Nếu chưa, hãy đến trạm còn chỗ trống.",
               "Đến quầy hoặc gặp nhân viên hỗ trợ của MeBike tại trạm.",
-              "Nhấn “Trình mã QR” và đưa màn hình này cho họ quét.",
+              "Đưa màn hình mã QR này cho nhân viên quét.",
               "Giữ mở ứng dụng cho đến khi nhân viên xác nhận đã kết thúc phiên thuê.",
             ].map((text, index) => (
               <View key={text} style={styles.instructionItem}>

--- a/apps/mobile/screen/staff/bike-swap/detail/components/request-bike-card.tsx
+++ b/apps/mobile/screen/staff/bike-swap/detail/components/request-bike-card.tsx
@@ -83,29 +83,6 @@ export function RequestBikeCard({ request }: RequestBikeCardProps) {
           )
         : null}
 
-      {request.status === "PENDING"
-        ? (
-            <AppCard borderRadius={22} chrome="flat" padding="$4" tone="muted">
-              <XStack alignItems="flex-start" gap="$3">
-                <IconSymbol color={theme.actionPrimary.val} name="info" size="input" />
-                <AppText flex={1} tone="muted" variant="bodySmall">
-                  Hệ thống sẽ tự động chọn 1 xe
-                  {" "}
-                  <AppText tone="default" variant="bodyStrong">
-                    AVAILABLE
-                  </AppText>
-                  {" "}
-                  tại trạm để giao cho khách khi bạn bấm
-                  {" "}
-                  <AppText tone="default" variant="bodyStrong">
-                    Chấp nhận
-                  </AppText>
-                  .
-                </AppText>
-              </XStack>
-            </AppCard>
-          )
-        : null}
     </AppCard>
   );
 }

--- a/apps/mobile/screen/staff/dashboard/staff-dashboard-screen.tsx
+++ b/apps/mobile/screen/staff/dashboard/staff-dashboard-screen.tsx
@@ -138,7 +138,7 @@ export default function StaffDashboardScreen() {
     <Screen tone="subtle">
       <StatusBar barStyle="light-content" backgroundColor="transparent" translucent />
       <ScrollView contentContainerStyle={{ paddingBottom: 32 }} showsVerticalScrollIndicator={false}>
-        <AppHeroHeader size="compact" title="Công cụ nhân viên" />
+        <AppHeroHeader size="compact" title="Công cụ vận hành" />
 
         <YStack gap="$5" padding="$4">
           <AppText variant="sectionTitle">Công cụ hỗ trợ</AppText>

--- a/apps/mobile/screen/staff/rental-detail/components/staff-end-rental-card.tsx
+++ b/apps/mobile/screen/staff/rental-detail/components/staff-end-rental-card.tsx
@@ -2,10 +2,8 @@ import { IconSymbol } from "@components/IconSymbol";
 import { borderWidths, spaceScale } from "@theme/metrics";
 import { AppBottomModalCard } from "@ui/patterns/app-bottom-modal-card";
 import { AppButton } from "@ui/primitives/app-button";
-import { AppCard } from "@ui/primitives/app-card";
 import { AppInput } from "@ui/primitives/app-input";
 import { AppText } from "@ui/primitives/app-text";
-import { formatVietnamDateTime } from "@utils/date";
 import React from "react";
 import { useTheme, XStack, YStack } from "tamagui";
 
@@ -31,7 +29,7 @@ type Props = {
   }) => void;
 };
 
-const DEFAULT_REASON = "Kết thúc phiên thuê bởi nhân viên";
+const FALLBACK_REASON = "Hỗ trợ khách trả xe";
 
 export default function StaffEndRentalCard({
   bottomInset,
@@ -45,8 +43,7 @@ export default function StaffEndRentalCard({
   onSubmit,
 }: Props) {
   const theme = useTheme();
-  const activeReturnSlot = booking.returnSlot;
-  const endStation = activeReturnSlot?.station ?? managedStation;
+  const endStation = booking.returnSlot?.station ?? managedStation;
   const canEndRental = booking.status === "RENTED" && Boolean(endStation);
 
   const handleConfirm = () => {
@@ -57,7 +54,7 @@ export default function StaffEndRentalCard({
 
     onSubmit({
       confirmationMethod: "MANUAL",
-      reason: note.trim() ? note.trim() : DEFAULT_REASON,
+      reason: note.trim() ? note.trim() : FALLBACK_REASON,
       stationId: endStation.id,
     });
   };
@@ -105,52 +102,6 @@ export default function StaffEndRentalCard({
               .
             </AppText>
           </YStack>
-
-          {/*
-          <AppCard
-            borderColor="$borderSubtle"
-            borderRadius="$4"
-            borderWidth={borderWidths.subtle}
-            chrome="flat"
-            gap="$3"
-            padding="$4"
-            tone="muted"
-          >
-            <XStack alignItems="flex-start" gap="$3">
-              <YStack
-                alignItems="center"
-                backgroundColor="$surfaceDefault"
-                borderRadius="$round"
-                height={36}
-                justifyContent="center"
-                width={36}
-              >
-                <IconSymbol
-                  color={activeReturnSlot ? theme.statusWarning.val : theme.textBrand.val}
-                  name="location"
-                  size="sm"
-                  variant="filled"
-                />
-              </YStack>
-
-              <YStack flex={1} gap="$1">
-                <AppText variant="bodyStrong">
-                  {activeReturnSlot
-                    ? activeReturnSlot.station.name
-                    : (managedStation?.name ?? "Chưa xác định được trạm trả xe")}
-                </AppText>
-                <AppText tone="muted" variant="bodySmall">
-                  {activeReturnSlot
-                    ? `Giữ chỗ từ ${formatVietnamDateTime(activeReturnSlot.reservedFrom)}`
-                    : managedStation
-                      ? "Khách chưa giữ chỗ trước. Hệ thống sẽ kiểm tra chỗ trống hiện tại tại trạm của bạn khi xác nhận trả xe."
-                      : "Không tìm thấy trạm được gán cho bạn để xác nhận trả xe."}
-                </AppText>
-              </YStack>
-            </XStack>
-          </AppCard>
-          */}
-
           <YStack gap="$2">
             <AppText variant="subhead">Ghi chú (Tùy chọn)</AppText>
             <AppInput

--- a/apps/mobile/screen/staff/rental-detail/staff-rental-detail-screen.tsx
+++ b/apps/mobile/screen/staff/rental-detail/staff-rental-detail-screen.tsx
@@ -25,10 +25,9 @@ import StaffEndRentalCard from "./components/staff-end-rental-card";
 import { StaffJourneyCard } from "./components/staff-journey-card";
 import { StaffPartyCard } from "./components/staff-party-card";
 import { StaffSummaryCard } from "./components/staff-summary-card";
-import { StaffWarningCard } from "./components/staff-warning-card";
 import { useStaffRentalDetailScreen } from "./hooks";
 
-const DEFAULT_END_REASON = "Kết thúc phiên thuê bởi nhân viên";
+const DEFAULT_END_REASON = "";
 
 function getStatusMeta(status: string) {
   switch (status) {
@@ -128,17 +127,6 @@ function StaffRentalDetailScreen() {
           <YStack gap="$5" padding="$5">
             <StaffSummaryCard booking={booking} />
             <StaffJourneyCard booking={booking} />
-
-            {booking.status === "RENTED" && !booking.returnSlot
-              ? (
-                  <StaffWarningCard
-                    description={managedStation
-                      ? `Khách hàng chưa đặt chỗ trả xe trước. Bạn vẫn có thể thu xe tại ${managedStation.name} nếu hệ thống xác nhận còn chỗ trống.`
-                      : "Khách hàng chưa đặt chỗ trả xe và tài khoản của bạn chưa có trạm được gán để xác nhận thu xe."}
-                    title={managedStation ? "Chưa có chỗ trả xe trước" : "Không thể kết thúc phiên"}
-                  />
-                )
-              : null}
 
             <StaffPartyCard booking={booking} />
           </YStack>

--- a/apps/mobile/screen/station-detail/index.tsx
+++ b/apps/mobile/screen/station-detail/index.tsx
@@ -217,7 +217,7 @@ export default function StationDetailScreen() {
                   <YStack alignItems="center" flexDirection="row" gap="$2">
                     <IconSymbol color={theme.textTertiary.val} name="info" size="sm" />
                     <AppText flex={1} tone="muted" variant="meta">
-                      Giữ chỗ trước là tuỳ chọn. Nếu muốn chắc chắn có chỗ trả tại trạm này, hãy lưu lại bãi trả rồi đưa mã QR cho nhân viên khi tới nơi.
+                      Giữ chỗ trước để đảm bảo còn chỗ trả xe tại trạm này. Khi tới nơi, đưa mã QR cho nhân viên.
                     </AppText>
                   </YStack>
                 </AppCard>

--- a/apps/mobile/screen/technician/incidents/hooks/use-technician-incident-actions.ts
+++ b/apps/mobile/screen/technician/incidents/hooks/use-technician-incident-actions.ts
@@ -85,7 +85,7 @@ export function useTechnicianIncidentActions({
 
     Alert.alert(
       "Từ chối sự cố",
-      "Nếu từ chối, hệ thống sẽ điều phối kỹ thuật viên khác cho sự cố này.",
+      "Bạn có chắc muốn từ chối sự cố này?",
       [
         { text: "Hủy", style: "cancel" },
         {

--- a/apps/mobile/screen/technician/incidents/technician-incident-detail-screen.tsx
+++ b/apps/mobile/screen/technician/incidents/technician-incident-detail-screen.tsx
@@ -49,6 +49,19 @@ function getIncidentHeadline(incidentType: string) {
   return formatIncidentTitle(incidentType);
 }
 
+function getRentalStatusLabel(status: string | null | undefined) {
+  switch (status) {
+    case "RENTED":
+      return "Đang thuê";
+    case "COMPLETED":
+      return "Hoàn thành";
+    case "OVERDUE_UNRETURNED":
+      return "Quá hạn chưa trả";
+    default:
+      return status ?? "";
+  }
+}
+
 function SectionCard({
   accentTone = "accent",
   children,
@@ -332,7 +345,7 @@ export default function TechnicianIncidentDetailScreen() {
               value={incident.reporterUser.phoneNumber}
             />
             <DetailRow emptyLabel="Chưa có mã chuyến" label="Mã chuyến thuê" value={incident.rental?.id ? `${incident.rental.id.slice(0, 10)}...` : ""} />
-            <DetailRow emptyLabel="Chưa có trạng thái" isLast label="Trạng thái chuyến" value={incident.rental?.status ?? ""} valueTone="warning" />
+            <DetailRow emptyLabel="Chưa có trạng thái" isLast label="Trạng thái chuyến" value={getRentalStatusLabel(incident.rental?.status)} valueTone="warning" />
           </SectionCard>
 
           <SectionCard accentTone="success" icon="bike" title="Thông tin xe & Vị trí">

--- a/apps/mobile/screen/technician/incidents/technician-incident-list-screen.tsx
+++ b/apps/mobile/screen/technician/incidents/technician-incident-list-screen.tsx
@@ -15,6 +15,7 @@ import {
   formatIncidentDuration,
   getIncidentSeverityLabel,
   getIncidentSeverityTone,
+  getIncidentSourceLabel,
   getIncidentStatusLabel,
   getIncidentStatusTone,
   getIncidentTypeLabel,
@@ -148,7 +149,7 @@ function IncidentRow({
               tone={getIncidentSeverityTone(incident.severity)}
               withDot={false}
             />
-            <StatusBadge label="Trong chuyến thuê" size="compact" tone="neutral" withDot={false} />
+            <StatusBadge label={getIncidentSourceLabel(incident.source)} size="compact" tone="neutral" withDot={false} />
           </XStack>
 
           <YStack gap="$3">

--- a/apps/mobile/utils/business-hours.ts
+++ b/apps/mobile/utils/business-hours.ts
@@ -51,7 +51,7 @@ export function parseTimeStringToWallClockDate(value: string): Date {
 }
 
 export function getOvernightOperationsClosedMessage(): string {
-  return "Hệ thống tạm ngưng thao tác này từ 23:00 đến 05:00 giờ Việt Nam. Vui lòng thử lại sau 05:00.";
+  return "Không thể thực hiện thao tác này từ 23:00 đến 05:00. Vui lòng thử lại sau 05:00.";
 }
 
 export function getFixedSlotOperatingHoursMessage(): string {

--- a/apps/server/prisma/seed/rating-reasons.ts
+++ b/apps/server/prisma/seed/rating-reasons.ts
@@ -11,10 +11,8 @@ export const ratingReasonsSeed: ReadonlyArray<{
 }> = [
   { type: RatingReasonType.COMPLIMENT, appliesTo: AppliesToEnum.bike, message: "Xe chạy êm, vận hành tốt" },
   { type: RatingReasonType.COMPLIMENT, appliesTo: AppliesToEnum.bike, message: "Xe sạch sẽ" },
-  { type: RatingReasonType.COMPLIMENT, appliesTo: AppliesToEnum.bike, message: "Xe còn nhiều pin" },
   { type: RatingReasonType.ISSUE, appliesTo: AppliesToEnum.bike, message: "Phanh chưa tốt" },
   { type: RatingReasonType.ISSUE, appliesTo: AppliesToEnum.bike, message: "Xe bẩn hoặc có mùi" },
-  { type: RatingReasonType.ISSUE, appliesTo: AppliesToEnum.bike, message: "Pin yếu" },
 
   { type: RatingReasonType.COMPLIMENT, appliesTo: AppliesToEnum.station, message: "Trạm dễ tìm" },
   { type: RatingReasonType.COMPLIMENT, appliesTo: AppliesToEnum.station, message: "Trạm gọn gàng, an toàn" },

--- a/apps/server/src/domain/ai/prompts/customer-assistant.prompt.sections.ts
+++ b/apps/server/src/domain/ai/prompts/customer-assistant.prompt.sections.ts
@@ -22,9 +22,12 @@ export const customerAssistantToolRules = [
 
 export const customerAssistantRentalRules = [
   "Rental rules: a user cannot have more than one active rental at a time.",
+  "Rental rules: treat OVERDUE_UNRETURNED as not active and not normally returnable. In MeBike this state should be treated as a lost-bike / overdue-loss situation, not as a standard return flow.",
   "Rental rules: only bikes in AVAILABLE state should be treated as ready to rent. BOOKED, RESERVED, BROKEN, REDISTRIBUTING, LOST, and DISABLED bikes are not ready for a new rental.",
   "Rental rules: return guidance must respect live station return capacity. If a station has no return capacity, say so plainly and suggest another station only when tool data supports it.",
   "Rental guidance: if a user asks about returning an active rental, their intended return station, or whether they already reserved return capacity, check the current return slot first before giving generic return advice.",
+  "Rental guidance: if the only relevant rental state is OVERDUE_UNRETURNED, do not tell the user to go return it like a normal active rental. Explain plainly that the trip is already in overdue-unreturned / lost-bike handling and advise based only on safe known policy.",
+  "Rental guidance: do not proactively say phrases like 'coi la mat xe' or other harsh internal loss-handling wording unless the user explicitly asks about that status or policy. Prefer neutral wording like 'qua han chua tra' in normal answers.",
   "Rental guidance: when a user asks how to end an active rental, explain the normal flow plainly: go to a suitable station, complete the return in app or with staff guidance if required, and follow the return confirmation flow shown in the app.",
   "Rental guidance: when a user is actively renting and asks about where to return, whether a station will be full, or how to make return smoother, you may proactively suggest reserving a return slot first if live station data supports that station as a return option.",
   "Rental guidance: describe a return slot as an optional way to reserve return capacity at a station for an active rental. Present it as a practical recommendation, not a mandatory step.",


### PR DESCRIPTION
## Summary
- remove over-explained or confusing copy from staff and technician flows, including the staff return warning block and bike-swap helper card
- localize technician incident source and rental status labels from real API values instead of hardcoded English/internal text
- simplify overnight-hours and return-flow messaging, and remove invalid battery-related bike rating reasons from server seed data

## Validation
- `pnpm exec eslint --fix` on changed mobile files
- `pnpm exec eslint` on changed mobile files
- `pnpm tsc --noEmit` in `apps/server`
- `pnpm exec tsc --noEmit` in `apps/mobile` still fails on existing unrelated error: `screen/environment/hooks/use-environment-impact-screen.ts(252,26): Object literal may only specify known properties, and 'pageParam' does not exist in type 'FetchNextPageOptions'.`