### PR TITLE
refactor(ui): update bike identifier display in distribution details

### DIFF
--- a/apps/frontend/src/app/agency/distribution-request/detail/[id]/client.tsx
+++ b/apps/frontend/src/app/agency/distribution-request/detail/[id]/client.tsx
@@ -462,7 +462,7 @@ export const DistributionRequestDetailClient = ({
                     STT
                   </TableHead>
                   <TableHead className="font-bold text-slate-600">
-                    Mã xe (Bike ID)
+                    Mã số xe
                   </TableHead>
                   <TableHead className="font-bold text-slate-600">
                     Trạng thái
@@ -500,7 +500,7 @@ export const DistributionRequestDetailClient = ({
                         </TableCell>
                         <TableCell>
                           <code className="px-2.5 py-1 bg-slate-100 rounded border border-slate-200 text-slate-700 font-mono text-xs font-semibold">
-                            {item.bike.id}
+                            {item.bike.bikeNumber}
                           </code>
                         </TableCell>
                         <TableCell>

--- a/apps/frontend/src/app/manager/distribution-request/detail/[id]/client.tsx
+++ b/apps/frontend/src/app/manager/distribution-request/detail/[id]/client.tsx
@@ -290,7 +290,7 @@ export const DistributionRequestDetailClient = ({
                     </TableHead>
                   )}
                   <TableHead className="w-[60px] text-center font-bold text-slate-600">STT</TableHead>
-                  <TableHead className="font-bold text-slate-600">Mã xe (Bike ID)</TableHead>
+                  <TableHead className="font-bold text-slate-600">Mã số xe</TableHead>
                   <TableHead className="font-bold text-slate-600">Trạng thái</TableHead>
                   <TableHead className="font-bold text-slate-600 text-right pr-6">Thời gian bàn giao</TableHead>
                 </TableRow>
@@ -314,7 +314,7 @@ export const DistributionRequestDetailClient = ({
                         <TableCell className="text-center font-medium text-slate-500">{index + 1}</TableCell>
                         <TableCell>
                           <code className="px-2.5 py-1 bg-slate-100 rounded border border-slate-200 text-slate-700 font-mono text-xs font-semibold">
-                            {item.bike.id}
+                            {item.bike.bikeNumber}
                           </code>
                         </TableCell>
                         <TableCell>

--- a/apps/frontend/src/app/staff/distribution-request/detail/[id]/client.tsx
+++ b/apps/frontend/src/app/staff/distribution-request/detail/[id]/client.tsx
@@ -260,7 +260,8 @@ export const DistributionRequestDetailClient = ({ data, onStartTransit, onCancel
               <TableHeader className="bg-slate-50/80">
                 <TableRow className="hover:bg-transparent">
                   <TableHead className="w-[80px] text-center font-bold text-slate-600">STT</TableHead>
-                  <TableHead className="font-bold text-slate-600">Mã xe (Bike ID)</TableHead>
+                  
+                  <TableHead className="font-bold text-slate-600">Mã số xe</TableHead>
                   <TableHead className="font-bold text-slate-600">Trạng thái</TableHead>
                   <TableHead className="font-bold text-slate-600 text-right pr-6">Thời gian bàn giao</TableHead>
                 </TableRow>
@@ -276,7 +277,7 @@ export const DistributionRequestDetailClient = ({ data, onStartTransit, onCancel
                         </TableCell>
                         <TableCell>
                           <code className="px-2.5 py-1 bg-slate-100 rounded border border-slate-200 text-slate-700 font-mono text-xs font-semibold">
-                            {item.bike.id}
+                            {item.bike.bikeNumber}
                           </code>
                         </TableCell>
                         <TableCell>


### PR DESCRIPTION
Update the distribution request detail views across agency, manager, and staff roles to use `bikeNumber` instead of `id` for better readability, and rename the column header from "Mã xe (Bike ID)" to "Mã số xe".