### PR TITLE
add pgadmin service for Coolify deployments

### DIFF
--- a/compose.coolify.yaml
+++ b/compose.coolify.yaml
@@ -35,6 +35,24 @@ services:
       retries: 10
       start_period: 5s
 
+  pgadmin:
+    image: dpage/pgadmin4:9
+    restart: unless-stopped
+    environment:
+      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL}
+      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD}
+      PGADMIN_CONFIG_ENHANCED_COOKIE_PROTECTION: "False"
+      PGADMIN_CONFIG_LOGIN_BANNER: "Authorized access only. Activity may be monitored."
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - mebike-internal
+    volumes:
+      - mebike-pgadmin-data:/var/lib/pgadmin
+    expose:
+      - "80"
+
   mosquitto:
     image: eclipse-mosquitto:2
     restart: unless-stopped
@@ -205,3 +223,4 @@ volumes:
   mebike-postgres-data:
   mebike-redis-data:
   mebike-mosquitto-data:
+  mebike-pgadmin-data:

--- a/compose.vps.env.example
+++ b/compose.vps.env.example
@@ -15,11 +15,14 @@ APEX_DOMAIN=mebike.site
 FRONTEND_HOST=mebike.site
 FRONTEND_WWW_HOST=www.mebike.site
 SERVER_HOST=api.mebike.site
+PGADMIN_HOST=pgadmin.mebike.site
 
 POSTGRES_USER=mebike
 POSTGRES_PASSWORD=change-me
 POSTGRES_DB=mebike
 PRISMA_TRANSACTION_TIMEOUT_MS=10000
+PGADMIN_DEFAULT_EMAIL=admin@mebike.site
+PGADMIN_DEFAULT_PASSWORD=change-me
 
 IOT_MQTT_USERNAME=change-me
 IOT_MQTT_PASSWORD=change-me


### PR DESCRIPTION
## Summary
- add a pgAdmin service to `compose.coolify.yaml` so production Postgres can be inspected through the Coolify stack
- add pgAdmin login env placeholders to `compose.vps.env.example`
- keep pgAdmin attached only to the internal Docker network with its own persistent volume