### PR TITLE
fix: scope pending bike hold lookup

### DIFF
--- a/apps/server/src/domain/reservations/repository/read/reservation.hold-read.repository.ts
+++ b/apps/server/src/domain/reservations/repository/read/reservation.hold-read.repository.ts
@@ -78,8 +78,8 @@ export function makeReservationHoldReadRepository(
         try: () =>
           client.reservation.findFirst({
             where: {
-              bikeId,
               ...pendingHoldWhere(now),
+              bikeId,
             },
             orderBy: { endTime: "asc" },
             select: selectReservationRow,

--- a/apps/server/src/domain/reservations/repository/test/read/reservation.read.repository.int.test.ts
+++ b/apps/server/src/domain/reservations/repository/test/read/reservation.read.repository.int.test.ts
@@ -61,7 +61,7 @@ describe("reservationRepository read integration", () => {
     expect(Option.isNone(result)).toBe(true);
   });
 
-  it.fails("findPendingHoldByBikeIdNow ignores holds for other bikes", async () => {
+  it("findPendingHoldByBikeIdNow ignores holds for other bikes", async () => {
     const now = new Date();
     const user = await kit.createUser();
     const station = await kit.createStation({ name: "Station Other Bike Hold" });


### PR DESCRIPTION
## Summary

Fixes `findPendingHoldByBikeIdNow` so it checks the requested bike only.
