### PR TITLE
refactor(ui): highlight available slot counts in distribution request forms

### DIFF
--- a/apps/frontend/src/app/agency/distribution-request/create/client.tsx
+++ b/apps/frontend/src/app/agency/distribution-request/create/client.tsx
@@ -91,7 +91,7 @@ export default function CreateDistributionRequestClient({
                   />
                   <input type="hidden" {...register("sourceStationId")} value={stations.currentStation.id} />
                 </div>
-
+                <Label>Số lượng xe hiện tại của trạm xuất : <span className="text-red-600 font-semibold">{stations.currentStation.operationalAvailableSlots}</span></Label>
                 {/* Target Station */}
                 <div className="space-y-2">
                   <Label className="font-semibold">Trạm đích <span className="text-destructive">*</span></Label>
@@ -134,7 +134,7 @@ export default function CreateDistributionRequestClient({
                   {/* Hiển thị số chỗ trống tách biệt khỏi thẻ Label để không bị lệch */}
                   {selectedTargetStation && (
                     <p className="text-sm text-muted-foreground mb-1">
-                      Chỗ còn trống tại trạm đích: <span className="font-semibold text-foreground">{maxAvailableSlots}</span>
+                      Chỗ còn trống tại trạm đích: <span className="font-semibold text-foreground text-red-600">{maxAvailableSlots}</span>
                     </p>
                   )}
 

--- a/apps/frontend/src/app/staff/distribution-request/create/client.tsx
+++ b/apps/frontend/src/app/staff/distribution-request/create/client.tsx
@@ -112,6 +112,7 @@ export default function CreateDistributionRequestClient({
                     value={stations.currentStation.id}
                   />
                 </div>
+                <Label>Số lượng xe hiện tại của trạm xuất : <span className="text-red-600 font-semibold">{stations.currentStation.operationalAvailableSlots}</span></Label>
 
                 {/* Target Station */}
                 <div className="space-y-2">
@@ -164,7 +165,7 @@ export default function CreateDistributionRequestClient({
                   {selectedTargetStation && (
                     <p className="text-sm text-muted-foreground">
                       Chỗ còn trống tại trạm đích:{" "}
-                      <span className="font-semibold text-foreground">
+                      <span className="font-semibold text-foreground text-red-600">
                         {maxAvailableSlots}
                       </span>
                     </p>


### PR DESCRIPTION
-Update the distribution request creation forms for both agency and staff roles to improve visibility of station capacity. This includes adding the current operational available slots for the source station and applying a red color to the available slots at the target station to draw user attention to capacity constraints.