### PR TITLE
refactor(ui): remove maximum limit for requested quantity in redistribution schema

### DIFF
--- a/apps/frontend/src/schemas/distribution-request-schema.ts
+++ b/apps/frontend/src/schemas/distribution-request-schema.ts
@@ -3,8 +3,7 @@ import { isValidUUID } from "@utils";
 export const CreateRedistributionRequestSchema = z.object({
   requestedQuantity: z
     .int("Phải là số nguyên")
-    .min(1, "Số lượng phải lớn hơn 0")
-    .max(20, "Số lượng tối đa là 20"),
+    .min(1, "Số lượng phải lớn hơn 0"),
   sourceStationId: z
     .string()
     .min(1, "Mã trạm không được để trống")


### PR DESCRIPTION
Remove the `.max(20)` constraint from `requestedQuantity` in the `CreateRedistributionRequestSchema` to allow for larger redistribution requests.